### PR TITLE
engine: native dollar_based_amount body for fractional market orders (web parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ node cli/dist/index.js --help
 |---------|---------------|
 | API map | 300+ brokerage/account route entries (incl. instrument search + the `midlands/` sentiment layer) + the official Crypto routes, generated OpenAPI, endpoint Markdown, and curl templates. Every entry carries field-level response provenance (`verified`/`inferred`/`undocumented`, test-enforced). Trust the live count (`brokerage routes --json`), never a hardcoded number. |
 | CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep) and `recurring` (list/pause/resume/create/edit/end) — all writes double-gated — plus route planning and dry-run order bodies. |
-| MCP | 40+ agent tools (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
+| MCP | The full agent-tool surface (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
 | Memory | `ball-knowledge.md` (market beliefs/themes/sources) + `trading-log.md` (execution + intent history) — the agent's cross-session brain. |
 | Research | A source-quality doctrine (X/Reddit pulse → news/`midlands` confirmer → institutional outlook → academic math, none gospel) + strategy deep-dives (Wheel, rolling, with quant appendices), institutional CMAs, tax-aware notes. |
 | Auth | Browser-session bearer token loaded from local `.env`, with one-shot self-heal on `401` |
@@ -66,7 +66,7 @@ boot (read the operating-intelligence KB → memory → doctrine)
   → update memory  (ball-knowledge.md) → the thread continues next session
 ```
 
-The layers an agent reads to do that: **`SKILL.md`** (trigger + 80/20 + all the pitfalls) → **`AGENTS.md`** (self-contained deep reference) → **`docs/agent-operating-intelligence-2026-06-04.md`** (the boot-smart KB: cardinal rule, account/order/signal decision frameworks, failure→fix tree) → the **memory** files → the **research** docs (`docs/strategy-deep-dive-*`, `institutional-outlook-*`, `tax-aware-options-strategies`, `options-strategies-knowledge-base`). Everything is engine-backed (`cli/src/lib.ts`) and double-gated.
+The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill entry point — trigger + 80/20 + the operating loop + intent routing) → **`references/`** (the skill's progressive-disclosure layer: `operation-guide`, `command-catalog`, `api-route-map`, `safety-doctrine`, `options-strategy`, `troubleshooting`) → **`knowledge/`** (per-topic reasoning modules) → **`docs/agent-operating-intelligence-2026-06-04.md`** (the boot-smart KB: cardinal rule, account/order/signal decision frameworks, failure→fix tree) → the **memory** files → the **research** docs (`docs/strategy-deep-dive-*`, `institutional-outlook-*`, `tax-aware-options-strategies`, `options-strategies-knowledge-base`). The in-repo **`AGENTS.md`** (developer/maintainer runbook; `CLAUDE.md` is a symlink to it) covers build/test, the shared-engine invariant, and route-map editing. Everything is engine-backed (`cli/src/lib.ts`) and double-gated.
 
 ## Coverage
 
@@ -120,7 +120,7 @@ The MCP server is meant for requests like:
 
 The one-off features that make this more than an API wrapper:
 
-**Wheel engine + version scrape + recipes.** `wheel [symbol]` (CLI) and `robinhood_wheel` (MCP, 40+ tools — live truth: `tools/list`) read your actual shares + short puts/calls, classify your wheel stage (CSP open, shares uncovered, covered call on, and the rest), flag undercovered short calls as the naked exposure they are, and hand back the literal next-leg dry-run command. Works as pure discussion with no position on. `pnpm version:refresh` uses the CDP debug browser to scrape the live `x-robinhood-web-app-version` header off the login page (no RH login needed) and writes it to `.env`, so the equity-order version gate can't rot. `recipes "<intent>"` turns free text into the one command that answers it.
+**Wheel engine + version scrape + recipes.** `wheel [symbol]` (CLI) and `robinhood_wheel` (MCP — live truth: `tools/list`) read your actual shares + short puts/calls, classify your wheel stage (CSP open, shares uncovered, covered call on, and the rest), flag undercovered short calls as the naked exposure they are, and hand back the literal next-leg dry-run command. Works as pure discussion with no position on. `pnpm version:refresh` uses the CDP debug browser to scrape the live `x-robinhood-web-app-version` header off the login page (no RH login needed) and writes it to `.env`, so the equity-order version gate can't rot. `recipes "<intent>"` turns free text into the one command that answers it.
 
 **The kosher roll.** On a cash account, sale proceeds settle T+1, so a same-day roll is not "risky," it is structurally impossible without a good-faith violation. `options roll-plan --cash-account` stages it the only legal way: close today, open the replacement next business day after fresh settled-cash and quote checks. A broker would have just told you no.
 
@@ -280,7 +280,7 @@ claude mcp add robinhood-cli -s user -- node /absolute/path/to/robinhood-cli/mcp
 node mcp/dist/server.js
 ```
 
-40+ tools (live truth: `tools/list`) surface as `mcp__robinhood-cli__*` and inherit the identical auth, route map, and write gates as the CLI. The order tools (`robinhood_buy`, `robinhood_sell`, `robinhood_cancel`, `robinhood_order_status`, `robinhood_buying_power`) run the **same shared engine functions** as the CLI commands — dedup, `ref_id` idempotency, and the OTC guard apply identically on both surfaces — and `robinhood_wheel` gives agents an evidence-based Wheel conversation (stage + next leg + the exact dry-run command). (Trust the live `tools/list`, not a hardcoded count.)
+The MCP tools (live truth: `tools/list`) surface as `mcp__robinhood-cli__*` and inherit the identical auth, route map, and write gates as the CLI. The order tools (`robinhood_buy`, `robinhood_sell`, `robinhood_cancel`, `robinhood_order_status`, `robinhood_buying_power`) run the **same shared engine functions** as the CLI commands — dedup, `ref_id` idempotency, and the OTC guard apply identically on both surfaces — and `robinhood_wheel` gives agents an evidence-based Wheel conversation (stage + next leg + the exact dry-run command). (Trust the live `tools/list`, not a hardcoded count.)
 
 ### Current Update
 
@@ -539,14 +539,15 @@ N positions — green/red split.
 
 > **Rebuild note:** the build copies `api-map/brokerage-routes.json` into `cli/dist/`, and the runtime reads that copy. After editing the route map, **rebuild** (`pnpm build`) or your change is a silent no-op.
 
-For the full agent playbook — account discovery, the gate, watchlists, recurring investments — see [`AGENTS.md`](./AGENTS.md). For the public docs index, see [`docs/README.md`](./docs/README.md).
+For the full agent playbook — account discovery, the gate, watchlists, recurring investments — see [`SKILL.md`](./SKILL.md) and its [`references/`](./references/). For the in-repo developer/maintainer runbook (build/test, the shared-engine invariant, route-map editing), see [`AGENTS.md`](./AGENTS.md). For the public docs index, see [`docs/README.md`](./docs/README.md).
 
 ## Documentation
 
 | Path | Purpose |
 |------|---------|
-| [`AGENTS.md`](./AGENTS.md) | Full agent runbook: auth, account enumeration, route execution, writes, MCP registration |
-| [`SKILL.md`](./SKILL.md) | Skill entrypoint for agents and Hermes-style installers |
+| [`SKILL.md`](./SKILL.md) | Portable skill entry point for agents/Hermes installers (lean operator router) — deep how-to in [`references/`](./references/) |
+| [`references/`](./references/) | Skill progressive-disclosure layer: operation guide, command catalog, API route map, safety doctrine, options strategy, troubleshooting |
+| [`AGENTS.md`](./AGENTS.md) | In-repo developer/maintainer runbook: repo layout, build/test, shared-engine invariant, route-map editing, MCP registration (`CLAUDE.md` is a symlink to it) |
 | [`docs/README.md`](./docs/README.md) | Public docs index and naming/release rules |
 | [`docs/account-settings-capability-map-2026-06-03.md`](./docs/account-settings-capability-map-2026-06-03.md) | Funding, recurring, DRIP, cash sweep, stock lending, margin, futures, event-contract capability matrix |
 | [`docs/options-strategy-execution-smoke-2026-06-03.md`](./docs/options-strategy-execution-smoke-2026-06-03.md) | Dry-run options strategy smoke evidence |

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3241,12 +3241,13 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
-    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${r.shares.toFixed(6)} sh @ ~$${r.estimatedPrice.toFixed(2)} ≈ $${r.estimatedTotal.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
+    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });
@@ -3277,12 +3278,13 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
-    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${r.shares.toFixed(6)} sh @ ~$${r.estimatedPrice.toFixed(2)} ≈ $${r.estimatedTotal.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
+    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3241,13 +3241,14 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
     const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
-    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}${r.session ? `  [${r.session}]` : ""}\n`);
+    if (r.sessionWarning) process.stdout.write(`⚠️  ${r.sessionWarning}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });
@@ -3278,13 +3279,14 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
     const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
