### PR TITLE
feat: watchlist add/remove/create (discovery/lists writes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,13 +305,13 @@ robinhood-cli options chain NVDA --expiration 2026-07-02 --type put --width 10 -
 ```
 
 ```text
-$ robinhood-cli options positions          # illustrative output (not real holdings)
+$ robinhood-cli options positions          # illustrative output — EXAMPLE DATA, not real holdings
 contract            acct   qty  entry  mark    value_usd  pl_usd    day_usd  return    delta
 ------------------  -----  ---  -----  ------  ---------  --------  -------  --------  -----
-DRAM $50 Call 6/18  …9919  1    $1.30  $18.65  $[redacted]   $[redacted]  $112.00  +1334.6%  0.93
-HPE $30 Call 9/18   …6346  1    $1.68  $19.00  $[redacted]   $[redacted]  $86.00   +1031.0%  0.88
+ACME $50 Call 6/18  …XXXX  1    $1.30  $1.95   $195.00    $65.00    $12.00   +50.0%   0.61
+EXMP $30 Call 9/18  …XXXX  1    $1.60  $2.10   $210.00    $50.00    $9.00    +31.3%   0.55
 ...
-TOTAL: value $[redacted] | unrealized $[redacted] | day $198.00
+TOTAL: value $405.00 | unrealized $115.00 | day $21.00
 ```
 
 Both are pure reads (no write gate). `--json` emits structured rows for piping into a spreadsheet or an agent.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node cli/dist/index.js --help
 | Surface | Current state |
 |---------|---------------|
 | API map | 300+ brokerage/account route entries (incl. instrument search + the `midlands/` sentiment layer) + the official Crypto routes, generated OpenAPI, endpoint Markdown, and curl templates. Every entry carries field-level response provenance (`verified`/`inferred`/`undocumented`, test-enforced). Trust the live count (`brokerage routes --json`), never a hardcoded number. |
-| CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep) and `recurring` (list/pause/resume/create/edit/end) — all writes double-gated — plus route planning and dry-run order bodies. |
+| CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep), `recurring` (list/pause/resume/create/edit/end), and `watchlist` (list/add/remove/create) — all writes double-gated — plus route planning and dry-run order bodies. |
 | MCP | The full agent-tool surface (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
 | Memory | `ball-knowledge.md` (market beliefs/themes/sources) + `trading-log.md` (execution + intent history) — the agent's cross-session brain. |
 | Research | A source-quality doctrine (X/Reddit pulse → news/`midlands` confirmer → institutional outlook → academic math, none gospel) + strategy deep-dives (Wheel, rolling, with quant appendices), institutional CMAs, tax-aware notes. |
@@ -80,7 +80,7 @@ The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill e
 - **Orders** — equity and options order history, status (single-order lookup with the instrument UUID resolved to a real ticker), placement, and cancellation — with pending-duplicate dedup and `ref_id` idempotency on every send.
 - **Portfolio P&L** — `portfolio` (aliases `pnl`/`snapshot`): one call → per-account day Δ + after-hours Δ + per-account buying power, drivers rolled up by underlying in **dollars** across all accounts, with a reconciliation line.
 - **Recipes** — `recipes "<intent>"`: free-text intent → the one CLI command (and MCP tool) that answers it.
-- **Watchlists** — list, add, remove.
+- **Watchlists** — list, add, remove, create (writes double-gated; the real endpoint is `discovery/lists/items/`, captured + verified live).
 - **Margin health** — `margin`: per-account answer to "am I borrowing, how much, at what rate, billed when" — amount borrowed in dollars, interest rate, next billing date, margin available, and buying power with margin; accounts without margin data degrade silently.
 - **Recurring investments** — first-class list, pause, resume, **create, edit, and end** (all double-gated; create/edit body shapes verified live).
 - **Account settings** — first-class `settings` group: DRIP (account-wide + per-stock), trade-on-expiration, PDT protection, stock lending, cash-sweep unenroll — double-gated, several verified live.
@@ -207,6 +207,8 @@ robinhood-cli options roll-plan --account <ACCOUNT_NUMBER> --symbol DRAM --type 
 robinhood-cli api-map options-contract-links --account <ACCOUNT_NUMBER> --symbol DRAM --expiration 2026-12-18 --type call --side buy --strike 80 --json
 robinhood-cli stock profile DRAM --account <ACCOUNT_NUMBER> --json
 robinhood-cli watchlist list                          # your custom watchlists + sizes
+robinhood-cli watchlist add "Homie index" NVDA AMAT   # add tickers (double-gated, dry-run by default)
+robinhood-cli watchlist create "Og handle fund"       # make a new list (double-gated)
 robinhood-cli brokerage routes --category orders      # browse mapped routes
 robinhood-cli brokerage plan "https://api.robinhood.com/accounts/{0}/" --param 0=ACCOUNT_ID --json
 ```
@@ -232,6 +234,7 @@ One line per question. All reads are live and free; the order/settings commands 
 | `buy` / `sell` / `cancel` / `order-status` | The order lifecycle — dollar or share sizing, dedup + `ref_id` idempotency, real-ticker status |
 | `buying-power [--account N]` | "What can I actually spend?" — the BP family, not the headline number |
 | `recurring list/pause/resume/create/edit/end` | "What's on autopilot, and change it" |
+| `watchlist list/add/remove/create` | "Show my custom lists, and edit them" — add/remove tickers (resolved by name) or make a new list (double-gated) |
 | `settings show/drip/expiration/pdt/lending/sweep` | "Read or toggle account settings" (double-gated) |
 | `history --days N` | "What actually executed?" — unified equity + options + crypto + transfers, newest first |
 | `quote <SYM...>` | Live last/bid/ask/day-change for any symbols |
@@ -521,6 +524,12 @@ robinhood-cli positions --account <ROTH_ACCOUNT_NUMBER>     # Roth IRA
 
 # Your custom watchlists and how many symbols each holds.
 robinhood-cli watchlist list
+
+# Edit watchlists — add/remove tickers (resolved by name) or create a list.
+# Writes are dry-run until BOTH gates are set, like every other write here.
+robinhood-cli watchlist create "AI memory"
+ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist add "AI memory" MU AMAT LRCX --live-write
+ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist remove "AI memory" LRCX --live-write
 
 # Option expirations for a symbol (handy before `options chain`).
 robinhood-cli options expirations MRVL

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@
 - [ ] **Doc contradictions to reconcile (found 2026-06-11, 9 items)**: iron-condor leg names differ
   between SKILL.md sections (catalog JSON ids are authoritative); naked-short-call leg id; after-hours
   options self-contradiction in SKILL.md; wash-sale strictness differs between rolling deep-dive and
-  tax doc; SKILL 38 vs TODO 37 tool count; account mask …7523 vs ••••2523; `?account=` vs
+  tax doc; SKILL 38 vs TODO 37 tool count; account-mask format inconsistent between two docs; `?account=` vs
   `?account_number=` in order-templates doc; PDT-lifted vs vestigial PDT toggles; "18 strategy
   workflows" vs 20 catalog ids.
 
@@ -198,13 +198,7 @@ verified, 40 inferred). That number is *not* a 219-item backlog — read it corr
 - [ ] Tax-loss harvesting helper (FRCB is $0.01, LWLG bleeding, UI underwater)
 
 ### Portfolio snapshot (Jun 3 live)
-| Account | Value |
-|---------|-------|
-| ••••6346 IRA Roth | $[redacted] (equity $[redacted] + options $[redacted]) |
-| ••••0497 far 9mo plus | $[redacted] (equity $[redacted] + options $[redacted], margin $[redacted]) |
-| ••••9919 near 3mo-roll | $[redacted] (equity $[redacted] + options $[redacted]) |
-| ••••9911 Agentic | $0 |
-| ••••2523 Agentic-long | $0 |
-| **TOTAL** | **$[redacted]** |
+_Redacted — real account tails and exact balances removed. Pull a live snapshot with `portfolio` /
+`accounts` when you need current numbers; don't commit real balances to the repo._
 
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,67 @@
 - [ ] Auto-journal nudge — after a fill, prompt a `review note` so film-study notes accumulate at the moment of the trade.
 - [ ] `exposure` — concentration by underlying/sector + portfolio-wide net Greeks.
 
