### PR TITLE
Harden CLI + MCP + API: buy/sell/cancel/BP/order-status/dedup

### DIFF
--- a/MOTHERSHIP-SETUP.md
+++ b/MOTHERSHIP-SETUP.md
@@ -1,0 +1,25 @@
+# robinhood-cli on mothership — keep it up to date
+
+Public code comes from GitHub; private bits (info/, .env) come via this Syncthing
+folder (~/Sync/robinhood-cli-private, shared frostbyte <-> mothership).
+
+## First-time setup (on mothership)
+```bash
+git clone https://github.com/zaydiscold/robinhood-cli.git
+cd robinhood-cli
+# overlay the private bits from the synced folder:
+cp -r "$HOME/Sync/robinhood-cli-private/info" ./info
+cp "$HOME/Sync/robinhood-cli-private/.env" ./.env
+pnpm install && pnpm build
+node cli/dist/index.js quote MRVL --json   # smoke test
+```
+
+## Refresh (on mothership, whenever frostbyte pushes/updates)
+```bash
+cd robinhood-cli && git pull
+cp -rf "$HOME/Sync/robinhood-cli-private/info" ./info
+cp -f "$HOME/Sync/robinhood-cli-private/.env" ./.env
+pnpm install && pnpm build
+```
+Note: the token in .env expires ~weekly; re-run auth refresh on frostbyte and it
+re-syncs here automatically.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,39 @@
+# TODO — robinhood-cli hardening roadmap
+
+## High priority
+
+- [ ] **Web app version auto-scrape**: The `x-robinhood-web-app-version` header rotates periodically. Scrape it from the live browser (CDP) during `scripts/refresh-auth.sh` or on first API call. Currently hardcoded to `2026.24.2030+bc12ef34` in lib.ts.
+
+- [ ] **Order status ticker resolution**: `order-status` shows instrument UUID instead of ticker symbol. Add an instrument lookup call to resolve the UUID to a symbol for display.
+
+- [ ] **Options order live test**: The `buy` command was tested live with equity orders. Options orders use a different body schema (legs, strategy, etc.) and need a live test pass to verify `order_form_version` and other fields.
+
+- [ ] **ref_id on all orders**: Both buy and sell now include `ref_id` for Robinhood-level idempotency. MCP buy/sell tools should also include `ref_id`.
+
+## Medium priority
+
+- [ ] **Summary/dashboard command**: Combine portfolio + bp + top positions into one view. `portfolio` already does most of this; a `summary` alias with different defaults would suffice.
+
+- [ ] **Dollar-value aggregation in positions**: `positions` shows per-account breakdown. Add a `--all` flag that aggregates quantities and values across accounts by symbol.
+
+- [ ] **MCP dedup parity**: CLI buy/sell have dedup checks. MCP `robinhood_buy` and `robinhood_sell` do not — they should use the same `logTrade` + dedup pattern.
+
+- [ ] **Settings MCP read parity**: The CLI `settings show` reads DRIP, PDT, sweep, lending, options level. The original MCP `robinhood_settings` handles reads via its `show` sub-action — verify parity.
+
+## Low priority
+
+- [ ] **Bonfire endpoint mapping**: ~50 more endpoints on `bonfire.robinhood.com` are observable in the browser but not in our route map. Categories: dividends, tax documents, monthly statements, price alerts, instant deposits, debit card management.
+
+- [ ] **Crypto endpoint live test**: Crypto routes exist in the map and MCP tools exist (`robinhood_crypto_*`) but haven't been tested for live order placement.
+
+- [ ] **Browser CDP capture automation**: The route map was built from manual CDP captures. Automate: log into Robinhood in Chrome, drive through all feature pages, capture XHR requests, diff against existing routes, add new ones.
+
+- [ ] **Order confirmation flow**: The web app shows a confirmation modal before placing orders. Capture that DOM flow for order review/safety patterns.
+
+- [ ] **Per-instrument DRIP settings**: The CLI `settings` command shows account-wide DRIP. Per-instrument DRIP (toggle DRIP on/off per symbol) exists in the route map but no CLI command.
+
+## Documentation
+
+- [ ] **API map changelog**: Track route additions/removals over time so the map's freshness is auditable.
+- [ ] **MCP tool catalog in SKILL.md**: Full 33-tool inventory with descriptions.
+- [ ] **Error code reference**: Common Robinhood API errors and their fixes (order_form_version, subpenny, fractional, app version gate).

--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -6621,5 +6621,18 @@
     "requestTypes": [
       "XHR"
     ]
+  },
+  {
+    "url": "https://api.robinhood.com/orders/{0}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "orders"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-06-09: single order status lookup by ID",
+    "summary": "Get a single order by ID (state, fills, price, quantity)"
   }
 ]

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,7 @@ import {
   computePortfolioPnl,
   tryBrokerageGetJson,
   gatedBrokerageWrite,
+  logTrade,
   executeBrokerageRequest,
   executeCryptoRequest,
   filterAccountContextWorkflows,
@@ -2503,15 +2504,17 @@ program
       return;
     }
     if (opts.account) process.stdout.write(`Account ${opts.account}\n`);
+    process.stdout.write(`as of ${new Date().toISOString()}\n`);
     printTable(
       rows.map((row: any) => ({
         symbol: row.symbol,
         qty: Number.isInteger(row.qty) ? row.qty : row.qty.toFixed(4),
-        avgCost: usd(row.avgCost),
         last: usd(row.last),
+        value: usd((row.qty || 0) * (row.last || 0)),
+        avgCost: usd(row.avgCost),
         return: pct(row.returnPct)
       })),
-      ["symbol", "qty", "avgCost", "last", "return"]
+      ["symbol", "qty", "last", "value", "avgCost", "return"]
     );
     const winners = rows.filter((row: any) => Number.isFinite(row.returnPct) && row.returnPct > 0).length;
     process.stdout.write(`\n${held.length} positions — ${winners} green, ${held.length - winners} red.\n`);
@@ -2543,11 +2546,12 @@ program
 
     if (opts.json) { printJson({ generatedAt: new Date().toISOString(), ...r }); return; }
 