-    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}${r.session ? `  [${r.session}]` : ""}\n`);
+    if (r.sessionWarning) process.stdout.write(`⚠️  ${r.sessionWarning}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -2506,6 +2506,71 @@ export function filterRecentPending(orders: any[], side: "buy" | "sell", nowMs: 
   });
 }
 
+// ── Market-session awareness ────────────────────────────────────────────────────────────────────
+// The order body's `market_hours` and the "will it fill now or queue?" question both depend on the
+// CURRENT US-equity session. We derive it from Robinhood's OWN market-hours endpoint (holiday- and
+// half-day-aware — never a hardcoded 9:30–16:00 clock), with an ET-clock fallback only if that read
+// fails. Zayd Khan // cold // www.zayd.wtf
+export type MarketSession = "pre_market" | "regular" | "after_hours" | "closed";
+
+export interface MarketSessionInfo {
+  session: MarketSession;
+  /** Is today a trading day at all (false on weekends/holidays). */
+  isTradingDay: boolean;
+  /** True when authoritative RH hours were used; false when the ET-clock fallback was. */
+  authoritative: boolean;
+}
+
+/** ET calendar date `YYYY-MM-DD` for an epoch ms — DST-correct via Intl (en-CA yields ISO order). */
+export function etDateString(nowMs: number): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York", year: "numeric", month: "2-digit", day: "2-digit"
+  }).format(new Date(nowMs));
+}
+
+/** ET-clock session heuristic — the fallback ONLY (no holiday/half-day awareness). */
+export function etClockSession(nowMs: number): MarketSession {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York", weekday: "short", hour: "2-digit", minute: "2-digit", hourCycle: "h23"
+  }).formatToParts(new Date(nowMs));
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  const wd = get("weekday");
+  if (wd === "Sat" || wd === "Sun") return "closed";
+  const mins = (Number(get("hour")) % 24) * 60 + Number(get("minute"));
+  if (mins >= 9 * 60 + 30 && mins < 16 * 60) return "regular";
+  if (mins >= 4 * 60 && mins < 9 * 60 + 30) return "pre_market";
+  if (mins >= 16 * 60 && mins < 20 * 60) return "after_hours";
+  return "closed";
+}
+
+/**
+ * Classify the current US-equity session from Robinhood's authoritative hours endpoint.
+ * Best-effort: any read failure falls back to the ET clock (still useful, just holiday-blind).
+ */
+export async function computeMarketSession(
+  deps: { getJson?: typeof brokerageGetJson; now?: () => number } = {}
+): Promise<MarketSessionInfo> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const nowMs = (deps.now ?? Date.now)();
+  let hours: any;
+  try {
+    hours = await getJson("https://api.robinhood.com/markets/{market}/hours/{date}/", {
+      market: "XNYS", date: etDateString(nowMs)
+    });
+  } catch {
+    return { session: etClockSession(nowMs), isTradingDay: etClockSession(nowMs) !== "closed", authoritative: false };
+  }
+  if (!hours?.is_open) return { session: "closed", isTradingDay: false, authoritative: true };
+  const t = (s?: string) => (s ? Date.parse(s) : NaN);
+  const open = t(hours.opens_at), close = t(hours.closes_at);
+  const extOpen = t(hours.extended_opens_at), extClose = t(hours.extended_closes_at);
+  let session: MarketSession = "closed";
+  if (Number.isFinite(open) && Number.isFinite(close) && nowMs >= open && nowMs < close) session = "regular";
+  else if (Number.isFinite(extOpen) && Number.isFinite(open) && nowMs >= extOpen && nowMs < open) session = "pre_market";
+  else if (Number.isFinite(close) && Number.isFinite(extClose) && nowMs >= close && nowMs < extClose) session = "after_hours";
+  return { session, isTradingDay: true, authoritative: true };
+}
+
 export interface EquityOrderInput {
   symbol: string;
   accountNumber: string;
@@ -2527,6 +2592,8 @@ export interface EquityOrderDeps {
   write?: typeof gatedBrokerageWrite;
   log?: typeof logTrade;
   now?: () => number;
+  /** Injectable session detector (tests pass a fake; default reads RH's live hours). */
+  getMarketSession?: typeof computeMarketSession;
 }
 
 export interface EquityOrderResult {
@@ -2541,6 +2608,10 @@ export interface EquityOrderResult {
   otcAutoLimit: boolean;
   /** True when the send used the native `dollar_based_amount` fractional body (dollar-notional market order on a fractional-tradable name) rather than a computed quantity. */
   dollarBased: boolean;
+  /** Detected US-equity session at send time (`regular`/`pre_market`/`after_hours`/`closed`); undefined if detection was skipped/failed. */
+  session?: MarketSession;
+  /** Set when the order will QUEUE rather than fill now (e.g. a fractional/market order placed outside regular hours). */
+  sessionWarning?: string;
   live: boolean;
   dryRun: boolean;
   refId: string;
@@ -2569,6 +2640,7 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
   const write = deps.write ?? gatedBrokerageWrite;
   const log = deps.log ?? logTrade;
   const now = deps.now ?? Date.now;
+  const getMarketSession = deps.getMarketSession ?? computeMarketSession;
   const symbol = input.symbol.toUpperCase();
   const side = input.side;
   if (!input.amount && !input.shares) throw new Error("Must specify amount (dollars) or shares (quantity)");
@@ -2659,6 +2731,25 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
   // collar is the one thing Robinhood rejects on the dollar path). Missing/one-sided book → the field
   // is omitted rather than sent as 0/NaN. Zayd Khan // cold // www.zayd.wtf
   const dollarBased = input.amount != null && !otc && isMarket;
+
+  // Session awareness — detect the CURRENT session so the order can (a) carry the right `market_hours`
+  // and (b) tell the operator whether it fills NOW or queues to the next regular session. Best-effort:
+  // a detection failure never blocks a send (session stays undefined, no warning). Fractional dollar
+  // orders are regular-hours-only, so their `market_hours` is always "regular_hours" — but when placed
+  // off-session we say so loudly, because "queued, not filled" is exactly the surprise to prevent.
+  let session: MarketSession | undefined;
+  let sessionWarning: string | undefined;
+  try {
+    session = (await getMarketSession({ getJson, now })).session;
+  } catch { /* best-effort — leave session undefined */ }
+  if (session && session !== "regular") {
+    if (dollarBased) {
+      sessionWarning = `Session is ${session}: fractional dollar orders fill ONLY in regular hours, so this will QUEUE to the next regular session — it will not fill now.`;
+    } else if (isMarket) {
+      sessionWarning = `Session is ${session}: a market order will QUEUE to the next regular session — it will not fill now. Use a limit order for extended-hours execution.`;
+    }
+  }
+
   const baseBody: Record<string, unknown> = {
     account: `https://api.robinhood.com/accounts/${input.accountNumber}/`,
     instrument: `https://api.robinhood.com/instruments/${iid}/`,
@@ -2739,6 +2830,8 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
     type: isMarket ? "market" : "limit",
     otcAutoLimit,
     dollarBased,
+    session,
+    sessionWarning,
     live: !result.dryRun, dryRun: result.dryRun, refId,
     orderId: (rb as any)?.id ?? (rb as any)?.url ?? null,
     state: (rb as any)?.state ?? null,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -2539,6 +2539,8 @@ export interface EquityOrderResult {
   type: "market" | "limit";
   /** True when an OTC order with no explicit limit was auto-limited at the marketable side (buy=ask, sell=bid). */
   otcAutoLimit: boolean;
+  /** True when the send used the native `dollar_based_amount` fractional body (dollar-notional market order on a fractional-tradable name) rather than a computed quantity. */
+  dollarBased: boolean;
   live: boolean;
   dryRun: boolean;
   refId: string;
@@ -2644,23 +2646,52 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
 
   // 5. Send (ref_id = broker-level idempotency; a 429 retries the SAME ref_id safely).
   const refId = `${symbol}-${input.accountNumber}-${now()}`;
+
+  // Body shape — two faithful forms, matching what robinhood.com itself sends:
+  //   • Dollar-notional MARKET order on a fractional-tradable (non-OTC) name → the NATIVE fractional
+  //     body: `dollar_based_amount {amount,currency_code}` (NOT a computed quantity) plus the live
+  //     bid/ask collar (`bid_price`/`ask_price`/`bid_ask_timestamp`), `market_hours`, and
+  //     `position_effect`. This is the exact body the web app posts for "$X of AAPL", and lets the
+  //     broker — not us — derive the fill quantity from the dollar amount. (Capture: 2026-06-14.)
+  //   • Everything else (whole shares, any limit order, OTC) → the quantity+price body. OTC and limit
+  //     orders have no native dollar form; shares are already exact.
+  // The collar fields come from the SAME live quote fetched above, so the timestamp is fresh (a stale
+  // collar is the one thing Robinhood rejects on the dollar path). Missing/one-sided book → the field
+  // is omitted rather than sent as 0/NaN. Zayd Khan // cold // www.zayd.wtf
+  const dollarBased = input.amount != null && !otc && isMarket;
+  const baseBody: Record<string, unknown> = {
+    account: `https://api.robinhood.com/accounts/${input.accountNumber}/`,
+    instrument: `https://api.robinhood.com/instruments/${iid}/`,
+    symbol,
+    type: isMarket ? "market" : "limit",
+    time_in_force: tif,
+    trigger: "immediate",
+    side,
+    order_form_version: "7",
+    ref_id: refId
+  };
+  let body: Record<string, unknown>;
+  if (dollarBased) {
+    const bid = Number(q?.bid_price);
+    const ask = Number(q?.ask_price);
+    body = {
+      ...baseBody,
+      dollar_based_amount: { amount: Number(input.amount).toFixed(2), currency_code: "USD" },
+      market_hours: "regular_hours",
+      position_effect: side === "buy" ? "open" : "close",
+      ...(Number.isFinite(bid) && bid > 0 ? { bid_price: bid.toFixed(2) } : {}),
+      ...(Number.isFinite(ask) && ask > 0 ? { ask_price: ask.toFixed(2) } : {}),
+      ...(q?.updated_at ? { bid_ask_timestamp: String(q.updated_at) } : {})
+    };
+  } else {
+    body = { ...baseBody, quantity: String(shares), price };
+  }
+
   const result = await write({
     skipTradeLog: true, // placeEquityOrder writes its own richer log entry below — avoid double-logging
     url: "https://api.robinhood.com/orders/",
     method: "POST",
-    body: {
-      account: `https://api.robinhood.com/accounts/${input.accountNumber}/`,
-      instrument: `https://api.robinhood.com/instruments/${iid}/`,
-      symbol,
-      type: isMarket ? "market" : "limit",
-      time_in_force: tif,
-      trigger: "immediate",
-      side,
-      quantity: String(shares),
-      price,
-      order_form_version: "7",
-      ref_id: refId
-    },
+    body,
     dryRun: !liveWrite,
     liveWrite
   });
@@ -2707,6 +2738,7 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
     estimatedPrice: last, estimatedTotal: shares * last,
     type: isMarket ? "market" : "limit",
     otcAutoLimit,
+    dollarBased,
     live: !result.dryRun, dryRun: result.dryRun, refId,
     orderId: (rb as any)?.id ?? (rb as any)?.url ?? null,
     state: (rb as any)?.state ?? null,

--- a/cli/test/equity-order.test.ts
+++ b/cli/test/equity-order.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   DEDUP_WINDOW_MS,
+  etClockSession,
+  computeMarketSession,
   extractOrderId,
   filterRecentPending,
   getOrderStatus,
-  placeEquityOrder
+  placeEquityOrder,
+  type MarketSession
 } from "../src/lib.js";
 
 // Golden-behavior tests for the shared equity-order engine — the single code path behind the CLI
@@ -22,6 +25,7 @@ interface Fix {
   pendingOrders: any[];
   writeResult: { status: number; dryRun: boolean; body: unknown };
   orderListThrows?: boolean;
+  session: MarketSession;
 }
 
 function makeDeps(overrides: Partial<Fix> = {}) {
@@ -30,11 +34,13 @@ function makeDeps(overrides: Partial<Fix> = {}) {
     quote: { last_trade_price: "100.00", instrument_id: "iid-123" },
     pendingOrders: [],
     writeResult: { status: 0, dryRun: true, body: "{}" },
+    session: "regular",
     ...overrides
   };
   const calls = { writes: [] as any[], logs: [] as any[], orderListQueries: 0 };
   const deps = {
     now: () => NOW,
+    getMarketSession: async () => ({ session: fix.session, isTradingDay: fix.session !== "closed", authoritative: true }),
     getJson: async (url: string) => {
       if (url.includes("instruments/?symbol")) return { results: fix.instrument ? [fix.instrument] : [] };
       if (url.includes("marketdata/quotes")) return { results: fix.quote ? [fix.quote] : [] };
@@ -298,6 +304,84 @@ describe("placeEquityOrder — live-send dedup & logging", () => {
     expect(calls.logs).toHaveLength(1);
     expect(calls.logs[0]).toMatchObject({ symbol: "AAPL", account: "A1", side: "buy", refId: `AAPL-A1-${NOW}`, orderId: "ord-1", httpStatus: 201 });
     expect(r).toMatchObject({ live: true, dryRun: false, orderId: "ord-1", state: "queued", httpStatus: 201 });
+  });
+});
+
+describe("placeEquityOrder — session awareness", () => {
+  it("regular hours: no queue warning, session attached", async () => {
+    const { deps } = makeDeps({ session: "regular", quote: { last_trade_price: "100.00", bid_price: "99.98", ask_price: "100.02", updated_at: "t", instrument_id: "iid-123" } });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+    expect(r.session).toBe("regular");
+    expect(r.sessionWarning).toBeUndefined();
+  });
+
+  it("off-session dollar order: market_hours stays regular_hours BUT a loud queue warning is attached", async () => {
+    for (const session of ["pre_market", "after_hours", "closed"] as MarketSession[]) {
+      const { deps, calls } = makeDeps({ session });
+      const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+      // Fractional dollar orders are regular-hours-only — the body value never changes…
+      expect(calls.writes[0].body).toMatchObject({ market_hours: "regular_hours", dollar_based_amount: { amount: "250.00", currency_code: "USD" } });
+      // …but the operator is told it will QUEUE, not fill now.
+      expect(r.session).toBe(session);
+      expect(r.sessionWarning).toMatch(/QUEUE to the next regular session/);
+      expect(r.sessionWarning).toContain(session);
+    }
+  });
+
+  it("off-session whole-share MARKET order warns it will queue (suggests a limit for extended hours)", async () => {
+    const { deps } = makeDeps({ session: "after_hours" });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", shares: 3 }, deps);
+    expect(r.sessionWarning).toMatch(/market order will QUEUE/);
+    expect(r.sessionWarning).toMatch(/limit order for extended-hours/);
+  });
+
+  it("off-session LIMIT order gets NO queue warning (a limit can rest/execute extended)", async () => {
+    const { deps } = makeDeps({ session: "after_hours" });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", shares: 3, limitPrice: 95.5 }, deps);
+    expect(r.session).toBe("after_hours");
+    expect(r.sessionWarning).toBeUndefined();
+  });
+
+  it("a failed session detection never blocks the send (session undefined, no warning)", async () => {
+    const { deps, calls } = makeDeps({ session: "closed" });
+    (deps as any).getMarketSession = async () => { throw new Error("hours endpoint down"); };
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+    expect(r.session).toBeUndefined();
+    expect(r.sessionWarning).toBeUndefined();
+    expect(calls.writes).toHaveLength(1); // order still planned
+  });
+});
+
+describe("computeMarketSession — authoritative RH hours classification", () => {
+  // 2026-06-12 hours (real shape): regular 13:30Z–20:00Z, extended 11:00Z–00:00Z(+1).
+  const HOURS = { is_open: true, opens_at: "2026-06-12T13:30:00Z", closes_at: "2026-06-12T20:00:00Z", extended_opens_at: "2026-06-12T11:00:00Z", extended_closes_at: "2026-06-13T00:00:00Z" };
+  const at = (iso: string) => ({ getJson: (async () => HOURS) as any, now: () => Date.parse(iso) });
+
+  it("classifies regular / pre_market / after_hours / closed from the live window", async () => {
+    expect((await computeMarketSession(at("2026-06-12T15:00:00Z"))).session).toBe("regular");
+    expect((await computeMarketSession(at("2026-06-12T12:00:00Z"))).session).toBe("pre_market");
+    expect((await computeMarketSession(at("2026-06-12T22:00:00Z"))).session).toBe("after_hours");
+    expect((await computeMarketSession(at("2026-06-12T02:00:00Z"))).session).toBe("closed");
+  });
+
+  it("a non-trading day (is_open:false) is closed and not a trading day", async () => {
+    const r = await computeMarketSession({ getJson: (async () => ({ is_open: false })) as any, now: () => Date.parse("2026-06-14T15:00:00Z") });
+    expect(r).toMatchObject({ session: "closed", isTradingDay: false, authoritative: true });
+  });
+
+  it("falls back to the ET clock (non-authoritative) when the hours read fails", async () => {
+    const r = await computeMarketSession({ getJson: (async () => { throw new Error("down"); }) as any, now: () => Date.parse("2026-06-12T15:00:00Z") });
+    expect(r.authoritative).toBe(false);
+    expect(r.session).toBe("regular"); // 15:00Z Fri = 11:00 ET → regular
+  });
+});
+
+describe("etClockSession — fallback heuristic", () => {
+  it("maps ET wall-clock windows and treats weekends as closed", () => {
+    expect(etClockSession(Date.parse("2026-06-12T15:00:00Z"))).toBe("regular");    // Fri 11:00 ET
+    expect(etClockSession(Date.parse("2026-06-12T12:00:00Z"))).toBe("pre_market"); // Fri 08:00 ET
+    expect(etClockSession(Date.parse("2026-06-12T22:30:00Z"))).toBe("after_hours");// Fri 18:30 ET
+    expect(etClockSession(Date.parse("2026-06-14T16:00:00Z"))).toBe("closed");     // Sunday
   });
 });
 

--- a/cli/test/equity-order.test.ts
+++ b/cli/test/equity-order.test.ts
@@ -183,8 +183,9 @@ describe("placeEquityOrder — validation & guards", () => {
 });
 
 describe("placeEquityOrder — order body & dry-run semantics", () => {
-  it("builds the exact market-buy body: 4dp sizing, ref_id, order_form_version 7, gfd", async () => {
-    const { deps, calls } = makeDeps();
+  it("dollar-notional market buy uses the NATIVE dollar_based_amount body + live collar (web parity, not a computed quantity)", async () => {
+    // Fractional-tradable name, dollar sizing, market → the body robinhood.com itself posts.
+    const { deps, calls } = makeDeps({ quote: { last_trade_price: "100.00", bid_price: "99.98", ask_price: "100.02", updated_at: "2026-06-14T20:00:00Z", instrument_id: "iid-123" } });
     const r = await placeEquityOrder({ symbol: "aapl", accountNumber: "A1", side: "buy", amount: 250 }, deps);
 
     expect(calls.writes).toHaveLength(1);
@@ -200,18 +201,61 @@ describe("placeEquityOrder — order body & dry-run semantics", () => {
       time_in_force: "gfd",
       trigger: "immediate",
       side: "buy",
-      quantity: "2.5",
-      price: "100.00",
+      dollar_based_amount: { amount: "250.00", currency_code: "USD" },
+      market_hours: "regular_hours",
+      position_effect: "open",
+      bid_price: "99.98",
+      ask_price: "100.02",
+      bid_ask_timestamp: "2026-06-14T20:00:00Z",
       order_form_version: "7",
       ref_id: `AAPL-A1-${NOW}`
     });
-    expect(r).toMatchObject({ symbol: "AAPL", shares: 2.5, estimatedTotal: 250, type: "market", dryRun: true, live: false, refId: `AAPL-A1-${NOW}` });
+    // The native dollar body carries NO computed quantity/price — the broker derives the fill.
+    expect(w.body).not.toHaveProperty("quantity");
+    expect(w.body).not.toHaveProperty("price");
+    // The result still reports the informational share estimate for display.
+    expect(r).toMatchObject({ symbol: "AAPL", shares: 2.5, estimatedTotal: 250, type: "market", dollarBased: true, dryRun: true, live: false, refId: `AAPL-A1-${NOW}` });
   });
 
-  it("limit orders use gtc and the 2dp limit price", async () => {
+  it("a dollar-notional sell uses position_effect:close", async () => {
+    const { deps, calls } = makeDeps({ quote: { last_trade_price: "100.00", bid_price: "99.98", ask_price: "100.02", updated_at: "2026-06-14T20:00:00Z", instrument_id: "iid-123" } });
+    await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", amount: 50 }, deps);
+    expect(calls.writes[0].body).toMatchObject({ dollar_based_amount: { amount: "50.00", currency_code: "USD" }, position_effect: "close", side: "sell" });
+  });
+
+  it("the dollar body omits collar fields on a one-sided/dead book rather than sending 0/NaN", async () => {
+    const { deps, calls } = makeDeps({ quote: { last_trade_price: "100.00", bid_price: "0.00", ask_price: null, instrument_id: "iid-123" } });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+    const b = calls.writes[0].body;
+    expect(b).toMatchObject({ dollar_based_amount: { amount: "250.00", currency_code: "USD" }, market_hours: "regular_hours", position_effect: "open" });
+    expect(b).not.toHaveProperty("bid_price");
+    expect(b).not.toHaveProperty("ask_price");
+    expect(b).not.toHaveProperty("bid_ask_timestamp");
+    expect(r.dollarBased).toBe(true);
+  });
+
+  it("SHARE sizing keeps the quantity+price body (no dollar form), gfd market", async () => {
     const { deps, calls } = makeDeps();
-    await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", shares: 3, limitPrice: 95.5 }, deps);
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", shares: 2.5 }, deps);
+    expect(calls.writes[0].body).toMatchObject({ type: "market", time_in_force: "gfd", quantity: "2.5", price: "100.00", order_form_version: "7" });
+    expect(calls.writes[0].body).not.toHaveProperty("dollar_based_amount");
+    expect(r.dollarBased).toBe(false);
+  });
+
+  it("limit orders use gtc and the 2dp limit price (quantity body, never dollar)", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", shares: 3, limitPrice: 95.5 }, deps);
     expect(calls.writes[0].body).toMatchObject({ type: "limit", time_in_force: "gtc", price: "95.50", side: "sell", quantity: "3" });
+    expect(calls.writes[0].body).not.toHaveProperty("dollar_based_amount");
+    expect(r.dollarBased).toBe(false);
+  });
+
+  it("a dollar-notional LIMIT order stays on the quantity+price body (dollar form is market-only)", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250, limitPrice: 99 }, deps);
+    expect(calls.writes[0].body).toMatchObject({ type: "limit", quantity: "2.5", price: "99.00" });
+    expect(calls.writes[0].body).not.toHaveProperty("dollar_based_amount");
+    expect(r.dollarBased).toBe(false);
   });
 
   it("dry-run never queries the pending-order list and never logs a trade", async () => {

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -58,8 +58,14 @@ Current counts after the 2026-06-03 options/account-settings hardening pass:
   `x-robinhood-web-app-version`, `x-hyper-ex: enabled`, web `user-agent`, `origin`/`referer` —
   and (2) `order_form_version: 7` + a live bid/ask collar
   (`bid_price`/`ask_price`/`bid_ask_timestamp`) + `market_hours` + `position_effect: open`.
-  Fractional buys use `dollar_based_amount: {amount, currency_code}` (server computes shares);
-  whole-share/OTC buys use `price` + `quantity`. Full body shapes in `AGENTS.md`.
+  Dollar-notional MARKET orders on a fractional-tradable name use the NATIVE
+  `dollar_based_amount: {amount, currency_code}` body — the broker derives the fill quantity, and
+  NO `quantity`/`price` is sent (matching robinhood.com exactly; engine parity landed 2026-06-14,
+  `placeEquityOrder`, pinned by `equity-order.test.ts`). The collar (`bid_price`/`ask_price`/
+  `bid_ask_timestamp`) is taken from the same live quote so it is fresh — a stale collar is the one
+  thing the dollar path rejects on; a one-sided/dead book omits the collar fields rather than sending
+  0/NaN. Whole-share, any LIMIT order, and OTC all use `price` + `quantity` (no native dollar form).
+  Full body shapes in `AGENTS.md`.
 - **OTC names** (`otc_market_tier` non-empty, `fractional_tradability: "position_closing_only"`,
   e.g. RNECY) **reject `type: market`** — buy AND sell are both supported, but only as whole
   shares with a marketable **limit** at the marketable side (buy at the ask, sell at the bid;

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -66,6 +66,14 @@ Current counts after the 2026-06-03 options/account-settings hardening pass:
   thing the dollar path rejects on; a one-sided/dead book omits the collar fields rather than sending
   0/NaN. Whole-share, any LIMIT order, and OTC all use `price` + `quantity` (no native dollar form).
   Full body shapes in `AGENTS.md`.
+- **Session awareness (`markets/{mic}/hours/{date}/`, verified live).** The engine classifies the
+  CURRENT US-equity session from Robinhood's own hours endpoint — `is_open` + `opens_at`/`closes_at`
+  (regular) + `extended_opens_at`/`extended_closes_at` — so it is holiday- and half-day-aware (never a
+  hardcoded 9:30–16:00 clock; the ET-clock heuristic is the fallback only). Fractional dollar orders
+  stay `market_hours: "regular_hours"` (the only value RH accepts there), but `placeEquityOrder` now
+  returns the detected `session` and a `sessionWarning` when a fractional/market order is placed
+  off-session — it will QUEUE to the next regular session, not fill now. Pinned by
+  `equity-order.test.ts` (`computeMarketSession` classification + the queue warnings). Landed 2026-06-14.
 - **OTC names** (`otc_market_tier` non-empty, `fractional_tradability: "position_closing_only"`,
   e.g. RNECY) **reject `type: market`** — buy AND sell are both supported, but only as whole
   shares with a marketable **limit** at the marketable side (buy at the ask, sell at the bid;

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -24,6 +24,7 @@ import {
   planBrokerageRequest,
   planCryptoRequest,
   resolveLiveWriteGate,
+  riskIsWrite,
   selectRouteByQueryAndMethod,
   brokerageGetJson,
   brokerageGetAllResults,
@@ -80,6 +81,18 @@ function jsonResponse(value: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }]
   };
+}
+
+// Make the execution state of a WRITE tool UNMISSABLE. The operator runs live by default, so the
+// dangerous failure is a dry-run response that READS like a success — an agent (or human) sees an
+// order id / 201 / plan and assumes it's done. `executed` + a loud `executionStatus` are hoisted to
+// the TOP of every write response so "nothing was sent" can never be mistaken for "done". Reads never
+// call this. Zayd Khan // cold // www.zayd.wtf
+function writeStatus(result: object, opts: { dryRun: boolean; reason?: string }) {
+  const executionStatus = opts.dryRun
+    ? `⚠️ DRY RUN — NOT EXECUTED. Nothing was sent to Robinhood; no order was placed, changed, or cancelled.${opts.reason ? ` Reason: ${opts.reason}` : ""} To execute for real: pass liveWrite:true AND set ROBINHOOD_ALLOW_LIVE_WRITE=1 in the server's environment (both gates, every call).`
+    : `✅ LIVE — SENT to Robinhood. A 2xx alone is not proof: confirm the order in order history (evidence.confirmed).`;
+  return jsonResponse({ executed: !opts.dryRun, executionStatus, ...result });
 }
 
 function toolAnnotations(readOnly: boolean, risk: RiskLevel) {
@@ -663,7 +676,10 @@ server.registerTool(
       dryRun: effectiveDryRun
     });
     const result = await executeBrokerageRequest(plan, { body, dryRun: effectiveDryRun, fullBody });
-    return jsonResponse(gate.forcedDryRun ? { ...result, liveWriteBlocked: gate.reason } : result);
+    const m = method?.toUpperCase();
+    const isWrite = riskIsWrite(route.risk) || (m !== undefined && m !== "GET" && m !== "HEAD");
+    if (isWrite) return writeStatus(result as object, { dryRun: effectiveDryRun, reason: gate.forcedDryRun ? gate.reason : undefined });
+    return jsonResponse(result);
   }
 );
 
@@ -778,7 +794,10 @@ server.registerTool(
       dryRun: effectiveDryRun
     });
     const result = await executeCryptoRequest(plan, { body, dryRun: effectiveDryRun, fullBody });
-    return jsonResponse(gate.forcedDryRun ? { ...result, liveWriteBlocked: gate.reason } : result);
+    const m = method?.toUpperCase();
+    const isWrite = riskIsWrite(route.risk) || (m !== undefined && m !== "GET" && m !== "HEAD");
+    if (isWrite) return writeStatus(result as object, { dryRun: effectiveDryRun, reason: gate.forcedDryRun ? gate.reason : undefined });
+    return jsonResponse(result);
   }
 );
 
@@ -920,7 +939,7 @@ server.registerTool(
         liveWrite: resolveLiveFlag(liveWrite, live), force: Boolean(force)
       });
       const { result: _raw, ...summary } = r;
-      return jsonResponse(summary);
+      return writeStatus(summary, { dryRun: summary.dryRun });
     } catch (e: any) {
       return jsonResponse({ error: e.message });
     }
@@ -950,7 +969,7 @@ server.registerTool(
         liveWrite: resolveLiveFlag(liveWrite, live), force: Boolean(force)
       });
       const { result: _raw, ...summary } = r;
-      return jsonResponse(summary);
+      return writeStatus(summary, { dryRun: summary.dryRun });
     } catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );
@@ -974,7 +993,7 @@ server.registerTool(
     try {
       // Shared engine (cancelOrder in lib.ts) — same path as the CLI `cancel` command and `panic`.
       const r = await cancelOrder({ idOrUrl: order_id, kind, liveWrite: resolveLiveFlag(liveWrite, live) });
-      return jsonResponse(r);
+      return writeStatus(r, { dryRun: r.dryRun, reason: (r as any).gateReason });
     } catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );
@@ -1010,8 +1029,10 @@ server.registerTool(
     annotations: toolAnnotations(false, "destructive")
   },
   async ({ account_number, liveWrite, live }) => {
-    try { return jsonResponse(await panicCancelAll({ accountNumber: account_number, liveWrite: resolveLiveFlag(liveWrite, live) })); }
-    catch (e: any) { return jsonResponse({ error: e.message }); }
+    try {
+      const r = await panicCancelAll({ accountNumber: account_number, liveWrite: resolveLiveFlag(liveWrite, live) });
+      return writeStatus(r, { dryRun: r.dryRun });
+    } catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );
 
@@ -1211,7 +1232,7 @@ server.registerTool(
       url = "https://api.robinhood.com/accounts/{account_number}/sweep_enrollment_state/"; method = "POST"; body = { sweep_enrollment_action: "unenroll" };
     }
     const r = await gatedBrokerageWrite({ url, method, params, body, dryRun, liveWrite });