+## Watchlist writes — add/remove/create — SHIPPED 2026-06-15
+
+The watchlist surface is now read **+ write**, wired across all three places behind the double gate.
+**Correction to the original assumption:** the write endpoint is **`discovery/lists/items/`**, NOT
+`midlands/lists/items/` — captured + verified live 2026-06-15 (the `midlands/lists/*` entries are
+unrelated read routes). Contract: `POST discovery/lists/items/` with a list-id-keyed batch body
+`{ "<list_id>": [ {object_id, object_type, operation: create|delete} ] }`; create = `POST
+discovery/lists/` (201); delete-list = `DELETE discovery/lists/{id}/` (204). Full write-up in
+`docs/undocumented-surface.md`.
+
+- [x] **Captured the write contract** (CDP network capture, then API-verified add/remove/create/delete).
+- [x] **Route map** — added `discovery/lists/items/` POST (`write-mutate`); create/delete-list entries
+  already present. Rebuilt + regenerated api-map markdown/openapi/curl.
+- [x] **Engine** (`cli/src/lib.ts`) — `resolveInstrumentId`, `resolveWatchlist`, `watchlistMutateItems`,
+  `createWatchlist`, `deleteWatchlist` — all through `gatedBrokerageWrite`. No logic in the front doors.
+- [x] **CLI** — `watchlist add|remove <list> <SYM...>`, `watchlist create <name>` (thin wrappers).
+- [x] **MCP** — `robinhood_watchlist_add|remove|create` (tool count 50 → 53).
+- [x] **Test** — `cli/test/watchlist-write.test.ts` (method + URL + body shape); `mcp-tool-count` bumped.
+- [x] **Live-verified** — created "Homie index" + "Og handle fund", batched adds, add→remove round-trip
+  (all 200/201, readbacks confirmed) + recipes added for the intent router.
+
+## Undocumented route-body audit (2026-06-14)
+
+Audit of `api-map/brokerage-routes.json`: **219 of 310 routes are `fieldsSource: "undocumented"`** (51
+verified, 40 inferred). That number is *not* a 219-item backlog — read it correctly:
+
+- **137 are `sensitive-read` GETs** (balances, PII, profile, portfolios). They are **usable today** — you
+  call them and read the response; the empty `fields` only means the *response shape* isn't catalogued.
+  Optional polish (backfill response fields for nicer typed output), **not** a capability blocker.
+- **50 are plain `read`** — same story, usable now.
+- **32 are write-tier** (`write-safe`/`write-mutate`/`write-or-sensitive`/`destructive`) — these are the
+  ones where a **missing request body = the capability can't be used** (the watchlist-items case). Of
+  those 32: ~12 are **already wired** (the engine builds the body even though `fields` is empty: `orders/`
+  + cancel, `options/orders/` + cancel, `nummus/orders/` crypto + cancel, account-wide DRIP,
+  `recurring_schedules`, `marketability`/`review` via `pretrade`); 5 are **already tracked** below in
+  "Live auth needed" (sweep, instrument DRIP, `settings/margin`, slip/stock-lending, options_settings).
+
+### Genuinely untracked write bodies to reverse-engineer (CDP capture → fields + method → rebuild)
+
+- [ ] **Whole-watchlist CRUD** — `POST discovery/lists/` (create a custom list), `DELETE/PATCH
+  discovery/lists/{id}/` (delete/rename). Both `destructive`, category `watchlists`, empty fields.
+  Natural companion to the items add/remove in the Watchlist-writes section above — capture them in the
+  same session.
+- [ ] **DRIP enrollment** — `corp_actions/drip/enrollment/{account_number}/` (`write-or-sensitive`,
+  empty fields). Distinct from the account-wide `drip/account_settings/` toggle that's already built;
+  capture the enroll/unenroll body.
+- [ ] **Sweep enroll (alt host)** — `bonfire .../sms/sweep/agree_and_enroll` (`write-mutate`). Same cash-
+  sweep capability already tracked via `accounts/{account}/sweep_enrollment_state/`; capture both bodies
+  when doing the sweep toggle so we know which host the web app actually uses.
+
+### Explicitly NOT building (so nobody burns time capturing them)
+
+- **Money-movement cluster** — `ach/transfers/`, `ach/relationships/` (+ `/unlink/`), `wire/transfers`,
+  `acats/`, `nimbus/v1/asset_transfers`, `crypto-transfers/*`. These move **real cash off-platform**;
+  out of scope for a reads+trades tool by default. Revisit ONLY on an explicit decision to add
+  deposit/withdrawal automation.
+- **Telemetry / cosmetics** — `goku/*` log events, `app-comms/receipt/seen/`, upsell/promo/tooltip/
+  onboarding surfaces. No operator value.
+- **Sensitive identity writes** — `identi .../user_info/agreements/v2/sign/`, `subscription_fees/`. High
+  blast radius, near-zero operator benefit; leave parked.
+
 ## Social / showcase layer (parked 2026-06-11 — v2, after core)
 
 - [ ] **Trade cards + success graphics framework**: HTML template framework that renders a trade

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
   the PDF). Build: list + filter by type/year + download-all-1099s. Tax-season one-shot.
 - [x] **`margin` health command** (BUILT 2026-06-11: all-account scan, money-object unwrap, plain-English borrow line; MCP robinhood_margin): `margin/{account_number}/investing_info/` live-verified on the api
   host — amount_borrowed, margin_interest_rate, next_billing_date, projected intraday BP. Surface in
-  `portfolio` too: an account borrowing on margin should say so (live: …0497 borrowing $[redacted] @ rate).
+  `portfolio` too: an account borrowing on margin should say so.
 - [ ] **phoenix.robinhood.com is TLS-walled** (handshake refused, like ceres futures) — the app-only
   unified-balances host. Don't chase it; the per-account composition already covers balances.
 - [ ] **Options per-position P&L endpoint still unknown** (web UI shows it) — needs a CDP capture pass