-    process.stdout.write(`Portfolio P&L — ${r.accounts.length} account(s) — window: ${window}\n\n`);
+    process.stdout.write(`Portfolio P&L — ${r.accounts.length} account(s) — window: ${window}\n`);
+    process.stdout.write(`as of ${new Date().toISOString()}\n\n`);
     printTable(
-      r.accounts.map((a: any) => ({ account: `${a.label} (…${String(a.accountNumber).slice(-4)})`, equity: usd(a.equityUsd), day_change_usd: usd(a.dayChangeUsd), afterhrs_change_usd: usd(a.afterHoursChangeUsd) }))
-        .concat([{ account: r.complete ? "TOTAL" : `TOTAL (partial — ${r.accounts.filter((a: any) => a.partial).length} acct read failed)`, equity: usd(r.totals.equityUsd), day_change_usd: usd(r.totals.dayChangeUsd), afterhrs_change_usd: usd(r.totals.afterHoursChangeUsd) }]),
-      ["account", "equity", "day_change_usd", "afterhrs_change_usd"]
+      r.accounts.map((a: any) => ({ account: `${a.label} (…${String(a.accountNumber).slice(-4)})`, equity: usd(a.equityUsd), buying_power: usd(a.buyingPower), day_change_usd: usd(a.dayChangeUsd), afterhrs_change_usd: usd(a.afterHoursChangeUsd) }))
+        .concat([{ account: r.complete ? "TOTAL" : `TOTAL (partial — ${r.accounts.filter((a: any) => a.partial).length} acct read failed)`, equity: usd(r.totals.equityUsd), buying_power: "", day_change_usd: usd(r.totals.dayChangeUsd), afterhrs_change_usd: usd(r.totals.afterHoursChangeUsd) }]),
+      ["account", "equity", "buying_power", "day_change_usd", "afterhrs_change_usd"]
     );
 
     if (opts.by !== "account") {
@@ -2574,6 +2578,340 @@ program
     process.stdout.write(`\nDrivers explain ${usd(r.reconciliation.driverDayChangeUsd)} of the ${usd(r.totals.dayChangeUsd)} day move; residual ${usd(r.reconciliation.residualUsd)} = cash / dividends / transfers / option-vs-equity timing${mp ? ` (${mp} position(s) could not be priced)` : ""}. After-hours shown is EQUITY only (options don't print after-hours).\n`);
     const warns = [...(r.warnings ?? []), ...r.accounts.flatMap((a: any) => a.warnings)];
     if (warns.length) process.stdout.write(`${warns.map((w: string) => "⚠️  " + w).join("\n")}\n`);
+  });
+
+// ── buying-power: standalone per-account buying power breakdown (CLI + MCP parity) ──
+program
+  .command("buying-power")
+  .aliases(["bp"])
+  .description("Per-account buying power breakdown: regular BP, intraday BP, unleveraged BP, cash, margin used/total, margin health. Answers 'what can I actually deploy right now?'. Live read.")
+  .option("--account <number>", "scope to one account (default: all owned)")
+  .option("--json", "emit JSON")
+  .action(async (opts: any) => {
+    const graph = await brokerageGetJson("https://bonfire.robinhood.com/transfer/accounts/");
+    const rows: any[] = Array.isArray(graph?.results) ? graph.results : Array.isArray(graph) ? graph : [];
+    let accts: string[] = [];
+    for (const a of rows) {
+      if (a?.type !== "rhs" && a?.type !== "ira_roth") continue;
+      if (!a.account_number) continue;
+      accts.push(String(a.account_number));
+    }
+    if (opts.account) {
+      if (!accts.includes(String(opts.account))) throw new Error(`Account ${opts.account} not found.`);
+      accts = [String(opts.account)];
+    }
+
+    const results: any[] = [];
+    for (const acct of accts) {
+      try {
+        const bp = await brokerageGetJson("https://api.robinhood.com/accounts/{num}/buying_power_breakdown", { num: acct });
+        const p = await brokerageGetJson("https://api.robinhood.com/portfolios/{num}/", { num: acct });
+        const n = (v: unknown) => Number(v);
+        const equity = n(p.equity);
+        const marketVal = n(p.market_value);
+        const marginHealth = marketVal > 0 ? (equity / marketVal) * 100 : Number.NaN;
+        results.push({
+          accountNumber: acct,
+          buyingPower: n(bp.buying_power),
+          unleveragedBuyingPower: n(bp.unleveraged_buying_power),
+          intradayBuyingPower: n(bp.intraday_buying_power),
+          cash: n(bp.cash ?? (bp.breakdown?.find((x: any) => x.category === "Cash")?.value ?? 0)),
+          leverageEnabled: bp.leverage_enabled ?? false,
+          marginTotal: bp.breakdown?.find((x: any) => x.title?.toLowerCase().includes("margin total"))?.value ?? null,
+          marginUsed: bp.breakdown?.find((x: any) => x.title?.toLowerCase().includes("margin used"))?.value ?? null,
+          excessMaintenance: n(p.excess_maintenance),
+          excessMargin: n(p.excess_margin),
+          equity,
+          marketValue: marketVal,
+          marginHealthPct: marginHealth,
+        });
+      } catch (e) { results.push({ accountNumber: acct, error: (e as Error).message }); }
+    }
+
+    if (opts.json) { printJson(results); return; }
+
+    const labelMap = new Map<string, string>();
+    for (const a of rows) labelMap.set(String(a.account_number), a.account_name || a.display_title || "");
+    const label = (acct: string) => (labelMap.get(acct) || `…${acct.slice(-4)}`);
+
+    process.stdout.write("Buying Power — per account\n");
+    process.stdout.write(`as of ${new Date().toISOString()}\n\n`);
+    printTable(
+      results.filter((r: any) => !r.error).map((r: any) => ({
+        account: `${label(r.accountNumber)} (…${String(r.accountNumber).slice(-4)})`,
+        bp: usd(r.buyingPower),
+        unleveraged_bp: usd(r.unleveragedBuyingPower),
+        intraday_bp: usd(r.intradayBuyingPower),
+        cash: usd(r.cash),
+        margin_used: r.marginUsed != null ? usd(Math.abs(Number(r.marginUsed))) : "—",
+        margin_health: Number.isFinite(r.marginHealthPct) ? `${r.marginHealthPct.toFixed(1)}%` : "—",
+      })),
+      ["account", "bp", "unleveraged_bp", "intraday_bp", "cash", "margin_used", "margin_health"]
+    );
+
+    const errs = results.filter((r: any) => r.error);
+    if (errs.length) process.stdout.write(`\n⚠️  ${errs.length} account(s) failed: ${errs.map((e: any) => `…${String(e.accountNumber).slice(-4)}: ${e.error}`).join("; ")}\n`);
+  });
+
+// ── buy: simple market/limit order — one command, no raw JSON needed ──
+program
+  .command("buy")
+  .aliases(["order"])
+  .description("Place an equity order. Market buys are fractional. Dry-run by default; pass --live and set ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.")
+  .requiredOption("-s, --symbol <symbol>", "Ticker symbol")
+  .requiredOption("-a, --account <number>", "Account number")
+  .option("-m, --amount <dollars>", "Dollar amount (notional) — alternative to --shares")
+  .option("-q, --shares <number>", "Share quantity — alternative to --amount")
+  .option("-p, --price <number>", "Limit price (omit for market order)")
+  .option("--live", "Send live (requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--force", "Skip duplicate order check")
+  .option("--json", "emit JSON")
+  .action(async (opts: any) => {
+    if (!opts.amount && !opts.shares) throw new Error("Must specify --amount (dollars) or --shares (quantity)");
+    if (opts.amount && opts.shares) throw new Error("Specify --amount OR --shares, not both");
+
+    // 1. Resolve instrument
+    const inst = (await brokerageGetJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol: opts.symbol.toUpperCase() })).results?.[0];
+    if (!inst) throw new Error(`Symbol ${opts.symbol} not found`);
+    const iid = inst.id;
+
+    // 2. Get quote
+    const q = (await brokerageGetJson("https://api.robinhood.com/marketdata/quotes/?ids={ids}", { ids: iid })).results?.[0];
+    if (!q) throw new Error(`No quote for ${opts.symbol}`);
+    const last = Number(q.last_trade_price);
+    if (!last || last <= 0) throw new Error(`Invalid price for ${opts.symbol}: $${last}`);
+
+    // 3. Calculate quantity (Robinhood: 4 decimal places for fractional shares on most stocks)
+    const isMarket = !opts.price;
+    const rawShares = opts.amount ? Number(opts.amount) / last : Number(opts.shares);
+    const shares = Number(rawShares.toFixed(4));
+    const tif = isMarket ? "gfd" : "gtc";
+    // Market orders: Robinhood requires a price field — round to 2 decimals
+    const price = opts.price ? Number(opts.price).toFixed(2) : last.toFixed(2);
+
+    // 4. Dedup: check for recent orders on same symbol+account (prevents test+batch doubles)
+    const liveWrite = Boolean(opts.live);
+    if (liveWrite && !opts.force) {
+      try {
+        const recent = await brokerageGetJson("https://api.robinhood.com/orders/", {}, {
+          instrument: `https://api.robinhood.com/instruments/${iid}/`,
+          account_numbers: opts.account,
+          is_closed: "false"
+        });
+        const pending = (recent?.results ?? []).filter((o: any) =>
+          o.side === "buy" && o.state !== "filled" && o.state !== "cancelled" && o.state !== "rejected"
+        );
+        if (pending.length > 0) {
+          throw new Error(
+            `DEDUP: ${pending.length} pending buy order(s) for ${opts.symbol.toUpperCase()} already exist. ` +
+            `IDs: ${pending.map((o: any) => (o.id ?? "").slice(0, 8)).join(", ")}. ` +
+            `Pass --force to skip this check.`
+          );
+        }
+      } catch (e: any) {
+        if (e.message.startsWith("DEDUP:")) throw e;
+        // Dedup check failed non-fatally — continue
+      }
+    }
+
+    // 5. Execute
+    const result = await gatedBrokerageWrite({
+      url: "https://api.robinhood.com/orders/",
+      method: "POST",
+      body: {
+        account: `https://api.robinhood.com/accounts/${opts.account}/`,
+        instrument: `https://api.robinhood.com/instruments/${iid}/`,
+        symbol: opts.symbol.toUpperCase(),
+        type: isMarket ? "market" : "limit",
+        time_in_force: tif,
+        trigger: "immediate",
+        side: "buy",
+        quantity: String(shares),
+        price,
+        order_form_version: "7"
+      },
+      dryRun: !liveWrite,
+      liveWrite
+    });
+
+    // Log live trades to local/trading-log.jsonl
+    if (!result.dryRun) {
+      const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      logTrade({
+        ts: new Date().toISOString(),
+        symbol: opts.symbol.toUpperCase(), account: opts.account,
+        side: "buy", type: isMarket ? "market" : "limit",
+        shares, price: isMarket ? last : Number(opts.price),
+        estimatedTotal: shares * last, orderId: rb?.id ?? null,
+        state: rb?.state ?? null, httpStatus: result.status
+      }).catch(() => {});
+    }
+
+    if (opts.json) {
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares, estimatedPrice: last, estimatedTotal: shares * last, type: isMarket ? "market" : "limit", live: !result.dryRun, result });
+      return;
+    }
+
+    const mode = result.dryRun ? "DRY RUN" : "LIVE";
+    process.stdout.write(`${mode} ${isMarket ? "market" : "limit"} buy: ${opts.symbol.toUpperCase()} ${shares.toFixed(6)} sh @ ~$${last.toFixed(2)} ≈ $${(shares * last).toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    if (result.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
+    else {
+      const body = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      process.stdout.write(`Status: ${result.status}  id=${body?.id ?? body?.url ?? "?"}  state=${body?.state ?? "?"}\n`);
+    }
+  });
+
+// ── sell: mirror of buy for closing/reducing positions ──
+program
+  .command("sell")
+  .description("Place an equity sell order. Market sells are fractional. Dry-run by default; pass --live and set ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.")
+  .requiredOption("-s, --symbol <symbol>", "Ticker symbol")
+  .requiredOption("-a, --account <number>", "Account number")
+  .option("-m, --amount <dollars>", "Dollar amount (notional) — alternative to --shares")
+  .option("-q, --shares <number>", "Share quantity — alternative to --amount")
+  .option("-p, --price <number>", "Limit price (omit for market order)")
+  .option("--live", "Send live (requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--force", "Skip duplicate order check")
+  .option("--json", "emit JSON")
+  .action(async (opts: any) => {
+    if (!opts.amount && !opts.shares) throw new Error("Must specify --amount (dollars) or --shares (quantity)");
+    if (opts.amount && opts.shares) throw new Error("Specify --amount OR --shares, not both");
+
+    const inst = (await brokerageGetJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol: opts.symbol.toUpperCase() })).results?.[0];
+    if (!inst) throw new Error(`Symbol ${opts.symbol} not found`);
+    const iid = inst.id;
+
+    const q = (await brokerageGetJson("https://api.robinhood.com/marketdata/quotes/?ids={ids}", { ids: iid })).results?.[0];
+    if (!q) throw new Error(`No quote for ${opts.symbol}`);
+    const last = Number(q.last_trade_price);
+    if (!last || last <= 0) throw new Error(`Invalid price for ${opts.symbol}: $${last}`);
+
+    const isMarket = !opts.price;
+    const rawShares = opts.amount ? Number(opts.amount) / last : Number(opts.shares);
+    const shares = Number(rawShares.toFixed(4));
+    const tif = isMarket ? "gfd" : "gtc";
+    const price = opts.price ? Number(opts.price).toFixed(2) : last.toFixed(2);
+
+    const liveWrite = Boolean(opts.live);
+    if (liveWrite && !opts.force) {
+      try {
+        const recent = await brokerageGetJson("https://api.robinhood.com/orders/", {}, {
+          instrument: `https://api.robinhood.com/instruments/${iid}/`,
+          account_numbers: opts.account,
+          is_closed: "false"
+        });
+        const pending = (recent?.results ?? []).filter((o: any) =>
+          o.side === "sell" && o.state !== "filled" && o.state !== "cancelled" && o.state !== "rejected"
+        );
+        if (pending.length > 0) {
+          throw new Error(
+            `DEDUP: ${pending.length} pending sell order(s) for ${opts.symbol.toUpperCase()} already exist. ` +
+            `IDs: ${pending.map((o: any) => (o.id ?? "").slice(0, 8)).join(", ")}. ` +
+            `Pass --force to skip this check.`
+          );
+        }
+      } catch (e: any) {
+        if (e.message.startsWith("DEDUP:")) throw e;
+      }
+    }
+
+    const result = await gatedBrokerageWrite({
+      url: "https://api.robinhood.com/orders/",
+      method: "POST",
+      body: {
+        account: `https://api.robinhood.com/accounts/${opts.account}/`,
+        instrument: `https://api.robinhood.com/instruments/${iid}/`,
+        symbol: opts.symbol.toUpperCase(),
+        type: isMarket ? "market" : "limit",
+        time_in_force: tif,
+        trigger: "immediate",
+        side: "sell",
+        quantity: String(shares),
+        price,
+        order_form_version: "7"
+      },
+      dryRun: !liveWrite,
+      liveWrite
+    });
+
+    // Log live trades to local/trading-log.jsonl
+    if (!result.dryRun) {
+      const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      logTrade({
+        ts: new Date().toISOString(),
+        symbol: opts.symbol.toUpperCase(), account: opts.account,
+        side: "sell", type: isMarket ? "market" : "limit",
+        shares, price: isMarket ? last : Number(opts.price),
+        estimatedTotal: shares * last, orderId: rb?.id ?? null,
+        state: rb?.state ?? null, httpStatus: result.status
+      }).catch(() => {});
+    }
+
+    if (opts.json) {
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares, estimatedPrice: last, estimatedTotal: shares * last, type: isMarket ? "market" : "limit", live: !result.dryRun, result });
+      return;
+    }
+
+    const mode = result.dryRun ? "DRY RUN" : "LIVE";
+    process.stdout.write(`${mode} ${isMarket ? "market" : "limit"} sell: ${opts.symbol.toUpperCase()} ${shares.toFixed(6)} sh @ ~$${last.toFixed(2)} ≈ $${(shares * last).toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    if (result.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
+    else {
+      const body = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      process.stdout.write(`Status: ${result.status}  id=${body?.id ?? body?.url ?? "?"}  state=${body?.state ?? "?"}\n`);
+    }
+  });
+
+// ── cancel: cancel a pending order by ID ──
+program
+  .command("cancel")
+  .description("Cancel a pending order by ID. Dry-run by default; pass --live and set ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.")
+  .requiredOption("-i, --id <order_id>", "Order ID or URL to cancel")
+  .option("--live", "Send live (requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--force", "Skip duplicate order check")
+  .option("--json", "emit JSON")
+  .action(async (opts: any) => {
+    // Extract ID from URL if full URL given
+    const id = opts.id.includes("/orders/") ? opts.id.split("/orders/")[1].replace(/\/$/, "") : opts.id;
+    const liveWrite = Boolean(opts.live);
+    const result = await gatedBrokerageWrite({
+      url: "https://api.robinhood.com/orders/{0}/cancel/",
+      method: "POST",
+      params: { "0": id },
+      dryRun: !liveWrite,
+      liveWrite
+    });
+    if (opts.json) {
+      const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      printJson({ generatedAt: new Date().toISOString(), orderId: id, live: !result.dryRun, state: rb?.state ?? null, httpStatus: result.status });
+      return;
+    }
+    const mode = result.dryRun ? "DRY RUN" : "LIVE";
+    process.stdout.write(`${mode} cancel: ${id}  status=${result.status}\n`);
+  });
+
+// ── order: check status of a single order by ID ──
+program
+  .command("order-status")
+  .aliases(["status"])
+  .description("Check status of a single order by ID or URL. Shows symbol, side, quantity, price, state, fills.")
+  .requiredOption("-i, --id <order_id>", "Order ID or full URL")
+  .option("--json", "emit JSON")
+  .action(async (opts: any) => {
+    const id = opts.id.includes("/orders/") ? opts.id.split("/orders/")[1].replace(/\/$/, "") : opts.id;
+    const data = await brokerageGetJson("https://api.robinhood.com/orders/{0}/", { "0": id });
+    if (opts.json) {
+      printJson({ generatedAt: new Date().toISOString(), ...data });
+      return;
+    }
+    const o = data;
+    // Order GET doesn't return symbol — extract from instrument URL
+    const sym = o.symbol || (o.instrument ? o.instrument.split("/").filter(Boolean).pop()?.toUpperCase() : "?");
+    process.stdout.write(`${o.side?.toUpperCase() ?? "?"} ${sym}  ${o.cumulative_quantity ?? "0"} sh  @ $${Number(o.average_price ?? o.price ?? 0).toFixed(2)}  state=${o.state ?? "?"}\n`);
+    process.stdout.write(`id: ${o.id}\n`);
+    process.stdout.write(`created: ${o.created_at}\n`);
+    if (o.executions?.length) {
+      process.stdout.write(`fills: ${o.executions.length}  total_notional: ${o.total_notional?.amount ?? "?"}\n`);
+    }
   });
 
 const watchlist = new Command("watchlist").description("Inspect your custom watchlists (read)");

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2336,7 +2336,8 @@ program
       if (inWindow(t)) events.push({ time: String(t), kind: "transfer", summary: `${r.direction ?? "?"} ${r.amount ?? "?"}`, state: String(r.state ?? "?") });
     }
     events.sort((a, b) => Date.parse(b.time) - Date.parse(a.time));
-    if (opts.json) { printJson(events); return; }
+    if (opts.json) { printJson({ generatedAt: new Date().toISOString(), events }); return; }
+    process.stdout.write(`as of ${new Date().toISOString()}\n`);
     if (events.length === 0) { process.stdout.write(`No transactions in the last ${days} day(s).\n`); return; }
     printTable(
       events.map((e) => ({ when: e.time.slice(0, 19).replace("T", " "), type: e.kind, state: e.state, detail: e.summary })),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2699,9 +2699,11 @@ program
           account_numbers: opts.account,
           is_closed: "false"
         });
-        const pending = (recent?.results ?? []).filter((o: any) =>
-          o.side === "buy" && o.state !== "filled" && o.state !== "cancelled" && o.state !== "rejected"
-        );
+        const pending = (recent?.results ?? []).filter((o: any) => {
+          // Only block orders from the last 5 minutes (stale pending ≠ real duplicate)
+          const age = Date.now() - Date.parse(String(o.created_at ?? 0));
+          return o.side === "buy" && o.state !== "filled" && o.state !== "cancelled" && o.state !== "rejected" && age < 300_000;
+        });
         if (pending.length > 0) {
           throw new Error(
             `DEDUP: ${pending.length} pending buy order(s) for ${opts.symbol.toUpperCase()} already exist. ` +
@@ -2803,9 +2805,10 @@ program
           account_numbers: opts.account,
           is_closed: "false"
         });
-        const pending = (recent?.results ?? []).filter((o: any) =>
-          o.side === "sell" && o.state !== "filled" && o.state !== "cancelled" && o.state !== "rejected"
-        );
+        const pending = (recent?.results ?? []).filter((o: any) => {
+          const age = Date.now() - Date.parse(String(o.created_at ?? 0));
+          return o.side === "sell" && o.state !== "filled" && o.state !== "cancelled" && o.state !== "rejected" && age < 300_000;
+        });
         if (pending.length > 0) {
           throw new Error(
             `DEDUP: ${pending.length} pending sell order(s) for ${opts.symbol.toUpperCase()} already exist. ` +

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2715,7 +2715,8 @@ program
       }
     }
 
-    // 5. Execute
+    // 5. Execute (with ref_id for broker-level idempotency)
+    const refId = `${opts.symbol.toUpperCase()}-${opts.account}-${Date.now()}`;
     const result = await gatedBrokerageWrite({
       url: "https://api.robinhood.com/orders/",
       method: "POST",
@@ -2729,7 +2730,8 @@ program
         side: "buy",
         quantity: String(shares),
         price,
-        order_form_version: "7"
+        order_form_version: "7",
+        ref_id: refId
       },
       dryRun: !liveWrite,
       liveWrite
@@ -2816,6 +2818,7 @@ program
       }
     }
 
+    const refId = `${opts.symbol.toUpperCase()}-${opts.account}-${Date.now()}`;
     const result = await gatedBrokerageWrite({
       url: "https://api.robinhood.com/orders/",
       method: "POST",
@@ -2829,7 +2832,8 @@ program
         side: "sell",
         quantity: String(shares),
         price,
-        order_form_version: "7"
+        order_form_version: "7",
+        ref_id: refId
       },
       dryRun: !liveWrite,
       liveWrite

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -1551,13 +1551,31 @@ function cryptoAuthFromEnv(options: ExecuteCryptoOptions) {
 // request can be retried once. Returns undefined if the refresh produced nothing.
 // Runs in the CLI's own (TCC-permitted) context, so no daemon / Full Disk Access
 // grant is needed. See scripts/refresh-auth.sh for the disk-read rationale.
+function resolveBash(): string {
+  if (process.platform === "win32") {
+    // git-bash on Windows: try the standard Git install path first,
+    // then fall back to the MSYS2 /bin/bash (resolvable when running inside bash).
+    const candidates = [
+      "C:/Program Files/Git/usr/bin/bash.exe",
+      "C:/Program Files/Git/bin/bash.exe",
+      "/bin/bash",
+      "/usr/bin/bash",
+    ];
+    for (const c of candidates) {
+      if (existsSync(c)) return c;
+    }
+    return "bash"; // let execFileSync try PATH
+  }
+  return "/bin/bash";
+}
+
 function tryRefreshBrokerageToken(): string | undefined {
   try {
     const root = repoRoot();
     const script = join(root, "scripts", "refresh-auth.sh");
     const envPath = join(root, ".env");
     if (!existsSync(script)) return undefined;
-    execFileSync("/bin/bash", [script], { stdio: "ignore", timeout: 30000 });
+    execFileSync(resolveBash(), [script], { stdio: "ignore", timeout: 30000 });
     if (!existsSync(envPath)) return undefined;
     for (const line of readFileSync(envPath, "utf8").split("\n")) {
       const t = line.trim();
@@ -1693,7 +1711,7 @@ export async function executeBrokerageRequest(
       origin: "https://robinhood.com",
       referer: "https://robinhood.com/",
       "x-robinhood-api-version": process.env.ROBINHOOD_API_VERSION ?? "1.431.4",
-      "x-robinhood-web-app-version": process.env.ROBINHOOD_WEB_APP_VERSION ?? "2026.23.2025+43f8dad0de15",
+      "x-robinhood-web-app-version": process.env.ROBINHOOD_WEB_APP_VERSION ?? "2026.24.2030+bc12ef34",
       "x-hyper-ex": "enabled"
     };
     if (authToken) headers.authorization = `Bearer ${authToken}`;
@@ -1889,9 +1907,9 @@ export async function computePortfolioPnl(opts: PortfolioPnlOptions = {}): Promi
     return localLabels.get(acct) || localLabels.get("…" + l4) || localLabels.get(l4) || rhLabels.get(acct) || `…${l4}`;
   };
 
-  // 2. Per-account top-line + raw positions, in parallel; a failure degrades to a warning.
+  // 2. Per-account top-line + raw positions + buying power, in parallel; a failure degrades to a warning.
   const perAccount = await Promise.all(accts.map(async (acct) => {
-    const a: any = { acct, label: labelFor(acct), equity: Number.NaN, day: Number.NaN, afterHours: Number.NaN, equityPositions: [], optionPositions: [], warnings: [] as string[] };
+    const a: any = { acct, label: labelFor(acct), equity: Number.NaN, day: Number.NaN, afterHours: Number.NaN, buyingPower: Number.NaN, equityPositions: [], optionPositions: [], warnings: [] as string[] };
     try {
       const p = await brokerageGetJson("https://api.robinhood.com/portfolios/{num}/", { num: acct });
       const equity = n(p.equity), ext = n(p.extended_hours_equity);
@@ -1901,6 +1919,10 @@ export async function computePortfolioPnl(opts: PortfolioPnlOptions = {}): Promi
       a.afterHours = Number.isFinite(ext) && Number.isFinite(equity) ? ext - equity : Number.NaN;
       a.day = Number.isFinite(equity) && Number.isFinite(prevClose) ? equity - prevClose : Number.NaN;
     } catch (e) { a.warnings.push(`portfolio read failed (${acct}): ${(e as Error).message.slice(0, 50)}`); }
+    try {
+      const bp = await brokerageGetJson("https://api.robinhood.com/accounts/{num}/buying_power_breakdown", { num: acct });
+      a.buyingPower = n(bp.buying_power);
+    } catch { /* buying power is best-effort; degrade silently */ }
     try {
       const eq = await brokerageGetAllResults("https://api.robinhood.com/positions/", {}, { nonzero: "true", account_number: acct });
       a.equityPositions = eq.filter((x: any) => n(x.quantity) > 0).map((x: any) => ({ symbol: x.symbol, iid: x.instrument_id, qty: n(x.quantity) }));
@@ -1990,7 +2012,7 @@ export async function computePortfolioPnl(opts: PortfolioPnlOptions = {}): Promi
     totals: { equityUsd: totals.equity, dayChangeUsd: totals.day, afterHoursChangeUsd: totals.afterHours },
     reconciliation: { driverDayChangeUsd: driverDaySum, totalsDayChangeUsd: totals.day, residualUsd: residual, mispricedPositions,
       note: "residual = cash/dividends/transfers/option-vs-equity timing (NOT failed pricing — see mispricedPositions); after-hours is EQUITY-only (options don't print after-hours)" },
-    accounts: perAccount.map((a) => ({ accountNumber: a.acct, label: a.label, equityUsd: a.equity, dayChangeUsd: a.day, afterHoursChangeUsd: a.afterHours, partial: !Number.isFinite(a.equity), warnings: a.warnings })),
+    accounts: perAccount.map((a) => ({ accountNumber: a.acct, label: a.label, equityUsd: a.equity, dayChangeUsd: a.day, afterHoursChangeUsd: a.afterHours, buyingPower: a.buyingPower, partial: !Number.isFinite(a.equity), warnings: a.warnings })),
     byUnderlying: top ? byUnderlying.slice(0, top) : byUnderlying,
     byPosition: top ? byPosition.slice(0, top) : byPosition,
     warnings: globalWarnings
@@ -2020,6 +2042,17 @@ export async function gatedBrokerageWrite(opts: {
   const plan = planBrokerageRequest({ route, method: opts.method, params: opts.params ?? {}, body: opts.body, dryRun: effectiveDryRun });
   const result = await executeBrokerageRequest(plan, { dryRun: effectiveDryRun, body: opts.body, fullBody: true });
   return { status: result.status, dryRun: effectiveDryRun, reason: gate.reason, body: result.body };
+}
+
+/** Append a trade to the local trading log (JSONL, one line per order). Best-effort. */
+export async function logTrade(entry: Record<string, unknown>) {
+  try {
+    const { appendFileSync, existsSync, mkdirSync } = await import("fs");
+    const { join } = await import("path");
+    const logDir = join(repoRoot(), "local");
+    if (!existsSync(logDir)) mkdirSync(logDir, { recursive: true });
+    appendFileSync(join(logDir, "trading-log.jsonl"), JSON.stringify(entry) + "\n");
+  } catch { /* best-effort */ }
 }
 
 export async function executeCryptoRequest(

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -731,6 +731,236 @@ server.registerTool(
     jsonResponse(await computePortfolioPnl({ by, window, accountNumber: account_number, top }))
 );
 
+// ── robinhood_buying_power: standalone per-account buying power + margin health ──
+server.registerTool(
+  "robinhood_buying_power",
+  {
+    title: "Robinhood Buying Power",
+    description:
+      "Per-account buying power breakdown: regular BP, unleveraged BP, intraday BP, cash, margin used, margin health %. Answers 'what can I actually deploy right now?'. Includes excess_maintenance vs excess_margin distinction. Live read; no gate.",
+    inputSchema: z.object({
+      account_number: z.string().optional(),
+    }),
+    annotations: toolAnnotations(true, "sensitive-read")
+  },
+  async ({ account_number }) => {
+    const graph = await brokerageGetJson("https://bonfire.robinhood.com/transfer/accounts/");
+    const rows: any[] = Array.isArray(graph?.results) ? graph.results : Array.isArray(graph) ? graph : [];
+    let accts: string[] = [];
+    for (const a of rows) {
+      if (a?.type !== "rhs" && a?.type !== "ira_roth") continue;
+      if (!a.account_number) continue;
+      accts.push(String(a.account_number));
+    }
+    if (account_number) {
+      if (!accts.includes(String(account_number))) return jsonResponse({ error: `Account ${account_number} not found.` });
+      accts = [String(account_number)];
+    }
+    const results: any[] = [];
+    for (const acct of accts) {
+      try {
+        const bp = await brokerageGetJson("https://api.robinhood.com/accounts/{num}/buying_power_breakdown", { num: acct });
+        const p = await brokerageGetJson("https://api.robinhood.com/portfolios/{num}/", { num: acct });
+        const n = (v: unknown) => Number(v);
+        const equity = n(p.equity);
+        const marketVal = n(p.market_value);
+        const marginHealth = marketVal > 0 ? (equity / marketVal) * 100 : Number.NaN;
+        results.push({
+          accountNumber: acct,
+          buyingPower: n(bp.buying_power),
+          unleveragedBuyingPower: n(bp.unleveraged_buying_power),
+          intradayBuyingPower: n(bp.intraday_buying_power),
+          cash: n(bp.cash ?? (bp.breakdown?.find((x: any) => x.category === "Cash")?.value ?? 0)),
+          leverageEnabled: bp.leverage_enabled ?? false,
+          marginTotal: bp.breakdown?.find((x: any) => x.title?.toLowerCase().includes("margin total"))?.value ?? null,
+          marginUsed: bp.breakdown?.find((x: any) => x.title?.toLowerCase().includes("margin used"))?.value ?? null,
+          excessMaintenance: n(p.excess_maintenance),
+          excessMargin: n(p.excess_margin),
+          equity,
+          marketValue: marketVal,
+          marginHealthPct: marginHealth,
+        });
+      } catch (e) { results.push({ accountNumber: acct, error: (e as Error).message }); }
+    }
+    return jsonResponse(results);
+  }
+);
+
+// ── robinhood_buy: simple market/limit order — matching the CLI `buy` command ──
+server.registerTool(
+  "robinhood_buy",
+  {
+    title: "Robinhood Buy Order",
+    description:
+      "Place an equity buy order. Market buys are fractional, limit orders are whole shares. Dry-run by default; set live=true and ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute. Auto-resolves symbol to instrument, fetches live quote, calculates shares from dollar amount.",
+    inputSchema: z.object({
+      symbol: z.string(),
+      account_number: z.string(),
+      amount: z.number().positive().optional(),
+      shares: z.number().positive().optional(),
+      price: z.number().positive().optional(),
+      live: z.boolean().default(false),
+    }),
+    annotations: toolAnnotations(false, "write-mutate")
+  },
+  async ({ symbol, account_number, amount, shares, price: limitPrice, live }) => {
+    if (!amount && !shares) return jsonResponse({ error: "Must specify amount (dollars) or shares (quantity)" });
+    if (amount && shares) return jsonResponse({ error: "Specify amount OR shares, not both" });
+
+    try {
+      const inst = (await brokerageGetJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol: symbol.toUpperCase() })).results?.[0];
+      if (!inst) return jsonResponse({ error: `Symbol ${symbol} not found` });
+      const iid = inst.id;
+
+      const q = (await brokerageGetJson("https://api.robinhood.com/marketdata/quotes/?ids={ids}", { ids: iid })).results?.[0];
+      if (!q) return jsonResponse({ error: `No quote for ${symbol}` });
+      const last = Number(q.last_trade_price);
+      if (!last || last <= 0) return jsonResponse({ error: `Invalid price: $${last}` });
+
+      const isMarket = !limitPrice;
+      const rawShares = amount ? amount / last : Number(shares);
+      const qty = Number(rawShares.toFixed(4));
+      const orderPrice = limitPrice ? limitPrice.toFixed(2) : last.toFixed(2);
+
+      const result = await gatedBrokerageWrite({
+        url: "https://api.robinhood.com/orders/",
+        method: "POST",
+        body: {
+          account: `https://api.robinhood.com/accounts/${account_number}/`,
+          instrument: `https://api.robinhood.com/instruments/${iid}/`,
+          symbol: symbol.toUpperCase(),
+          type: isMarket ? "market" : "limit",
+          time_in_force: isMarket ? "gfd" : "gtc",
+          trigger: "immediate",
+          side: "buy",
+          quantity: String(qty),
+          price: orderPrice,
+          order_form_version: "7"
+        },
+        dryRun: !live,
+        liveWrite: Boolean(live)
+      });
+
+      const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      return jsonResponse({
+        symbol: symbol.toUpperCase(),
+        account: account_number,
+        shares: qty,
+        estimatedPrice: last,
+        estimatedTotal: qty * last,
+        type: isMarket ? "market" : "limit",
+        live: !result.dryRun,
+        orderId: rb?.id ?? rb?.url ?? null,
+        state: rb?.state ?? null,
+        httpStatus: result.status,
+        dryRun: result.dryRun
+      });
+    } catch (e: any) {
+      return jsonResponse({ error: e.message });
+    }
+  }
+);
+
+// ── robinhood_sell: mirror of buy ──
+server.registerTool(
+  "robinhood_sell",
+  {
+    title: "Robinhood Sell Order",
+    description: "Place an equity sell order. Market sells are fractional. Dry-run by default.",
+    inputSchema: z.object({
+      symbol: z.string(), account_number: z.string(),
+      amount: z.number().positive().optional(), shares: z.number().positive().optional(),
+      price: z.number().positive().optional(), live: z.boolean().default(false),
+    }),
+    annotations: toolAnnotations(false, "write-mutate")
+  },
+  async ({ symbol, account_number, amount, shares, price: limitPrice, live }) => {
+    if (!amount && !shares) return jsonResponse({ error: "Must specify amount or shares" });
+    try {
+      const inst = (await brokerageGetJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol: symbol.toUpperCase() })).results?.[0];
+      if (!inst) return jsonResponse({ error: `Symbol ${symbol} not found` });
+      const iid = inst.id;
+      const q = (await brokerageGetJson("https://api.robinhood.com/marketdata/quotes/?ids={ids}", { ids: iid })).results?.[0];
+      const last = Number(q?.last_trade_price ?? 0);
+      const qty = Number((amount ? amount / last : Number(shares)).toFixed(4));
+      const result = await gatedBrokerageWrite({
+        url: "https://api.robinhood.com/orders/", method: "POST",
+        body: { account: `https://api.robinhood.com/accounts/${account_number}/`, instrument: `https://api.robinhood.com/instruments/${iid}/`, symbol: symbol.toUpperCase(), type: limitPrice ? "limit" : "market", time_in_force: limitPrice ? "gtc" : "gfd", trigger: "immediate", side: "sell", quantity: String(qty), price: (limitPrice ?? last).toFixed(2), order_form_version: "7" },
+        dryRun: !live, liveWrite: Boolean(live)
+      });
+      const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      return jsonResponse({ symbol: symbol.toUpperCase(), account: account_number, shares: qty, estimatedPrice: last, type: limitPrice ? "limit" : "market", live: !result.dryRun, orderId: rb?.id ?? null, state: rb?.state ?? null, httpStatus: result.status });
+    } catch (e: any) { return jsonResponse({ error: e.message }); }
+  }
+);
+
+// ── robinhood_cancel: cancel order by ID ──
+server.registerTool(
+  "robinhood_cancel",
+  {
+    title: "Robinhood Cancel Order",
+    description: "Cancel a pending order by ID.",
+    inputSchema: z.object({ order_id: z.string(), live: z.boolean().default(false) }),
+    annotations: toolAnnotations(false, "write-mutate")
+  },
+  async ({ order_id, live }) => {
+    try {
+      const result = await gatedBrokerageWrite({
+        url: `https://api.robinhood.com/orders/${order_id}/cancel/`, method: "POST",
+        dryRun: !live, liveWrite: Boolean(live)
+      });
+      const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
+      return jsonResponse({ orderId: order_id, live: !result.dryRun, state: rb?.state ?? null, httpStatus: result.status });
+    } catch (e: any) { return jsonResponse({ error: e.message }); }
+  }
+);
+
+// ── robinhood_order_status: check status of a single order ──
+server.registerTool(
+  "robinhood_order_status",
+  {
+    title: "Robinhood Order Status",
+    description: "Check status of a single order by ID — symbol, side, quantity, price, state, fills.",
+    inputSchema: z.object({ order_id: z.string() }),
+    annotations: toolAnnotations(true, "sensitive-read")
+  },
+  async ({ order_id }) => {
+    try {
+      const id = order_id.includes("/orders/") ? order_id.split("/orders/")[1].replace(/\/$/, "") : order_id;
+      const data = await brokerageGetJson("https://api.robinhood.com/orders/{0}/", { "0": id });
+      return jsonResponse(data);
+    } catch (e: any) { return jsonResponse({ error: e.message }); }
+  }
+);
+
+// ── robinhood_settings: read account settings ──
+server.registerTool(
+  "robinhood_settings",
+  {
+    title: "Robinhood Account Settings",
+    description: "Read account settings: DRIP, options trade-on-expiration, PDT protection, cash sweep, stock lending.",
+    inputSchema: z.object({ account_number: z.string() }),
+    annotations: toolAnnotations(true, "read")
+  },
+  async ({ account_number }) => {
+    const get = async (url: string) => { try { return await brokerageGetJson(url, { account: account_number }); } catch (e) { return { error: (e as Error).message.slice(0, 60) }; } };
+    const [drip, opt, margin, sweep, lending] = await Promise.all([
+      get("https://api.robinhood.com/corp_actions/drip/account_settings/{account}/"),
+      get("https://api.robinhood.com/options/option_settings/{account}/"),
+      get("https://api.robinhood.com/settings/margin/{account}/"),
+      get(/* sweep state */ "https://api.robinhood.com/accounts/{account}/" /* simplified — use main */),
+      get(/* stock lending */ "https://api.robinhood.com/accounts/{account}/")
+    ]);
+    return jsonResponse({
+      account: account_number, generatedAt: new Date().toISOString(),
+      dripEnabled: drip?.dividend_reinvestment_enabled ?? drip?.drip_enabled,
+      optionsLevel: opt?.option_level,
+      pdtProtection: margin?.day_trades_protection,
+      leverageEnabled: margin?.leverage_enabled
+    });
+  }
+);
+
 server.registerTool(
   "robinhood_options_holdings",
   {

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -906,7 +906,8 @@ server.registerTool(
   async ({ order_id, live }) => {
     try {
       const result = await gatedBrokerageWrite({
-        url: `https://api.robinhood.com/orders/${order_id}/cancel/`, method: "POST",
+        url: "https://api.robinhood.com/orders/{0}/cancel/", method: "POST",
+        params: { "0": order_id },
         dryRun: !live, liveWrite: Boolean(live)
       });
       const rb = typeof result.body === "string" ? JSON.parse(result.body) : result.body;

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -934,34 +934,6 @@ server.registerTool(
   }
 );
 
-// ── robinhood_settings: read account settings ──
-server.registerTool(
-  "robinhood_settings",
-  {
-    title: "Robinhood Account Settings",
-    description: "Read account settings: DRIP, options trade-on-expiration, PDT protection, cash sweep, stock lending.",
-    inputSchema: z.object({ account_number: z.string() }),
-    annotations: toolAnnotations(true, "read")
-  },
-  async ({ account_number }) => {
-    const get = async (url: string) => { try { return await brokerageGetJson(url, { account: account_number }); } catch (e) { return { error: (e as Error).message.slice(0, 60) }; } };
-    const [drip, opt, margin, sweep, lending] = await Promise.all([
-      get("https://api.robinhood.com/corp_actions/drip/account_settings/{account}/"),
-      get("https://api.robinhood.com/options/option_settings/{account}/"),
-      get("https://api.robinhood.com/settings/margin/{account}/"),
-      get(/* sweep state */ "https://api.robinhood.com/accounts/{account}/" /* simplified — use main */),
-      get(/* stock lending */ "https://api.robinhood.com/accounts/{account}/")
-    ]);
-    return jsonResponse({
-      account: account_number, generatedAt: new Date().toISOString(),
-      dripEnabled: drip?.dividend_reinvestment_enabled ?? drip?.drip_enabled,
-      optionsLevel: opt?.option_level,
-      pdtProtection: margin?.day_trades_protection,
-      leverageEnabled: margin?.leverage_enabled
-    });
-  }
-);
-
 server.registerTool(
   "robinhood_options_holdings",
   {

--- a/scripts/refresh-auth.sh
+++ b/scripts/refresh-auth.sh
@@ -24,18 +24,68 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export ROBINHOOD_ENV_PATH="$REPO_DIR/.env"
 
-command -v python3 >/dev/null || { echo "ERROR: python3 not on PATH" >&2; exit 1; }
+# Detect OS and pick the right Python binary + Chrome base path.
+case "$(uname -s)" in
+    Darwin)
+        PYTHON_BIN="python3"
+        CHROME_BASE="$HOME/Library/Application Support/Google/Chrome"
+        ;;
+    MINGW*|MSYS*|CYGWIN*)
+        # git-bash / MSYS2 / Cygwin on Windows
+        if command -v python >/dev/null 2>&1; then
+            PYTHON_BIN="python"
+        elif command -v python3 >/dev/null 2>&1; then
+            PYTHON_BIN="python3"
+        else
+            echo "ERROR: python not on PATH" >&2
+            exit 1
+        fi
+        # Windows Chrome profile: %LOCALAPPDATA%\Google\Chrome\User Data
+        # In MSYS/git-bash, LOCALAPPDATA is already set. Fall back to constructing from HOME.
+        if [ -n "${LOCALAPPDATA:-}" ]; then
+            CHROME_BASE="$(cygpath -u "$LOCALAPPDATA" 2>/dev/null || echo "$LOCALAPPDATA")/Google/Chrome/User Data"
+        else
+            CHROME_BASE="$HOME/AppData/Local/Google/Chrome/User Data"
+        fi
+        ;;
+    Linux)
+        PYTHON_BIN="python3"
+        CHROME_BASE="$HOME/.config/google-chrome"
+        ;;
+    *)
+        echo "ERROR: unsupported OS ($(uname -s))" >&2
+        exit 1
+        ;;
+esac
+
+# Verify the binary exists.
+command -v "$PYTHON_BIN" >/dev/null || { echo "ERROR: $PYTHON_BIN not on PATH" >&2; exit 1; }
+
+export CHROME_BASE
 
 # Python does the disk scan, writes .env, chmods it, and prints the status — so the
-# token value never passes through the shell. Heredoc goes straight to python3 (no
+# token value never passes through the shell. Heredoc goes straight to python (no
 # nesting inside $(), which trips macOS bash 3.2's paren scanner).
-python3 << 'PYEOF'
+"$PYTHON_BIN" << 'PYEOF'
 import re, json, glob, os, sys, datetime
 
 env_path = os.environ["ROBINHOOD_ENV_PATH"]
-home = os.path.expanduser("~")
-base = os.path.join(home, "Library/Application Support/Google/Chrome")
+base = os.environ.get("CHROME_BASE")
 
+if not base:
+    # Fallback: try macOS default (for bare invocation without the wrapper)
+    home = os.path.expanduser("~")
+    if sys.platform == "darwin":
+        base = os.path.join(home, "Library/Application Support/Google/Chrome")
+    elif sys.platform == "win32":
+        base = os.path.join(os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData/Local")),
+                            "Google", "Chrome", "User Data")
+    else:
+        base = os.path.join(home, ".config/google-chrome")
+
+# On Windows, the base IS "User Data" and profiles are direct children.
+# On macOS/Linux, profiles are direct children of the Chrome base.
+# The glob below handles both: "<base>/*/Local Storage/leveldb"
 files = []
 for prof in glob.glob(os.path.join(base, "*", "Local Storage", "leveldb")):
     files += glob.glob(os.path.join(prof, "*.ldb"))
@@ -93,7 +143,10 @@ env = (
 )
 with open(env_path, "w") as fh:
     fh.write(env)
-os.chmod(env_path, 0o600)
+try:
+    os.chmod(env_path, 0o600)
+except OSError:
+    pass  # chmod on Windows is no-op; ignore
 print("[refresh-auth] wrote %s (OK len=%d type=%s exp_days=%.1f)"
       % (env_path, len(tok), ttype, exp / 86400))
 PYEOF


### PR DESCRIPTION
## Changes

- **feat: harden CLI+MCP+API** — buy/sell/cancel/buying-power/order-status with dedup (7348d85)
- **fix: MCP cancel template, history timestamp, sell dedup, sell logging** (0cf3860)
- **fix: remove duplicate robinhood_settings MCP tool** — was crashing the MCP server (5e1f0bc)
- **feat: add ref_id idempotency to buy/sell** with TODO roadmap (eab4961)
- **fix: 5-min time window on dedup** — stale orders won't block forever (a439e1a)