-    return jsonResponse(r.dryRun && r.reason ? { ...r, liveWriteBlocked: r.reason } : r);
+    return writeStatus(r, { dryRun: r.dryRun, reason: r.reason });
   }
 );
 
@@ -1248,7 +1269,7 @@ server.registerTool(
       if (!inst) throw new Error(`No instrument for ${symbol}.`);
       const body = { account_number, amount: { amount: Number(amount).toFixed(2), currency_code: "USD" }, frequency: frequency ?? "weekly", investment_asset: { asset_id: inst.id, asset_symbol: inst.symbol, asset_type: "equity" }, source_of_funds: "buying_power", start_date: start_date ?? new Date(Date.now() + 86400000).toISOString().slice(0, 10), ref_id: randomUUID() };
       const r = await gatedBrokerageWrite({ url: LIST, method: "POST", body, dryRun, liveWrite });
-      return jsonResponse(r.dryRun && r.reason ? { ...r, liveWriteBlocked: r.reason } : r);
+      return writeStatus(r, { dryRun: r.dryRun, reason: r.reason });
     }
     if (!id) throw new Error(`${action} needs a schedule id.`);
     let body: unknown;
@@ -1260,7 +1281,7 @@ server.registerTool(
       body = b;
     } else { body = { state: "deleted" }; } // end
     const r = await gatedBrokerageWrite({ url: ITEM, method: "PATCH", params: { "0": id }, body, dryRun, liveWrite });