--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -7991,6 +7991,30 @@
     "source": "manual"
   },
   {
+    "url": "https://api.robinhood.com/discovery/lists/items/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "watchlists"
+    ],
+    "risk": "write-mutate",
+    "methods": [
+      "POST"
+    ],
+    "summary": "Add or remove items in custom watchlists. Body is an object keyed by list_id -> array of {object_id (instrument UUID, NOT ticker), object_type (instrument|currency_pair|option_strategy), operation (create=add | delete=remove)}. Batches multiple items and multiple lists in one call. Reversible (add/remove items; not destructive like deleting a list).",
+    "bodyKeys": [
+      "object_id",
+      "object_type",
+      "operation"
+    ],
+    "source": "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)",
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [],
+    "fieldsSource": "verified"
+  },
+  {
     "url": "https://api.robinhood.com/discovery/lists/{id}/",
     "host": "api.robinhood.com",
     "categories": [

--- a/api-map/curl/brokerage-route-templates.sh
+++ b/api-map/curl/brokerage-route-templates.sh
@@ -603,6 +603,9 @@
 # sensitive-read GET https://bonfire.robinhood.com/margin/{id}/investing_info/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/margin/{id}/investing_info/'
 
+# sensitive-read GET https://api.robinhood.com/margin/{account_number}/investing_info/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/margin/{account_number}/investing_info/'
+
 # sensitive-read GET https://bonfire.robinhood.com/margin/{id}/settings/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/margin/{id}/settings/'
 
@@ -837,6 +840,9 @@
 # sensitive-read GET https://api.robinhood.com/discovery/lists/?owner_type=custom
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/discovery/lists/?owner_type=custom'
 
+# write-mutate POST https://api.robinhood.com/discovery/lists/items/
+# curl -sS -X POST -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/discovery/lists/items/'
+
 # destructive PATCH https://api.robinhood.com/discovery/lists/{id}/
 # curl -sS -X PATCH -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/discovery/lists/{id}/'
 
@@ -926,5 +932,8 @@
 
 # sensitive-read GET https://api.robinhood.com/orders/{0}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/orders/{0}/'
+
+# sensitive-read GET https://api.robinhood.com/options/orders/{0}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/orders/{0}/'
 
 # Zayd Khan // cold // www.zayd.wtf

--- a/api-map/markdown/brokerage-routes.md
+++ b/api-map/markdown/brokerage-routes.md
@@ -4,8 +4,8 @@ Source: reverse-engineered routes plus sanitized authenticated Chrome/CDP captur
 
 Personal repo semantics: mapped routes can be executed live with caller-owned `ROBINHOOD_BROKERAGE_TOKEN` or `ROBINHOOD_COOKIE`. Pass `--dry-run` when you want a non-sending test plan.
 
-Current count: 308 route templates.
-Risk counts: destructive=9, read=86, sensitive-read=190, write-mutate=10, write-or-sensitive=7, write-safe=6.
+Current count: 311 route templates.
+Risk counts: destructive=9, read=86, sensitive-read=192, write-mutate=11, write-or-sensitive=7, write-safe=6.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -211,6 +211,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | GET | account | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/buying_power_hub_view` |
 | sensitive-read | GET | account, telemetry-config | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/eligibility` |
 | sensitive-read | GET | account | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/investing_info/` |
+| sensitive-read | GET | account, margin | api.robinhood.com | live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10). | `https://api.robinhood.com/margin/{account_number}/investing_info/` |
 | sensitive-read | GET | account | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/settings/` |
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/market_indices` |
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/onboarding/{id}/` |
@@ -289,6 +290,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | inferred | uncategorized | api.robinhood.com | community-seed | `https://api.robinhood.com/discovery/lists/user_items/` |
 | sensitive-read | inferred | uncategorized | api.robinhood.com | community-seed | `https://api.robinhood.com/discovery/lists/{0}/` |
 | sensitive-read | inferred | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/?owner_type=custom` |
+| write-mutate | POST | watchlists | api.robinhood.com | cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/) | `https://api.robinhood.com/discovery/lists/items/` |
 | destructive | PATCH,DELETE | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/{id}/` |
 | destructive | POST | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/` |
 | destructive | PATCH,DELETE | recurring | bonfire.robinhood.com | wire-writes 2026-05-29 | `https://bonfire.robinhood.com/recurring_schedules/{0}/` |
@@ -319,5 +321,6 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | read | GET | marketdata | api.robinhood.com | cdp-2026-06-04-injected-capture (observed; price historicals per symbol) | `https://api.robinhood.com/marketdata/historicals/{symbol}/` |
 | read | GET | options, marketdata | bonfire.robinhood.com | cdp-2026-06-04-injected-capture (observed; option strategy historical chart; strategy_code = {option_uuid}_S1) | `https://bonfire.robinhood.com/options/{strategy_code}/historical-chart/` |
 | sensitive-read | GET | orders | api.robinhood.com | self-extension 2026-06-09: single order status lookup by ID | `https://api.robinhood.com/orders/{0}/` |
+| sensitive-read | GET | options, orders | api.robinhood.com | self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order. | `https://api.robinhood.com/options/orders/{0}/` |
 
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-margin-7baccount-number-7d-investing-info.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-margin-7baccount-number-7d-investing-info.md
@@ -1,0 +1,17 @@
+# GET /margin/%7Baccount_number%7D/investing_info/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: account, margin
+Source: live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10).
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/margin/{account_number}/investing_info/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-7b0-7d.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-7b0-7d.md
@@ -1,0 +1,17 @@
+# GET /options/orders/%7B0%7D/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: options, orders
+Source: self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order.
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/orders/{0}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/post-api-robinhood-com-discovery-lists-items.md
+++ b/api-map/markdown/endpoints/post-api-robinhood-com-discovery-lists-items.md
@@ -1,0 +1,17 @@
+# POST /discovery/lists/items/
+
+Mutation: yes
+Risk: write-mutate
+
+Host: api.robinhood.com
+Categories: watchlists
+Source: cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/discovery/lists/items/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/robinhood-routes.md
+++ b/api-map/markdown/robinhood-routes.md
@@ -4,10 +4,10 @@ Source: official Robinhood Crypto Trading OpenAPI plus sanitized authenticated C
 
 Crypto operations are official Robinhood-published endpoints and should use Ed25519 signing. Brokerage/account operations are browser-backed route-map entries and use caller-owned brokerage token or browser cookie auth.
 
-Current count: 324 route entries.
+Current count: 327 route entries.
 Official Crypto route entries: 16.
-Brokerage/account route entries: 308.
-Risk counts: destructive=11, read=92, sensitive-read=196, write-mutate=12, write-or-sensitive=7, write-safe=6.
+Brokerage/account route entries: 311.
+Risk counts: destructive=11, read=92, sensitive-read=198, write-mutate=13, write-or-sensitive=7, write-safe=6.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -67,6 +67,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | yes | destructive | PATCH,DELETE | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/{id}/` |
 | no | sensitive-read | inferred |  | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/discovery/lists/default/` |
 | no | sensitive-read | inferred |  | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/discovery/lists/items/` |
+| yes | write-mutate | POST | watchlists | api.robinhood.com | cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/) | `https://api.robinhood.com/discovery/lists/items/` |
 | no | sensitive-read | inferred |  | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/discovery/lists/user_items/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/discovery/ratings/{id}/overview/` |
 | no | sensitive-read | GET | history-documents | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/dividends/` |
@@ -92,6 +93,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/instruments/{0}/splits/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/instruments/{id}/shorting/` |
 | no | read | GET | telemetry-config | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/kaizen/experiments/{id}/` |
+| no | sensitive-read | GET | account, margin | api.robinhood.com | live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10). | `https://api.robinhood.com/margin/{account_number}/investing_info/` |
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/margin/{account_number}/upgrade_restrictions` |
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/margin/{account_number}/upgrade_restrictions/` |
 | no | read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/margin/calls/` |
@@ -162,6 +164,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | yes | write-or-sensitive | PATCH | options, settings, account | api.robinhood.com | web-ui-capture-2026-06-03 (account/settings/investing toggle) | `https://api.robinhood.com/options/option_settings/{account_number}/` |
 | no | sensitive-read | GET | options, orders | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/options/orders/` |
 | yes | write-mutate | POST | account, options, trading | api.robinhood.com | self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders; supports legs[] for single/multi-leg. Double-gated. | `https://api.robinhood.com/options/orders/` |
+| no | sensitive-read | GET | options, orders | api.robinhood.com | self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order. | `https://api.robinhood.com/options/orders/{0}/` |
 | yes | destructive | POST | options, orders | api.robinhood.com | wire-writes 2026-05-29 | `https://api.robinhood.com/options/orders/{0}/cancel/` |
 | no | read | GET | options, trading | api.robinhood.com | cdp-2026-06-04-dram-option-order-flow (observed; collateral pre-check, order passed url-encoded in ?order={json}) | `https://api.robinhood.com/options/orders/collateral/` |
 | no | sensitive-read | inferred | account, options | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/options/positions/` |

--- a/api-map/openapi/robinhood-brokerage.openapi.json
+++ b/api-map/openapi/robinhood-brokerage.openapi.json
@@ -3885,6 +3885,37 @@
           "community-seed"
         ],
         "x-robinhood-seen-on": []
+      },
+      "post": {
+        "operationId": "brokerage_post_discovery_lists_items",
+        "summary": "Watchlists brokerage route",
+        "description": "Personal route map entry. Risk: write-mutate. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "watchlists"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "write-mutate",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/discovery/lists/items/"
+        ],
+        "x-robinhood-sources": [
+          "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200",
+          "the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)"
+        ],
+        "x-robinhood-seen-on": []
       }
     },
     "/discovery/lists/user_items/": {
@@ -6555,6 +6586,49 @@
           "stock-nvda-options",
           "stock-tsla"
         ]
+      }
+    },
+    "/margin/{account_number}/investing_info/": {
+      "get": {
+        "operationId": "brokerage_get_margin_account_number_investing_info",
+        "summary": "Account brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "account",
+          "margin"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/margin/{account_number}/investing_info/"
+        ],
+        "x-robinhood-sources": [
+          "live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10)."
+        ],
+        "x-robinhood-seen-on": []
       }
     },
     "/margin/{account_number}/upgrade_restrictions": {
@@ -10406,6 +10480,49 @@
         "x-robinhood-sources": [
           "self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders",
           "supports legs[] for single/multi-leg. Double-gated."
+        ],
+        "x-robinhood-seen-on": []
+      }
+    },
+    "/options/orders/{param_0}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_param_0",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "orders"
+        ],
+        "parameters": [
+          {
+            "name": "param_0",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder param_0. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/{0}/"
+        ],
+        "x-robinhood-sources": [
+          "self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order."
         ],
         "x-robinhood-seen-on": []
       }

--- a/api-map/openapi/robinhood-unified.openapi.json
+++ b/api-map/openapi/robinhood-unified.openapi.json
@@ -5823,6 +5823,38 @@
         ],
         "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"
+      },
+      "post": {
+        "operationId": "brokerage_post_discovery_lists_items",
+        "summary": "Watchlists brokerage route",
+        "description": "Personal route map entry. Risk: write-mutate. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "watchlists"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "write-mutate",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/discovery/lists/items/"
+        ],
+        "x-robinhood-sources": [
+          "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200",
+          "the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)"
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
       }
     },
     "/discovery/lists/user_items/": {
@@ -8543,6 +8575,50 @@
           "stock-nvda-options",
           "stock-tsla"
         ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/margin/{account_number}/investing_info/": {
+      "get": {
+        "operationId": "brokerage_get_margin_account_number_investing_info",
+        "summary": "Account brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "account",
+          "margin"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/margin/{account_number}/investing_info/"
+        ],
+        "x-robinhood-sources": [
+          "live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10)."
+        ],
+        "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"
       }
     },
@@ -12468,6 +12544,50 @@
         "x-robinhood-sources": [
           "self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders",
           "supports legs[] for single/multi-leg. Double-gated."
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/options/orders/{param_0}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_param_0",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "orders"
+        ],
+        "parameters": [
+          {
+            "name": "param_0",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder param_0. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/{0}/"
+        ],
+        "x-robinhood-sources": [
+          "self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order."
         ],
         "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"

--- a/api-map/recipes.json
+++ b/api-map/recipes.json
@@ -178,6 +178,45 @@
       "notes": "owner_type=custom is mandatory (handled internally)."
     },
     {
+      "id": "watchlist-add",
+      "intent": "Add tickers to a watchlist",
+      "triggers": [
+        "add to watchlist",
+        "add to my list",
+        "put on my watchlist"
+      ],
+      "command": "watchlist add <list> <SYM...> --live-write",
+      "mcpTool": "robinhood_watchlist_add",
+      "risk": "write-mutate",
+      "notes": "List resolved by name or id; tickers resolved to instrument UUIDs internally. Double-gated, dry-run by default."
+    },
+    {
+      "id": "watchlist-remove",
+      "intent": "Remove tickers from a watchlist",
+      "triggers": [
+        "remove from watchlist",
+        "take off my list",
+        "delete from watchlist"
+      ],
+      "command": "watchlist remove <list> <SYM...> --live-write",
+      "mcpTool": "robinhood_watchlist_remove",
+      "risk": "write-mutate",
+      "notes": "Same endpoint as add (operation=delete). Double-gated."
+    },
+    {
+      "id": "watchlist-create",
+      "intent": "Create a new watchlist",
+      "triggers": [
+        "make a watchlist",
+        "create a list",
+        "new watchlist"
+      ],
+      "command": "watchlist create <name> --live-write",
+      "mcpTool": "robinhood_watchlist_create",
+      "risk": "write-mutate",
+      "notes": "POST discovery/lists/ with display_name (+ optional icon emoji). Double-gated."
+    },
+    {
       "id": "accounts",
       "intent": "List all my accounts + capabilities",
       "triggers": [

--- a/api-map/robinhood-routes.json
+++ b/api-map/robinhood-routes.json
@@ -1502,6 +1502,30 @@
     "fieldsShape": "object"
   },
   {
+    "url": "https://api.robinhood.com/discovery/lists/items/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "watchlists"
+    ],
+    "risk": "write-mutate",
+    "methods": [
+      "POST"
+    ],
+    "summary": "Add or remove items in custom watchlists. Body is an object keyed by list_id -> array of {object_id (instrument UUID, NOT ticker), object_type (instrument|currency_pair|option_strategy), operation (create=add | delete=remove)}. Batches multiple items and multiple lists in one call. Reversible (add/remove items; not destructive like deleting a list).",
+    "bodyKeys": [
+      "object_id",
+      "object_type",
+      "operation"
+    ],
+    "source": "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)",
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [],
+    "fieldsSource": "verified"
+  },
+  {
     "url_template": "https://api.robinhood.com/discovery/lists/user_items/",
     "method": "GET",
     "risk": "sensitive-read",
@@ -1576,8 +1600,35 @@
       "instrument_id",
       "page_size"
     ],
-    "fields": [],
-    "fieldsSource": "undocumented"
+    "fields": [
+      "account",
+      "active_instrument_id",
+      "amount",
+      "cash_dividend_id",
+      "days_early",
+      "drip_enabled",
+      "ex_dividend_date",
+      "fee",
+      "fx_order_id",
+      "gross_amount",
+      "id",
+      "instrument",
+      "is_early_dividend",
+      "is_primary_account",
+      "nra_withholding",
+      "paid_at",
+      "payable_date",
+      "position",
+      "rate",
+      "record_date",
+      "related_adjustments",
+      "state",
+      "url",
+      "withholding"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list",
+    "notes": "live-verified 2026-06-11: full dividend history (102 records on test account). First-class `dividends` command candidate: income by symbol/year, upcoming payouts via payable_date, per-dividend drip_enabled."
   },
   {
     "url": "https://api.robinhood.com/documents/",
@@ -1606,8 +1657,27 @@
       "type",
       "type__in"
     ],
-    "fields": [],
-    "fieldsSource": "undocumented"
+    "fields": [
+      "account",
+      "created_at",
+      "date",
+      "download_url",
+      "filetype",
+      "id",
+      "insert_1_url",
+      "insert_2_url",
+      "insert_3_url",
+      "insert_4_url",
+      "insert_5_url",
+      "insert_6_url",
+      "is_from_rhs",
+      "type",
+      "updated_at",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list",
+    "notes": "live-verified 2026-06-11: cursor-paginated. type values seen: 1099, 1099_crypto, 1099r_roth, 5498_roth, account_statement, trade_confirm. download_url serves the PDF — first-class `documents` command candidate (tax-season: pull all 1099s in one shot)."
   },
   {
     "url": "https://api.robinhood.com/documents/edocs_v2/custodial/",
@@ -2433,6 +2503,35 @@
     ],
     "fieldsSource": "verified",
     "fieldsShape": "object"
+  },
+  {
+    "url": "https://api.robinhood.com/margin/{account_number}/investing_info/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "account",
+      "margin"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "fields": [
+      "amount_borrowed",
+      "buying_power_with_margin",
+      "eligible_for_tiered_rates",
+      "gold_interest_exemption_amount",
+      "interest_exemption_amount",
+      "margin_available",
+      "margin_interest_rate",
+      "margin_limit_withheld_due_to_volatility",
+      "margin_used_including_cash_held",
+      "next_billing_date",
+      "projected_intraday_buying_power",
+      "projected_intraday_margin_available"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "object",
+    "source": "live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10)."
   },
   {
     "url": "https://api.robinhood.com/margin/{account_number}/upgrade_restrictions",
@@ -4421,6 +4520,22 @@
       "ref_id",
       "override_day_trade_checks"
     ],
+    "fields": [],
+    "fieldsSource": "undocumented"
+  },
+  {
+    "url": "https://api.robinhood.com/options/orders/{0}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "orders"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order.",
+    "summary": "Get a single options order by ID (state, legs, fills, price, quantity)",
     "fields": [],
     "fieldsSource": "undocumented"
   },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -38,6 +38,8 @@ import {
   getMarginHealth,
   tryBrokerageGetJson,
   gatedBrokerageWrite,
+  watchlistMutateItems,
+  createWatchlist,
   logTrade,
   placeEquityOrder,
   getOrderStatus,
@@ -3490,7 +3492,7 @@ program
     if (pendingRolls.length) process.stdout.write(`\n⏳ ${pendingRolls.length} pending kosher roll(s) — run roll-ledger list\n`);
   });
 
-const watchlist = new Command("watchlist").description("Inspect your custom watchlists (read)");
+const watchlist = new Command("watchlist").description("Inspect (read) and edit (add/remove/create, double-gated) your custom watchlists");
 
 watchlist
   .command("list")
@@ -3519,6 +3521,49 @@ watchlist
       rows.map((row: any) => ({ name: row.name, items: Number.isFinite(row.items) ? row.items : "—", emoji: row.emoji, id: row.id })),
       ["name", "items", "emoji", "id"]
     );
+  });
+
+watchlist
+  .command("add <list> <symbols...>")
+  .description("Add tickers to a custom watchlist (by name or id). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (list: string, symbols: string[], opts: { dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await watchlistMutateItems({ list, symbols, operation: "create", dryRun: opts.dryRun, liveWrite: opts.liveWrite });
+    if (out.result.dryRun && out.result.reason) process.stderr.write(`${out.result.reason}\n`);
+    if (opts.json) { printJson({ list: out.list, operation: "add", items: out.items, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
+    process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} add ${out.items.map((i) => i.symbol).join(", ")} -> "${out.list.display_name}" (${out.list.id})\n`);
+    if (out.result.body) process.stdout.write(`${out.result.body}\n`);
+  });
+
+watchlist
+  .command("remove <list> <symbols...>")
+  .description("Remove tickers from a custom watchlist (by name or id). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (list: string, symbols: string[], opts: { dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await watchlistMutateItems({ list, symbols, operation: "delete", dryRun: opts.dryRun, liveWrite: opts.liveWrite });
+    if (out.result.dryRun && out.result.reason) process.stderr.write(`${out.result.reason}\n`);
+    if (opts.json) { printJson({ list: out.list, operation: "remove", items: out.items, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
+    process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} remove ${out.items.map((i) => i.symbol).join(", ")} <- "${out.list.display_name}" (${out.list.id})\n`);
+    if (out.result.body) process.stdout.write(`${out.result.body}\n`);
+  });
+
+watchlist
+  .command("create <name>")
+  .description("Create a new custom watchlist. Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .option("--emoji <emoji>", "icon emoji for the list")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (name: string, opts: { emoji?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await createWatchlist({ displayName: name, iconEmoji: opts.emoji, dryRun: opts.dryRun, liveWrite: opts.liveWrite });
+    if (out.result.dryRun && out.result.reason) process.stderr.write(`${out.result.reason}\n`);
+    if (opts.json) { printJson({ displayName: name, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
+    process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} create watchlist "${name}"${opts.emoji ? ` ${opts.emoji}` : ""}\n`);
+    if (out.result.body) process.stdout.write(`${out.result.body}\n`);
   });
 
 program.addCommand(watchlist);

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -2478,6 +2478,145 @@ export async function logTrade(entry: Record<string, unknown>) {
   } catch { /* best-effort */ }
 }
 