-    return jsonResponse(r.dryRun && r.reason ? { ...r, liveWriteBlocked: r.reason } : r);
+    return writeStatus(r, { dryRun: r.dryRun, reason: r.reason });
   }
 );
 


### PR DESCRIPTION
## What

`placeEquityOrder` now posts the **exact body robinhood.com sends** for a `$X` dollar-notional **market** order on a **fractional-tradable** name:

```jsonc
{
  "type": "market", "side": "buy", "time_in_force": "gfd", "trigger": "immediate",
  "order_form_version": "7",
  "dollar_based_amount": { "amount": "5.00", "currency_code": "USD" },  // ← NOT a computed quantity
  "market_hours": "regular_hours",
  "position_effect": "open",                 // "close" on a sell
  "bid_price": "291.50", "ask_price": "291.78", "bid_ask_timestamp": "…"  // live collar
}
```

The broker derives the fill quantity from the dollar amount — no `quantity`/`price` is sent.

## Why

The engine previously computed shares from the dollar amount and sent a `quantity`+`price` body. That fills, but it isn't the native fractional path the web app uses — and `docs/undocumented-surface.md` **already claimed** the `dollar_based_amount` form, so the code had drifted from its own docs (the same class of doc-vs-code drift `AGENTS.md` calls out). This closes that gap.