+// ───────────────────────── Watchlist writes (shared CLI + MCP) ─────────────────────────
+// Robinhood custom watchlists ("Lists") are USER-level, NOT account-scoped — one set of lists per
+// login, shown across every account. The write surface is discovery/lists/* (captured + verified live
+// 2026-06-14 — the REAL endpoint is discovery/lists/items/, NOT the midlands/lists/items/ the route map
+// once assumed):
+//   add/remove items : POST   discovery/lists/items/   body { "<list_id>": [ {object_id, object_type, operation} ] }
+//   create a list    : POST   discovery/lists/         body { display_name, icon_emoji? }  (201)
+//   delete a list    : DELETE discovery/lists/{id}/    (204)
+// object_id is the instrument UUID (resolved from a ticker via instruments/?symbol=), never the symbol.
+// operation: "create" = add, "delete" = remove. Both ride the same items endpoint. As with every write
+// here, these go through gatedBrokerageWrite — dry-run unless BOTH gates (liveWrite + env) are set.
+
+export const DISCOVERY_LISTS_URL = "https://api.robinhood.com/discovery/lists/";
+export const DISCOVERY_LISTS_ITEMS_URL = "https://api.robinhood.com/discovery/lists/items/";
+
+/** Resolve an equity ticker to its Robinhood instrument UUID (instruments/?symbol=). */
+export async function resolveInstrumentId(
+  symbol: string,
+  deps: { getJson?: typeof brokerageGetJson } = {}
+): Promise<string> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const sym = symbol.trim().toUpperCase();
+  const inst = (await getJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol: sym })).results?.[0];
+  if (!inst?.id) throw new Error(`Symbol ${sym} not found (instruments/?symbol= returned no match).`);
+  return inst.id as string;
+}
+
+export interface WatchlistRef {
+  id: string;
+  display_name: string;
+  allowed_object_types: string[];
+}
+
+/** Resolve a custom watchlist by id or (case-insensitive) display_name. Reads owner_type=custom only. */
+export async function resolveWatchlist(
+  nameOrId: string,
+  deps: { getJson?: typeof brokerageGetJson } = {}
+): Promise<WatchlistRef> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const data = await getJson(DISCOVERY_LISTS_URL, {}, { owner_type: "custom" });
+  const lists: any[] = Array.isArray(data?.results) ? data.results : [];
+  const q = nameOrId.trim();
+  const match =
+    lists.find((l) => l.id === q) ??
+    lists.find((l) => String(l.display_name ?? "").toLowerCase() === q.toLowerCase());
+  if (!match) {
+    const names = lists.map((l) => l.display_name).filter(Boolean).join(", ") || "(none)";
+    throw new Error(`No custom watchlist matches "${nameOrId}". Existing custom lists: ${names}.`);
+  }
+  return { id: match.id, display_name: match.display_name, allowed_object_types: match.allowed_object_types ?? [] };
+}
+
+export interface WatchlistMutateInput {
+  /** List name or id. */
+  list: string;
+  symbols: string[];
+  /** "create" = add, "delete" = remove. */
+  operation: "create" | "delete";
+  /** Robinhood object type; defaults to "instrument" (equities). */
+  objectType?: string;
+  dryRun?: boolean;
+  liveWrite?: boolean;
+}
+
+export interface WatchlistMutateDeps {
+  getJson?: typeof brokerageGetJson;
+  write?: typeof gatedBrokerageWrite;
+  resolveInstrument?: (symbol: string) => Promise<string>;
+}
+
+/**
+ * Add or remove tickers in a custom watchlist. Resolves the list (by name/id) and each ticker (to an
+ * instrument UUID), builds the list-keyed batch body, and sends it through the double-gated write path.
+ */
+export async function watchlistMutateItems(input: WatchlistMutateInput, deps: WatchlistMutateDeps = {}) {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const write = deps.write ?? gatedBrokerageWrite;
+  const objectType = input.objectType ?? "instrument";
+  const resolveInstrument = deps.resolveInstrument ?? ((s: string) => resolveInstrumentId(s, { getJson }));
+  const symbols = input.symbols.map((s) => s.trim().toUpperCase()).filter(Boolean);
+  if (symbols.length === 0) throw new Error("No symbols given.");
+  const wl = await resolveWatchlist(input.list, { getJson });
+
+  const resolved: { symbol: string; object_id: string }[] = [];
+  for (const sym of symbols) {
+    const object_id = objectType === "instrument" ? await resolveInstrument(sym) : sym;
+    resolved.push({ symbol: sym, object_id });
+  }
+  const body = {
+    [wl.id]: resolved.map((r) => ({ object_id: r.object_id, object_type: objectType, operation: input.operation }))
+  };
+  const verb = input.operation === "create" ? "add" : "remove";
+  const result = await write({
+    url: DISCOVERY_LISTS_ITEMS_URL,
+    method: "POST",
+    body,
+    dryRun: input.dryRun,
+    liveWrite: input.liveWrite,
+    logContext: `watchlist ${verb}: ${symbols.join(",")} ${verb === "add" ? "->" : "<-"} ${wl.display_name}`
+  });
+  return { list: wl, operation: input.operation, items: resolved, body, result };
+}
+
+/** Create a new custom watchlist (POST discovery/lists/). Double-gated. */
+export async function createWatchlist(
+  input: { displayName: string; iconEmoji?: string; dryRun?: boolean; liveWrite?: boolean },
+  deps: { write?: typeof gatedBrokerageWrite } = {}
+) {
+  const write = deps.write ?? gatedBrokerageWrite;
+  const body: Record<string, unknown> = { display_name: input.displayName };
+  if (input.iconEmoji) body.icon_emoji = input.iconEmoji;
+  const result = await write({
+    url: DISCOVERY_LISTS_URL,
+    method: "POST",
+    body,
+    dryRun: input.dryRun,
+    liveWrite: input.liveWrite,
+    logContext: `watchlist create: ${input.displayName}`
+  });
+  return { displayName: input.displayName, body, result };
+}
+
+/** Delete a custom watchlist by id (DELETE discovery/lists/{id}/). Double-gated; irreversible. */
+export async function deleteWatchlist(
+  input: { id: string; dryRun?: boolean; liveWrite?: boolean },
+  deps: { write?: typeof gatedBrokerageWrite } = {}
+) {
+  const write = deps.write ?? gatedBrokerageWrite;
+  const result = await write({
+    url: "https://api.robinhood.com/discovery/lists/{id}/",
+    method: "DELETE",
+    params: { id: input.id },
+    dryRun: input.dryRun,
+    liveWrite: input.liveWrite,
+    logContext: `watchlist delete: ${input.id}`
+  });
+  return { id: input.id, result };
+}
+
 // ───────────────────────── Equity order engine (shared CLI + MCP) ─────────────────────────
 // The order-construction path is the dangerous one to duplicate (alignment invariant): the CLI
 // `buy`/`sell` commands and the MCP `robinhood_buy`/`robinhood_sell` tools both call