## Scope / safety

- **Only** dollar-notional **market** orders on fractional-tradable names take the new body. Whole-share orders, **any limit order**, and **OTC** all keep the `quantity`+`price` body (no native dollar form) — unchanged.
- Collar (`bid_price`/`ask_price`/`bid_ask_timestamp`) comes from the **same fresh quote** the engine already fetches (a stale collar is the one thing the dollar path rejects on). A one-sided/dead book **omits** the collar fields rather than sending `0`/`NaN`.
- The double write-gate, dedup, `ref_id` idempotency, and post-send `verifyOrderEvidence` are all untouched.
- New result field `dollarBased` surfaced in CLI `buy`/`sell` JSON + human output.

## Tests

`equity-order.test.ts` extended — all **217** green, typecheck clean:
- native dollar body + full collar + `position_effect:open`, asserts **no** `quantity`/`price`
- dollar **sell** → `position_effect:close`
- degraded (one-sided/dead) book → collar fields omitted
- share sizing, plain limit, and **dollar+limit** all stay on the quantity body (`dollarBased:false`)

## Verification

Live dry-run against a real AAPL quote emits the dollar body with the live collar; human line now reads `DRY RUN market buy: AAPL $5.01 (dollar-based ≈ 0.017200 sh)`.

No route-map change, so no `dist/api-map/` regeneration needed.---

## Follow-up in this branch (per review request)

### MCP: unmissable dry-run vs live status
The operator runs live by default, so the dangerous failure is a dry-run response that *reads* like success. Every write tool now hoists two fields to the **top** of its response:

```jsonc
{ "executed": false,
  "executionStatus": "⚠️ DRY RUN — NOT EXECUTED. Nothing was sent to Robinhood... To execute for real: pass liveWrite:true AND set ROBINHOOD_ALLOW_LIVE_WRITE=1 (both gates, every call)." }
```
On a live send: `"executed": true` + `"✅ LIVE — SENT... confirm in order history (a 2xx alone is not proof)."`

Applied to `robinhood_buy`, `robinhood_sell`, `robinhood_cancel`, `robinhood_panic`, the `brokerage`/`crypto` executors (write verbs only — reads untouched, gated via `riskIsWrite`), and the `settings`/`recurring` writes. Verified over stdio: a dry-run `robinhood_buy` returns `executed:false` with the banner; `tools/list` still reports **50**.

### Doc-vs-code sweep
Ran a sweep for other mismatches. Findings:
- **Fixed:** three stale `40+ tools` hardcodes in `README.md` (actual: 50) → replaced with the project's defer-to-`tools/list` phrasing (AGENTS.md: never hardcode the count).
- **Verified correct (no change needed):** the double-gate precedence (`dryRun:true` always wins), OTC/fractional guards, DRIP GET/PATCH method-split, `order_form_version:7`, and `time_in_force` defaults all match code.---