--- a/cli/test/dividends-documents-margin.test.ts
+++ b/cli/test/dividends-documents-margin.test.ts
@@ -237,7 +237,7 @@ describe("listDocuments — prefix type filter, tax-year filter, account filter"
   it("account filter is exact; records expose accountLast4 + downloadUrl; newest first", async () => {
     const r = await listDocuments({ accountNumber: "222222222" }, deps);
     expect(r.count).toBe(1);
-    expect(r.documents[0]).toMatchObject({ id: "d3", accountLast4: "6346", downloadUrl: "u3" });
+    expect(r.documents[0]).toMatchObject({ id: "d3", accountLast4: "2222", downloadUrl: "u3" });
     const all = await listDocuments({}, deps);
     expect(all.documents[0].id).toBe("d1");  // 2026-02-11 sorts first
   });
@@ -292,7 +292,7 @@ describe("getMarginHealth — multi-account scan with silent per-account degrada
   it("a 404 account degrades SILENTLY into skipped — the other accounts still report", async () => {
     const r = await getMarginHealth(undefined, deps);
     expect(r.accounts).toHaveLength(2);
-    expect(r.skipped).toEqual(["…6346"]);
+    expect(r.skipped).toEqual(["…2222"]);
     expect(r.scanned).toHaveLength(3);
     expect(r.warnings).toEqual([]);
   });

--- a/cli/test/mcp-tool-count.test.ts
+++ b/cli/test/mcp-tool-count.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Tool-count guard. The MCP server's tool count is referenced by a hard number in SKILL.md,
+// AGENTS.md, and README — and it has rotted before (docs said 38 / 40+ / 48 while the source
+// registered 50; see claims-audit CNT-1/2/6). This test forces anyone who adds or removes a
+// tool to CONSCIOUSLY bump the expected count here, which is the reminder to also fix the docs.
+// It is deterministic and offline: it parses mcp/src/server.ts source, no server boot, no network.
+
+const EXPECTED_TOOL_COUNT = 53;
+const FAIL_MSG =
+  "tool count changed — update SKILL.md/AGENTS.md/README tool-count references and this test.";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const serverSrc = readFileSync(resolve(here, "../../mcp/src/server.ts"), "utf8");
+
+describe("MCP tool-count guard", () => {
+  it(`registers exactly ${EXPECTED_TOOL_COUNT} tools via registerTool`, () => {
+    const registerCalls = serverSrc.match(/\bregisterTool\s*\(/g) ?? [];
+    expect(registerCalls.length, FAIL_MSG).toBe(EXPECTED_TOOL_COUNT);
+  });
+
+  it(`declares exactly ${EXPECTED_TOOL_COUNT} distinct robinhood_* tool names`, () => {
+    const names = new Set(
+      [...serverSrc.matchAll(/"(robinhood_[a-z0-9_]+)"/g)].map((m) => m[1])
+    );
+    expect(names.size, FAIL_MSG).toBe(EXPECTED_TOOL_COUNT);
+  });
+
+  it("the registerTool count matches the distinct-name count (no dupes, no untitled regs)", () => {
+    const registerCalls = (serverSrc.match(/\bregisterTool\s*\(/g) ?? []).length;
+    const names = new Set(
+      [...serverSrc.matchAll(/"(robinhood_[a-z0-9_]+)"/g)].map((m) => m[1])
+    ).size;
+    expect(registerCalls, FAIL_MSG).toBe(names);
+  });
+});
+
+// Zayd Khan // cold // www.zayd.wtf

--- a/cli/test/watchlist-write.test.ts
+++ b/cli/test/watchlist-write.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  watchlistMutateItems,
+  createWatchlist,
+  resolveWatchlist,
+  DISCOVERY_LISTS_URL,
+  DISCOVERY_LISTS_ITEMS_URL
+} from "../src/lib.js";
+
+// Injected-deps, no live network. Pins the verified discovery/lists write contract (captured
+// 2026-06-14): items add/remove POST discovery/lists/items/ with a list-id-keyed batch body, and
+// create POST discovery/lists/. Asserts method + URL + body shape end-to-end through the engine.
+
+const LISTS_FIXTURE = {
+  results: [
+    { id: "LID-1", display_name: "Homie index", allowed_object_types: ["instrument"] },
+    { id: "LID-2", display_name: "Uranium", allowed_object_types: ["instrument"] }
+  ]
+};
+
+function fakeGetJson() {
+  return async (url: string) => {
+    if (url.includes("/discovery/lists/")) return LISTS_FIXTURE;
+    throw new Error(`unexpected getJson url: ${url}`);
+  };
+}
+
+describe("watchlist writes — discovery/lists contract", () => {
+  it("resolveWatchlist matches by case-insensitive display_name", async () => {
+    const wl = await resolveWatchlist("homie INDEX", { getJson: fakeGetJson() as any });
+    expect(wl.id).toBe("LID-1");
+    expect(wl.display_name).toBe("Homie index");
+  });
+
+  it("resolveWatchlist matches by id and throws on no match", async () => {
+    const wl = await resolveWatchlist("LID-2", { getJson: fakeGetJson() as any });
+    expect(wl.display_name).toBe("Uranium");
+    await expect(resolveWatchlist("nope", { getJson: fakeGetJson() as any })).rejects.toThrow(/No custom watchlist/);
+  });
+
+  it("ADD builds a list-keyed batch body with operation=create against discovery/lists/items/", async () => {
+    let captured: any;
+    const out = await watchlistMutateItems(
+      { list: "Homie index", symbols: ["googl", "msft"], operation: "create", dryRun: true },
+      {
+        getJson: fakeGetJson() as any,
+        resolveInstrument: async (s: string) => `uuid-${s.toUpperCase()}`,
+        write: async (opts: any) => { captured = opts; return { status: 200, dryRun: true }; }
+      }
+    );
+    expect(captured.method).toBe("POST");
+    expect(captured.url).toBe(DISCOVERY_LISTS_ITEMS_URL);
+    expect(captured.body).toEqual({
+      "LID-1": [
+        { object_id: "uuid-GOOGL", object_type: "instrument", operation: "create" },
+        { object_id: "uuid-MSFT", object_type: "instrument", operation: "create" }
+      ]
+    });
+    expect(out.items).toEqual([
+      { symbol: "GOOGL", object_id: "uuid-GOOGL" },
+      { symbol: "MSFT", object_id: "uuid-MSFT" }
+    ]);
+  });
+
+  it("REMOVE uses operation=delete on the same endpoint", async () => {
+    let captured: any;
+    await watchlistMutateItems(
+      { list: "LID-1", symbols: ["AAPL"], operation: "delete", dryRun: true },
+      {
+        getJson: fakeGetJson() as any,
+        resolveInstrument: async () => "uuid-AAPL",
+        write: async (opts: any) => { captured = opts; return { status: 200, dryRun: true }; }
+      }
+    );
+    expect(captured.body).toEqual({ "LID-1": [{ object_id: "uuid-AAPL", object_type: "instrument", operation: "delete" }] });
+  });
+
+  it("ADD rejects when no symbols are given", async () => {
+    await expect(
+      watchlistMutateItems(
+        { list: "Homie index", symbols: [], operation: "create", dryRun: true },
+        { getJson: fakeGetJson() as any, resolveInstrument: async () => "x", write: async () => ({ status: 200, dryRun: true }) }
+      )
+    ).rejects.toThrow(/No symbols/);
+  });
+
+  it("CREATE posts display_name (+ optional emoji) to discovery/lists/", async () => {
+    let captured: any;
+    await createWatchlist(
+      { displayName: "Og handle fund", iconEmoji: "🛰️", dryRun: true },
+      { write: async (opts: any) => { captured = opts; return { status: 201, dryRun: true }; } }
+    );
+    expect(captured.method).toBe("POST");
+    expect(captured.url).toBe(DISCOVERY_LISTS_URL);
+    expect(captured.body).toEqual({ display_name: "Og handle fund", icon_emoji: "🛰️" });
+  });
+});
+
+// Zayd Khan // cold // www.zayd.wtf

--- a/docs/index-options-1256-conclusion-2026-06-04.md
+++ b/docs/index-options-1256-conclusion-2026-06-04.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-04
 **Method:** read-only / dry-run only. `brokerage search`, authed GET via `scripts/rh-get.mjs`. No `--live-write`, no `ROBINHOOD_ALLOW_LIVE_WRITE`, no orders placed.
-**Account context used for chain reads:** `111111111` (individual/cash).
+**Account context used for chain reads:** `{account_number}` (individual/cash).
 
 ---
 
@@ -58,7 +58,7 @@ The equity `instruments/` table has **no row** for any index — consistent with
 This is the decisive endpoint:
 
 ```
-GET options/chains/?account_number=111111111&underlying_symbol=SPX
+GET options/chains/?account_number={account_number}&underlying_symbol=SPX
   → SPX  (id a9f69c4e-9393-4554-9849-271f0297e70b)  can_open_position=true
   → SPXW (id 7a7fa2b1-b65e-4c75-a0b3-7f62749bee0a)  can_open_position=true
 GET ...underlying_symbol=XSP → XSP (bf82fd28-...) can_open_position=true
@@ -132,7 +132,7 @@ Corrected position:
 
 ### Caveats / open items (not blockers to the core finding)
 
-1. **Account entitlement.** Chain reads returned `can_open_position: true` for account `111111111`, but actually opening index-option positions may require an options-trading approval tier / index-options entitlement. Not order-tested (read/dry-run only by instruction). Verify entitlement before assuming executability.
+1. **Account entitlement.** Chain reads returned `can_open_position: true` for account `{account_number}`, but actually opening index-option positions may require an options-trading approval tier / index-options entitlement. Not order-tested (read/dry-run only by instruction). Verify entitlement before assuming executability.
 2. **No explicit settlement/exercise-style field** is returned by RH's option-instrument payload; cash-settled/European is inferred from `underlying_type=index` + empty `underlying_instruments` (the standard CBOE structure for these products). A live order ticket or a placed-then-cancelled dry-run would corroborate, but was out of scope here.
 3. **Min-tick differs** from equity options: SPX uses `below_tick 0.05 / above_tick 0.10, cutoff 3.00` (vs SPY's 0.01/0.01/0.00). Any future order math must read the chain's `min_ticks` (the repo already warns about per-chain ticks).
 
@@ -158,7 +158,7 @@ node cli/dist/index.js brokerage search "SPX" --json    # → ETFs only
 node scripts/rh-get.mjs "https://api.robinhood.com/instruments/?symbol=SPX"   # → results: []
 
 # the real index chains
-node scripts/rh-get.mjs "https://api.robinhood.com/options/chains/?account_number=111111111&underlying_symbol=SPX"
+node scripts/rh-get.mjs "https://api.robinhood.com/options/chains/?account_number={account_number}&underlying_symbol=SPX"
 node scripts/rh-get.mjs "https://api.robinhood.com/options/chains/a9f69c4e-9393-4554-9849-271f0297e70b/"   # underlying_instruments: []
 node scripts/rh-get.mjs "https://api.robinhood.com/options/instruments/?chain_id=a9f69c4e-9393-4554-9849-271f0297e70b&expiration_dates=2026-06-18&state=active&type=call"  # underlying_type: index
 node scripts/rh-get.mjs "https://api.robinhood.com/marketdata/options/?ids=89a6f0e5-95f1-4f96-bc88-4c7f7cd25d4f"  # live mark/bid/ask/OI

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -91,6 +91,29 @@ Current counts after the 2026-06-03 options/account-settings hardening pass:
 - Reference impl: `cli/src/index.ts` `brokerage buy` / `brokerage search`, `scripts/equity-buy.mjs`,
   `scripts/rh-get.mjs`. Receipts (account numbers + order ids) stay in gitignored `info/`.
 
+## 2026-06-15 — Watchlist write surface (`discovery/lists/items/`)
+
+Captured live to wire `watchlist add/remove/create` across CLI + MCP. **Corrects a prior assumption**:
+the write endpoint is `discovery/lists/items/`, *not* `midlands/lists/items/` (the `midlands/lists/*`
+entries are unrelated read routes).
+
+1. **Discovery source.** CDP network capture on `robinhood.com` (Add-to-Lists modal → Save), then
+   independently API-verified each verb with the session bearer.
+2. **Request method + body shape.**
+   - Add/remove items — `POST https://api.robinhood.com/discovery/lists/items/`, body keyed by list id:
+     `{ "<list_id>": [ { "object_id": "<instrument_uuid>", "object_type": "instrument", "operation": "create" | "delete" } ] }`
+     (`create` = add, `delete` = remove; batches many items / many lists in one call). `object_id` is the
+     instrument UUID (resolve via `instruments/?symbol=`), never the ticker. `object_type` mirrors the
+     list's `allowed_object_types` (`instrument` for equities, `currency_pair`/`option_strategy` otherwise).
+   - Create list — `POST https://api.robinhood.com/discovery/lists/`, body `{ "display_name": "...", "icon_emoji"?: "..." }` → 201 (server defaults emoji 💡 + the standard equity `allowed_object_types`).
+   - Delete list — `DELETE https://api.robinhood.com/discovery/lists/{id}/` → 204.
+3. **Auth/session.** Web-session bearer (`Authorization: Bearer …`) + the standard web headers (origin/referer/`x-robinhood-web-app-version`). Same auth as every other brokerage write.
+4. **Response shape.** Items POST echoes the request body (200). Create returns the full list object (id, display_name, owner UUID, allowed_object_types, item_count). Lists are **user-level, not account-scoped** — no `account_number` anywhere.
+5. **Rate-limit behavior.** None observed across the capture + verification writes.
+6. **Risk classification.** `discovery/lists/items/` POST = `write-mutate` (reversible add/remove);
+   `discovery/lists/` POST + `discovery/lists/{id}/` PATCH/DELETE = `destructive`. All double-gated; safe
+   for `brokerage execute` only behind both write gates. Wired as first-class `watchlist add/remove/create`.
+
 When a new undocumented route is discovered, record:
 
 1. Discovery source.

--- a/knowledge/accounts.md
+++ b/knowledge/accounts.md
@@ -60,9 +60,9 @@ Almost every Robinhood surface is account-scoped, and the bare endpoints + web U
 
 The headline balance is a mirage. On a **margin account, `cash` can be negative — that is the
 margin loan**, `equity` is net liquidation value, and the spendable figure is a small
-buying-power number that splits by purpose. Live example (2026-06-04, account …0497): equity
-≈ $[redacted], market value ≈ $[redacted], `cash` ≈ **$[redacted]** (margin debit), actual `buying_power` ≈
-**$[redacted]**.
+buying-power number that splits by purpose. On a margin account `equity` is the net liquidation
+value, `cash` can be **negative** (the margin loan), and the actual `buying_power` is typically a
+small fraction of either — read it live with `portfolio` / `margin`; never infer it from the headline.
 
 Read the family before sizing any order:
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -43,6 +43,8 @@ import {
   getMarginHealth,
   tryBrokerageGetJson,
   gatedBrokerageWrite,
+  watchlistMutateItems,
+  createWatchlist,
   placeEquityOrder,
   getOrderStatus,
   extractOrderId,
@@ -1333,6 +1335,78 @@ server.registerTool(
     annotations: toolAnnotations(true, "read")
   },
   async () => jsonResponse(await brokerageGetJson("https://api.robinhood.com/discovery/lists/?owner_type=custom", {}, { owner_type: "custom" }))
+);
+
+server.registerTool(
+  "robinhood_watchlist_add",
+  {
+    title: "Robinhood Watchlist — Add",
+    description: "Add tickers to a custom watchlist (resolved by name or id). Watchlists are user-level, not account-scoped. Reads resolve the list + each symbol's instrument UUID; the write is dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      list: z.string(),
+      symbols: z.array(z.string()).min(1),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ list, symbols, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await watchlistMutateItems({ list, symbols, operation: "create", dryRun, liveWrite });
+    return writeStatus(
+      { list: out.list, operation: "add", items: out.items, status: out.result.status, body: out.result.body },
+      { dryRun: out.result.dryRun, reason: out.result.reason }
+    );
+  }
+);
+
+server.registerTool(
+  "robinhood_watchlist_remove",
+  {
+    title: "Robinhood Watchlist — Remove",
+    description: "Remove tickers from a custom watchlist (resolved by name or id). Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      list: z.string(),
+      symbols: z.array(z.string()).min(1),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ list, symbols, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await watchlistMutateItems({ list, symbols, operation: "delete", dryRun, liveWrite });
+    return writeStatus(
+      { list: out.list, operation: "remove", items: out.items, status: out.result.status, body: out.result.body },
+      { dryRun: out.result.dryRun, reason: out.result.reason }
+    );
+  }
+);
+
+server.registerTool(
+  "robinhood_watchlist_create",
+  {
+    title: "Robinhood Watchlist — Create",
+    description: "Create a new custom watchlist (display_name, optional icon emoji). Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      name: z.string(),
+      emoji: z.string().optional(),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ name, emoji, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await createWatchlist({ displayName: name, iconEmoji: emoji, dryRun, liveWrite });
+    return writeStatus(
+      { displayName: name, status: out.result.status, body: out.result.body },
+      { dryRun: out.result.dryRun, reason: out.result.reason }
+    );
+  }
 );
 
 server.registerTool(

--- a/scripts/equity-buy.mjs
+++ b/scripts/equity-buy.mjs
@@ -11,10 +11,10 @@
 //
 // Usage:
 //   node scripts/equity-buy.mjs --preflight
-//   node scripts/equity-buy.mjs --account 222222222 --symbol ARKG --dollars 5 [--live]
-//   node scripts/equity-buy.mjs --accounts 111111111,222222222,333333333 --symbol ARKG --dollars 5 [--live]
-//   node scripts/equity-buy.mjs --account 222222222 --all-positions --dollars 3 [--live]
-//   node scripts/equity-buy.mjs --account 222222222 --symbol RNECY --shares 1 [--live]   (OTC -> auto limit)
+//   node scripts/equity-buy.mjs --account <ACCOUNT_NUMBER> --symbol ARKG --dollars 5 [--live]
+//   node scripts/equity-buy.mjs --accounts <ACCOUNT_NUMBER>,<ACCOUNT_NUMBER>,<ACCOUNT_NUMBER> --symbol ARKG --dollars 5 [--live]
+//   node scripts/equity-buy.mjs --account <ACCOUNT_NUMBER> --all-positions --dollars 3 [--live]
+//   node scripts/equity-buy.mjs --account <ACCOUNT_NUMBER> --symbol RNECY --shares 1 [--live]   (OTC -> auto limit)
 //
 // Auth: ROBINHOOD_BROKERAGE_TOKEN (and optional ROBINHOOD_COOKIE / ROBINHOOD_CSRF)
 // from the repo .env. Versions/UA overridable via env (see WEB_HEADERS).

--- a/scripts/validate-strategies.mjs
+++ b/scripts/validate-strategies.mjs
@@ -3,7 +3,7 @@
 // options/orders/ endpoint: place a far-from-/valid limit (GTC) → confirm 201 + echoed legs →
 // cancel immediately. Market closed + instant cancel = nothing fills. Proves the order bodies for
 // a wide strategy set across multiple expirations. Read/preview spirit; everything is cancelled.
-//   node scripts/validate-strategies.mjs [SYMBOL=AAPL] [ACCOUNT=333333333]
+//   node scripts/validate-strategies.mjs [SYMBOL=AAPL] [ACCOUNT=<ACCOUNT_NUMBER>]
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
 (function(){const p=join(REPO,".env");if(!existsSync(p))return;for(const l of readFileSync(p,"utf8").split("\n")){const t=l.trim();if(!t||t.startsWith("#"))continue;const e=t.indexOf("=");if(e<0)continue;const k=t.slice(0,e).trim();let v=t.slice(e+1).trim();if((v.startsWith('"')&&v.endsWith('"'))||(v.startsWith("'")&&v.endsWith("'")))v=v.slice(1,-1);if(k&&process.env[k]===undefined)process.env[k]=v;}})();
 const H=()=>({accept:"application/json","content-type":"application/json","user-agent":process.env.ROBINHOOD_USER_AGENT??"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",origin:"https://robinhood.com",referer:"https://robinhood.com/","x-robinhood-api-version":"1.431.4","x-robinhood-web-app-version":process.env.ROBINHOOD_WEB_APP_VERSION??"2026.24.3589+55c48b8f7a1c","x-hyper-ex":"enabled",authorization:"Bearer "+process.env.ROBINHOOD_BROKERAGE_TOKEN});
-const SYM=(process.argv[2]||"AAPL").toUpperCase(); const ACCT=process.argv[3]||"333333333";
+const SYM=(process.argv[2]||"AAPL").toUpperCase(); const ACCT=process.argv[3]||"";
 const api=async(u,o={})=>{const r=await fetch(u,o);const t=await r.text();let b=null;try{b=t?JSON.parse(t):null}catch{b=t}return{status:r.status,body:b}};
 const oUrl=id=>`https://api.robinhood.com/options/instruments/${id}/`;
 const log=(...a)=>process.stderr.write(a.join(" ")+"\n");


### PR DESCRIPTION
## What

Makes custom watchlists **editable**, not just readable — `add` / `remove` tickers and `create` lists, wired across the route map, engine, CLI, and MCP behind the existing double write-gate.

## The contract (captured + verified live)

The real write endpoint is **`POST discovery/lists/items/`** — *not* `midlands/lists/items/` as the route map previously assumed. Body is a list-id-keyed batch:

```json
{ "<list_id>": [ { "object_id": "<instrument_uuid>", "object_type": "instrument", "operation": "create" } ] }
```

`operation`: `create` = add, `delete` = remove (same endpoint). Create list = `POST discovery/lists/` (201); delete list = `DELETE discovery/lists/{id}/` (204). Tickers resolve to instrument UUIDs via `instruments/?symbol=`; lists resolve by name or id. Watchlists are **user-level, not account-scoped**.

Discovery method: CDP network capture on the Add-to-Lists modal, then each verb independently API-verified. Full write-up in `docs/undocumented-surface.md`.

## Wiring (all three places + tests)

- **route-map**: `discovery/lists/items/` POST (`write-mutate`); rebuilt + regenerated openapi/markdown/curl artifacts (route count 310 → 311). Create/delete-list entries already existed.
- **engine** (`cli/src/lib.ts`): `resolveInstrumentId`, `resolveWatchlist`, `watchlistMutateItems`, `createWatchlist`, `deleteWatchlist` — all through `gatedBrokerageWrite`; front doors stay thin.
- **cli**: `watchlist add|remove <list> <SYM...>`, `watchlist create <name>` (dry-run by default; `--live-write` + `ROBINHOOD_ALLOW_LIVE_WRITE=1` to send).
- **mcp**: `robinhood_watchlist_add|remove|create` (tool count 50 → 53).
- **recipes**: add/remove/create intents for the router.
- **tests**: `watchlist-write.test.ts` (method + URL + body shape, injected deps); `mcp-tool-count` bumped to 53.

## Verification

- `pnpm … typecheck` clean, `pnpm … test` → **232 passing** (15 files).
- Live-verified against a real account: created two lists, batched adds, and an add→remove round-trip (all 200/201, readbacks confirmed).

## Notes for review

- `dist/api-map/` was regenerated (runtime reads dist).
- The regenerated openapi/markdown artifacts include minor catch-up drift from route-map changes that predated the last artifact regen — expected, since they were stale at base.
- Base is `feat/dollar-based-amount-parity`; retarget to `main` if preferred.