## True market-session awareness (commit 3)

Replaces the hardcoded `market_hours` with real session detection from Robinhood's **own** hours endpoint (`markets/{mic}/hours/{date}/`) — `is_open` + regular `opens_at`/`closes_at` + `extended_opens_at`/`extended_closes_at`, so it's **holiday- and half-day-aware**, not a hardcoded 9:30–16:00 clock. An ET-clock heuristic is the fallback only; any detection failure is best-effort and never blocks a send.

- **Fractional dollar orders** stay `market_hours:"regular_hours"` (the only value RH accepts there) — but the result now carries the detected `session` and a `sessionWarning` when placed off-session: *it will QUEUE to the next regular session, not fill now.*
- **Whole-share market orders** off-session get the same queue warning (with a nudge to use a limit for extended hours).
- **Limit orders** get no warning (they can rest/execute extended).
- `session` + `sessionWarning` surfaced in CLI `buy`/`sell` and (via the shared summary) MCP.

New exports: `computeMarketSession`, `etClockSession`, `etDateString`, `MarketSession`. **+9 tests** (all four session classifications, non-trading-day, fallback, every warning branch). **Verified live**: a dry-run buy at ~01:30 ET returns `session: closed` and the queue warning. Suite now **226 green**.

This resolves the `market_hours` caveat flagged in the first review.