### PR TITLE
feat: watchlist items (read) + BP-aware basket buy (CLI + MCP parity)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ info/
 *.log
 *.tgz
 capture-extension/
+
+# local safety backups (never commit)
+_local-backups-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ website uses — not the official, walled "agent sandbox" (which is equity-only)
    manual login. (Details in §1.)
 
 4. **Two front doors** — the **CLI** (`cli/dist/index.js`, for humans/scripts) and the
-   **MCP server** (`mcp/dist/server.js`, 50 tools for agents incl. first-class parity tools — live truth is
+   **MCP server** (`mcp/dist/server.js`, the full first-class tool roster for agents — live truth is
    `tools/list`; reload a running server with `/reload-mcp` after pulling, or it advertises its old count). Both
    are thin wrappers over the engine — the order path (`placeEquityOrder`) and the wheel engine
    (`computeWheelState`) are literally the same functions on both surfaces.
@@ -458,11 +458,16 @@ encode the selected expiration, strike, side, or Builder legs. Resolve those fro
 
 ---
 
-## 8. Worked example — managing watchlists (create / rename / delete)
+## 8. Worked example — managing watchlists (create / rename / delete / item add+remove)
 
 Watchlists live under `discovery/lists/`. Every read AND the list endpoints need
-`owner_type=custom` as a discriminator. All three write verbs are proven live through
-the CLI (create 201, rename 200, delete 204).
+`owner_type=custom` as a discriminator. List create/rename/delete are proven live through
+the CLI (create 201, rename 200, delete 204), and **item add/remove are now mapped + tested**
+(verified 2026-06-14) via the first-class `watchlist add`/`remove`/`create` commands (double-gated;
+MCP `robinhood_watchlist_add`/`_remove`/`_create`), plus `watchlist items` (live read of a list's tickers +
+equity-buyable flag) and `watchlist buy` (BP-aware **basket buy**: $<amount> of every equity-buyable ticker,
+looping the shared `placeEquityOrder` engine per ticker; double-gated; MCP `robinhood_watchlist_items`/`_buy`).
+The raw `brokerage execute` recipes below still work, but prefer the first-class verbs for item edits.
 
 ```bash
 # List every watchlist (id + display_name). owner_type is REQUIRED.
@@ -500,8 +505,10 @@ Gotchas learned the hard way:
   too — it is not a CLI limitation. Every other list deletes cleanly.
 - **Method-aware routing** picks the right verb when a URL has several (GET vs POST on
   `discovery/lists/`, PATCH vs DELETE on `discovery/lists/{id}/`) — always pass `--method`.
-- Item add/remove/reorder (`discovery/lists/items/` POST) is **not yet mapped** — the
-  server returns `{"failed operations":""}` with no detail, so the exact body is unconfirmed.
+- Item **add/remove are mapped + tested** (verified 2026-06-14): `watchlist add`/`remove` POST a
+  list-id-keyed batch body to `discovery/lists/items/` —
+  `{"<list_id>":[{"object_id":"<uuid>","object_type":"instrument","operation":"create"|"delete"}]}` — and
+  resolve the target list by case-insensitive `display_name` or id. Item **reorder** (weight/sort) is still unmapped.
 
 ---
 
@@ -614,7 +621,7 @@ settings/permissions, never print the token value.
 claude mcp add robinhood-cli -s user -- node /absolute/path/to/robinhood-cli/mcp/dist/server.js
 ```
 
-Tools surface as `mcp__robinhood-cli__*` (50 tools incl. accounts/positions/portfolio/buy/sell/cancel/order-status/buying-power/wheel/options-holdings/options-inspect/settings/recurring/quote/history/watchlist/options-enumerate parity: route inspection, browser/account
+Tools surface as `mcp__robinhood-cli__*` (the full tool roster incl. accounts/positions/portfolio/buy/sell/cancel/order-status/buying-power/wheel/options-holdings/options-inspect/settings/recurring/quote/history/watchlist + the double-gated watchlist_add/remove/create/items/buy writes/options-enumerate parity: route inspection, browser/account
 context, options strategy workflows/plans, exact-contract link bundles, stock
 profile reads, brokerage plan/execute, and crypto routes/sign/plan/execute). `robinhood_buy`/`robinhood_sell`
 run the same shared engine as the CLI commands — pending-order dedup (5-min window; `force: true` skips),

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ node cli/dist/index.js --help
 |---------|---------------|
 | API map | 300+ brokerage/account route entries (incl. instrument search + the `midlands/` sentiment layer) + the official Crypto routes, generated OpenAPI, endpoint Markdown, and curl templates. Every entry carries field-level response provenance (`verified`/`inferred`/`undocumented`, test-enforced). Trust the live count (`brokerage routes --json`), never a hardcoded number. |
 | CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep) and `recurring` (list/pause/resume/create/edit/end) — all writes double-gated — plus route planning and dry-run order bodies. |
-| MCP | 40+ agent tools (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
+| MCP | The full agent-tool surface (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
 | Memory | `ball-knowledge.md` (market beliefs/themes/sources) + `trading-log.md` (execution + intent history) — the agent's cross-session brain. |
 | Research | A source-quality doctrine (X/Reddit pulse → news/`midlands` confirmer → institutional outlook → academic math, none gospel) + strategy deep-dives (Wheel, rolling, with quant appendices), institutional CMAs, tax-aware notes. |
 | Auth | Browser-session bearer token loaded from local `.env`, with one-shot self-heal on `401` |
@@ -66,7 +66,7 @@ boot (read the operating-intelligence KB → memory → doctrine)
   → update memory  (ball-knowledge.md) → the thread continues next session
 ```
 
-The layers an agent reads to do that: **`SKILL.md`** (trigger + 80/20 + all the pitfalls) → **`AGENTS.md`** (self-contained deep reference) → **`docs/agent-operating-intelligence-2026-06-04.md`** (the boot-smart KB: cardinal rule, account/order/signal decision frameworks, failure→fix tree) → the **memory** files → the **research** docs (`docs/strategy-deep-dive-*`, `institutional-outlook-*`, `tax-aware-options-strategies`, `options-strategies-knowledge-base`). Everything is engine-backed (`cli/src/lib.ts`) and double-gated.
+The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill entry point — trigger + 80/20 + the operating loop + intent routing) → **`references/`** (the skill's progressive-disclosure layer: `operation-guide`, `command-catalog`, `api-route-map`, `safety-doctrine`, `options-strategy`, `troubleshooting`) → **`knowledge/`** (per-topic reasoning modules) → **`docs/agent-operating-intelligence-2026-06-04.md`** (the boot-smart KB: cardinal rule, account/order/signal decision frameworks, failure→fix tree) → the **memory** files → the **research** docs (`docs/strategy-deep-dive-*`, `institutional-outlook-*`, `tax-aware-options-strategies`, `options-strategies-knowledge-base`). The in-repo **`AGENTS.md`** (developer/maintainer runbook; `CLAUDE.md` is a symlink to it) covers build/test, the shared-engine invariant, and route-map editing. Everything is engine-backed (`cli/src/lib.ts`) and double-gated.
 
 ## Coverage
 
@@ -120,7 +120,7 @@ The MCP server is meant for requests like:
 
 The one-off features that make this more than an API wrapper:
 
-**Wheel engine + version scrape + recipes.** `wheel [symbol]` (CLI) and `robinhood_wheel` (MCP, 40+ tools — live truth: `tools/list`) read your actual shares + short puts/calls, classify your wheel stage (CSP open, shares uncovered, covered call on, and the rest), flag undercovered short calls as the naked exposure they are, and hand back the literal next-leg dry-run command. Works as pure discussion with no position on. `pnpm version:refresh` uses the CDP debug browser to scrape the live `x-robinhood-web-app-version` header off the login page (no RH login needed) and writes it to `.env`, so the equity-order version gate can't rot. `recipes "<intent>"` turns free text into the one command that answers it.
+**Wheel engine + version scrape + recipes.** `wheel [symbol]` (CLI) and `robinhood_wheel` (MCP — live truth: `tools/list`) read your actual shares + short puts/calls, classify your wheel stage (CSP open, shares uncovered, covered call on, and the rest), flag undercovered short calls as the naked exposure they are, and hand back the literal next-leg dry-run command. Works as pure discussion with no position on. `pnpm version:refresh` uses the CDP debug browser to scrape the live `x-robinhood-web-app-version` header off the login page (no RH login needed) and writes it to `.env`, so the equity-order version gate can't rot. `recipes "<intent>"` turns free text into the one command that answers it.
 
 **The kosher roll.** On a cash account, sale proceeds settle T+1, so a same-day roll is not "risky," it is structurally impossible without a good-faith violation. `options roll-plan --cash-account` stages it the only legal way: close today, open the replacement next business day after fresh settled-cash and quote checks. A broker would have just told you no.
 
@@ -280,7 +280,7 @@ claude mcp add robinhood-cli -s user -- node /absolute/path/to/robinhood-cli/mcp
 node mcp/dist/server.js
 ```
 
-40+ tools (live truth: `tools/list`) surface as `mcp__robinhood-cli__*` and inherit the identical auth, route map, and write gates as the CLI. The order tools (`robinhood_buy`, `robinhood_sell`, `robinhood_cancel`, `robinhood_order_status`, `robinhood_buying_power`) run the **same shared engine functions** as the CLI commands — dedup, `ref_id` idempotency, and the OTC guard apply identically on both surfaces — and `robinhood_wheel` gives agents an evidence-based Wheel conversation (stage + next leg + the exact dry-run command). (Trust the live `tools/list`, not a hardcoded count.)
+The MCP tools (live truth: `tools/list`) surface as `mcp__robinhood-cli__*` and inherit the identical auth, route map, and write gates as the CLI. The order tools (`robinhood_buy`, `robinhood_sell`, `robinhood_cancel`, `robinhood_order_status`, `robinhood_buying_power`) run the **same shared engine functions** as the CLI commands — dedup, `ref_id` idempotency, and the OTC guard apply identically on both surfaces — and `robinhood_wheel` gives agents an evidence-based Wheel conversation (stage + next leg + the exact dry-run command). (Trust the live `tools/list`, not a hardcoded count.)
 
 ### Current Update
 
@@ -539,14 +539,15 @@ N positions — green/red split.
 
 > **Rebuild note:** the build copies `api-map/brokerage-routes.json` into `cli/dist/`, and the runtime reads that copy. After editing the route map, **rebuild** (`pnpm build`) or your change is a silent no-op.
 
-For the full agent playbook — account discovery, the gate, watchlists, recurring investments — see [`AGENTS.md`](./AGENTS.md). For the public docs index, see [`docs/README.md`](./docs/README.md).
+For the full agent playbook — account discovery, the gate, watchlists, recurring investments — see [`SKILL.md`](./SKILL.md) and its [`references/`](./references/). For the in-repo developer/maintainer runbook (build/test, the shared-engine invariant, route-map editing), see [`AGENTS.md`](./AGENTS.md). For the public docs index, see [`docs/README.md`](./docs/README.md).
 
 ## Documentation
 
 | Path | Purpose |
 |------|---------|
-| [`AGENTS.md`](./AGENTS.md) | Full agent runbook: auth, account enumeration, route execution, writes, MCP registration |
-| [`SKILL.md`](./SKILL.md) | Skill entrypoint for agents and Hermes-style installers |
+| [`SKILL.md`](./SKILL.md) | Portable skill entry point for agents/Hermes installers (lean operator router) — deep how-to in [`references/`](./references/) |
+| [`references/`](./references/) | Skill progressive-disclosure layer: operation guide, command catalog, API route map, safety doctrine, options strategy, troubleshooting |
+| [`AGENTS.md`](./AGENTS.md) | In-repo developer/maintainer runbook: repo layout, build/test, shared-engine invariant, route-map editing, MCP registration (`CLAUDE.md` is a symlink to it) |
 | [`docs/README.md`](./docs/README.md) | Public docs index and naming/release rules |
 | [`docs/account-settings-capability-map-2026-06-03.md`](./docs/account-settings-capability-map-2026-06-03.md) | Funding, recurring, DRIP, cash sweep, stock lending, margin, futures, event-contract capability matrix |
 | [`docs/options-strategy-execution-smoke-2026-06-03.md`](./docs/options-strategy-execution-smoke-2026-06-03.md) | Dry-run options strategy smoke evidence |

--- a/README.md
+++ b/README.md
@@ -305,13 +305,13 @@ robinhood-cli options chain NVDA --expiration 2026-07-02 --type put --width 10 -
 ```
 
 ```text
-$ robinhood-cli options positions          # illustrative output (not real holdings)
+$ robinhood-cli options positions          # illustrative output — EXAMPLE DATA, not real holdings
 contract            acct   qty  entry  mark    value_usd  pl_usd    day_usd  return    delta
 ------------------  -----  ---  -----  ------  ---------  --------  -------  --------  -----
-DRAM $50 Call 6/18  …9919  1    $1.30  $18.65  $[redacted]   $[redacted]  $112.00  +1334.6%  0.93
-HPE $30 Call 9/18   …6346  1    $1.68  $19.00  $[redacted]   $[redacted]  $86.00   +1031.0%  0.88
+ACME $50 Call 6/18  …XXXX  1    $1.30  $1.95   $195.00    $65.00    $12.00   +50.0%   0.61
+EXMP $30 Call 9/18  …XXXX  1    $1.60  $2.10   $210.00    $50.00    $9.00    +31.3%   0.55
 ...
-TOTAL: value $[redacted] | unrealized $[redacted] | day $198.00
+TOTAL: value $405.00 | unrealized $115.00 | day $21.00
 ```
 
 Both are pure reads (no write gate). `--json` emits structured rows for piping into a spreadsheet or an agent.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node cli/dist/index.js --help
 | Surface | Current state |
 |---------|---------------|
 | API map | 300+ brokerage/account route entries (incl. instrument search + the `midlands/` sentiment layer) + the official Crypto routes, generated OpenAPI, endpoint Markdown, and curl templates. Every entry carries field-level response provenance (`verified`/`inferred`/`undocumented`, test-enforced). Trust the live count (`brokerage routes --json`), never a hardcoded number. |
-| CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep) and `recurring` (list/pause/resume/create/edit/end) — all writes double-gated — plus route planning and dry-run order bodies. |
+| CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep), `recurring` (list/pause/resume/create/edit/end), and `watchlist` (list/add/remove/create) — all writes double-gated — plus route planning and dry-run order bodies. |
 | MCP | The full agent-tool surface (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
 | Memory | `ball-knowledge.md` (market beliefs/themes/sources) + `trading-log.md` (execution + intent history) — the agent's cross-session brain. |
 | Research | A source-quality doctrine (X/Reddit pulse → news/`midlands` confirmer → institutional outlook → academic math, none gospel) + strategy deep-dives (Wheel, rolling, with quant appendices), institutional CMAs, tax-aware notes. |
@@ -80,7 +80,7 @@ The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill e
 - **Orders** — equity and options order history, status (single-order lookup with the instrument UUID resolved to a real ticker), placement, and cancellation — with pending-duplicate dedup and `ref_id` idempotency on every send.
 - **Portfolio P&L** — `portfolio` (aliases `pnl`/`snapshot`): one call → per-account day Δ + after-hours Δ + per-account buying power, drivers rolled up by underlying in **dollars** across all accounts, with a reconciliation line.
 - **Recipes** — `recipes "<intent>"`: free-text intent → the one CLI command (and MCP tool) that answers it.
-- **Watchlists** — list, add, remove.
+- **Watchlists** — list, add, remove, create (writes double-gated; the real endpoint is `discovery/lists/items/`, captured + verified live).
 - **Margin health** — `margin`: per-account answer to "am I borrowing, how much, at what rate, billed when" — amount borrowed in dollars, interest rate, next billing date, margin available, and buying power with margin; accounts without margin data degrade silently.
 - **Recurring investments** — first-class list, pause, resume, **create, edit, and end** (all double-gated; create/edit body shapes verified live).
 - **Account settings** — first-class `settings` group: DRIP (account-wide + per-stock), trade-on-expiration, PDT protection, stock lending, cash-sweep unenroll — double-gated, several verified live.
@@ -207,6 +207,8 @@ robinhood-cli options roll-plan --account <ACCOUNT_NUMBER> --symbol DRAM --type 
 robinhood-cli api-map options-contract-links --account <ACCOUNT_NUMBER> --symbol DRAM --expiration 2026-12-18 --type call --side buy --strike 80 --json
 robinhood-cli stock profile DRAM --account <ACCOUNT_NUMBER> --json
 robinhood-cli watchlist list                          # your custom watchlists + sizes
+robinhood-cli watchlist add "Homie index" NVDA AMAT   # add tickers (double-gated, dry-run by default)
+robinhood-cli watchlist create "Og handle fund"       # make a new list (double-gated)
 robinhood-cli brokerage routes --category orders      # browse mapped routes
 robinhood-cli brokerage plan "https://api.robinhood.com/accounts/{0}/" --param 0=ACCOUNT_ID --json
 ```
@@ -232,6 +234,7 @@ One line per question. All reads are live and free; the order/settings commands 
 | `buy` / `sell` / `cancel` / `order-status` | The order lifecycle — dollar or share sizing, dedup + `ref_id` idempotency, real-ticker status |
 | `buying-power [--account N]` | "What can I actually spend?" — the BP family, not the headline number |
 | `recurring list/pause/resume/create/edit/end` | "What's on autopilot, and change it" |
+| `watchlist list/add/remove/create` | "Show my custom lists, and edit them" — add/remove tickers (resolved by name) or make a new list (double-gated) |
 | `settings show/drip/expiration/pdt/lending/sweep` | "Read or toggle account settings" (double-gated) |
 | `history --days N` | "What actually executed?" — unified equity + options + crypto + transfers, newest first |
 | `quote <SYM...>` | Live last/bid/ask/day-change for any symbols |
@@ -521,6 +524,12 @@ robinhood-cli positions --account <ROTH_ACCOUNT_NUMBER>     # Roth IRA
 
 # Your custom watchlists and how many symbols each holds.
 robinhood-cli watchlist list
+
+# Edit watchlists — add/remove tickers (resolved by name) or create a list.
+# Writes are dry-run until BOTH gates are set, like every other write here.
+robinhood-cli watchlist create "AI memory"
+ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist add "AI memory" MU AMAT LRCX --live-write
+ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist remove "AI memory" LRCX --live-write
 
 # Option expirations for a symbol (handy before `options chain`).
 robinhood-cli options expirations MRVL

--- a/SKILL.md
+++ b/SKILL.md
@@ -226,6 +226,14 @@ only via ETF proxies (USO/UVXY/BITO — normal equities, placeable via `brokerag
 strike + bid/ask/last + qty + link) across accounts; `options inspect <uuid>` opens one contract's
 full detail (metadata, Greeks, fill history, rare tax-timing note, buy/sell handoff).
 
+**Watchlists** — read custom lists (`watchlist list`) **and write them, double-gated** (verified 2026-06-14):
+`watchlist add <list> <symbols…>` / `watchlist remove <list> <symbols…>` (batch ops to `discovery/lists/items/`;
+resolve the list by case-insensitive `display_name` or id) and `watchlist create <name> [--emoji]` (POST
+`discovery/lists/`). MCP equivalents: `robinhood_watchlist_add`/`_remove`/`_create`. Read a list's live tickers
+with `watchlist items <list>` (symbol/price/equity-buyable flag), and **basket-buy** every equity-buyable name
+with `watchlist buy <list> --account <N> --amount <$>` — BP-aware, looping the shared `placeEquityOrder` engine
+per ticker (same OTC/dedup/`ref_id`/evidence guards; skips what won't fit; double-gated). Item **reorder** is not yet mapped.
+
 ### Strategy & tax knowledge (background — neutral, NOT risk guidance)
 Reference docs that give the agent broad options/tax background to reason about ANY strategy a user
 asks for. **Descriptive, not prescriptive** — they do NOT push a risk tolerance or steer toward "safe"
@@ -409,6 +417,11 @@ robinhood-cli options positions --json
 robinhood-cli options chain MRVL --width 6 --json
 robinhood-cli options expirations MRVL --json
 robinhood-cli watchlist list --json
+robinhood-cli watchlist add "My List" NVDA TSLA              # dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1
+robinhood-cli watchlist remove "My List" TSLA               # dry-run by default
+robinhood-cli watchlist create "Semis" --emoji 🛰️            # dry-run by default
+robinhood-cli watchlist items "Semis" --json                 # live read: tickers + price + equity-buyable flag
+robinhood-cli watchlist buy "Semis" --account <N> --amount 5 # BASKET BUY $5 of each buyable name — dry-run by default; double-gated
 robinhood-cli crypto routes --json
 robinhood-cli crypto sign --api-key "$ROBINHOOD_API_KEY" --private-key-b64 "$ROBINHOOD_PRIVATE_KEY_B64" --path /api/v1/crypto/trading/accounts/ --method GET
 robinhood-cli crypto execute "https://trading.robinhood.com/api/v2/crypto/marketdata/best_bid_ask/" --query-param symbol=BTC-USD --dry-run --json
@@ -425,6 +438,7 @@ Keep this split current when editing the skill:
 | Options research/planning | 18 strategy workflows; `options-strategy-plan` emits `reviewContract` | Planning only until exact user approval and write gates |
 | Equity/options order writes | Route-map executor against `orders/`, `options/orders/`, and cancel routes | Must use `--method`, exact body, `--live-write`, and `ROBINHOOD_ALLOW_LIVE_WRITE=1`; dry-run first |
 | Recurring investments | First-class `recurring list`, `recurring resume`, `recurring pause`; route map also has GET one schedule and POST create | Resume/pause are the verified first-class writes. Create/edit amount/funding-source are route-map research unless a fresh capture verifies body shape |
+| Watchlist read / edit / basket-buy | `watchlist list`/`items` (read); `watchlist add`/`remove`/`create` + `watchlist buy` (basket) (MCP `robinhood_watchlist_add`/`_remove`/`_create`/`_items`/`_buy`) | Double-gated writes (verified 2026-06-14): add/remove batch `discovery/lists/items/`, create POSTs `discovery/lists/`; `watchlist buy` loops the shared order engine per ticker (BP-aware, OTC/dedup/`ref_id` guards, skips what won't fit); item reorder still route-map research |
 | Money movement / funding | ACH relationships/transfers and cashier/deposit-schedule routes are mapped mostly as read or `write-or-sensitive` | Never mutate funding, ACH links, deposits, withdrawals, or transfers without a fresh route/body capture and explicit approval |
 | DRIP/options/account settings | DRIP GET/PATCH is method-split; account-setting routes are mapped or browser-observed | Treat account-setting writes as dry-run first; plan, obtain exact approval, send only with both gates, then verify reload state |
 | Crypto | Official Crypto API signing/planning/execution commands | Different auth from brokerage; crypto writes/cancels use the same double gate |
@@ -1255,9 +1269,9 @@ documented. To extend it safely:
 
 ## MCP Server
 
-50 tools (live truth: `tools/list`) surfaced via Hermes MCP (route/strategy planning + generic executors, PLUS first-class parity tools mirroring the CLI verbs: `robinhood_accounts`, `robinhood_positions`, `robinhood_portfolio` (one-call P&L: day Δ + after-hours Δ, drivers by underlying in dollars), `robinhood_buy`/`robinhood_sell` (the SAME shared order engine as the CLI — dedup, `ref_id`, OTC guard), `robinhood_cancel`, `robinhood_order_status` (UUID→ticker resolved), `robinhood_buying_power`, `robinhood_wheel` (evidence-based Wheel stage + next-leg command), `robinhood_options_holdings`, `robinhood_options_inspect`, `robinhood_settings`, `robinhood_recurring`, `robinhood_quote`, `robinhood_history`, `robinhood_watchlist`, `robinhood_options_enumerate`). Same engine -> same auth, gate, and method-aware routing as the CLI.
+The full first-class tool roster (live truth: `tools/list`, never a hardcoded count) surfaced via Hermes MCP (route/strategy planning + generic executors, PLUS first-class parity tools mirroring the CLI verbs: `robinhood_accounts`, `robinhood_positions`, `robinhood_portfolio` (one-call P&L: day Δ + after-hours Δ, drivers by underlying in dollars), `robinhood_buy`/`robinhood_sell` (the SAME shared order engine as the CLI — dedup, `ref_id`, OTC guard), `robinhood_cancel`, `robinhood_order_status` (UUID→ticker resolved), `robinhood_buying_power`, `robinhood_wheel` (evidence-based Wheel stage + next-leg command), `robinhood_options_holdings`, `robinhood_options_inspect`, `robinhood_settings`, `robinhood_recurring`, `robinhood_quote`, `robinhood_history`, `robinhood_watchlist` + the double-gated `robinhood_watchlist_add`/`robinhood_watchlist_remove`/`robinhood_watchlist_create` writes, `robinhood_options_enumerate`). Same engine -> same auth, gate, and method-aware routing as the CLI.
 
-> **Count note:** the *source/dist* registers 50 tools (live truth: `tools/list`). A *running* MCP process started before the
+> **Count note:** the *source/dist* registers the full roster (live truth: `tools/list`, never a hardcoded count). A *running* MCP process started before the
 > last tool additions will still advertise its old count until reloaded — run `/reload-mcp` (or restart
 > the server) after pulling, then confirm the client's `tools/list` count matches the current build.
 
@@ -1309,6 +1323,11 @@ claude mcp add robinhood-cli -s user -- \
 | `robinhood_quote` | Live quote(s) for one or more equity/ETF symbols |
 | `robinhood_history` | Unified history (equity + options + crypto orders + transfers), newest first |
 | `robinhood_watchlist` | Read custom watchlists (`owner_type=custom`) |
+| `robinhood_watchlist_add` | Add ticker(s) to a custom watchlist by name/id — batch `discovery/lists/items/` write (double-gated) |
+| `robinhood_watchlist_remove` | Remove ticker(s) from a custom watchlist by name/id (double-gated) |
+| `robinhood_watchlist_create` | Create a new custom watchlist (optional emoji) via `discovery/lists/` (double-gated) |
+| `robinhood_watchlist_items` | Read a custom watchlist's tickers live (symbol, price, equity-buyable flag) — the read half; pair with `robinhood_watchlist_buy` |
+| `robinhood_watchlist_buy` | **Basket buy** — buy $<amount> of EACH equity-buyable ticker in a watchlist (BP-aware; loops the shared order engine per ticker — OTC/dedup/`ref_id`/evidence guards) (double-gated) |
 | `robinhood_options_enumerate` | Bulk-enumerate every strike's `option_instrument_id` for a chain/expiration |
 | `robinhood_buy` | Equity buy (dollar-notional fractional or shares) — shared engine: OTC guard, pending-order dedup (5-min, `force` skips), `ref_id` idempotency, trade log; double-gated |
 | `robinhood_sell` | Equity sell — same shared engine + gates as `robinhood_buy` |
@@ -1380,7 +1399,7 @@ Always try Syncthing before fighting with SSH.
 7. **`owner_type=custom` is MANDATORY.** Every watchlist read without it returns 400: `"owner_type of request must be specified"`.
 8. **Rename uses `display_name`, not `name`.** Wrong field → 200 with no change.
 9. **The Options Watchlist cannot be deleted.** Robinhood hard-blocks it server-side (not a CLI bug).
-10. **Item add/remove/reorder is not yet mapped.** POST to `discovery/lists/items/` returns `"failed operations":""` with no detail.
+10. **Item add/remove ARE mapped (verified 2026-06-14); only reorder is not.** `watchlist add`/`remove` (MCP `robinhood_watchlist_add`/`_remove`) POST a list-id-keyed batch body to `discovery/lists/items/` — `{"<list_id>":[{"object_id":"<uuid>","object_type":"instrument","operation":"create"|"delete"}]}` — double-gated like every write. Item **reorder** (weight/sort) is still unmapped.
 
 ### Writes & Safety
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,21 @@
 # TODO — robinhood-cli hardening roadmap
 
+## ⏰ TRIGGER AT MARKET OPEN — custom-watchlist $1 basket (added 2026-06-15)
+
+- [ ] **Place the $1 watchlist basket at the next regular open.** Fractional dollar orders are
+  regular-hours-only (Robinhood **500s** them after hours — verified live 2026-06-15), so a basket
+  attempted after the 13:00 PDT close cannot fill. Run at/after **06:30 PDT (09:30 ET)**, market open:
+
+  ```bash
+  node cli/dist/index.js watchlist buy "<list-name>" --account <account_number> --amount 1 --live-write
+  ```
+
+  Notes: the command is **BP-aware** — if the basket total ($amount × tradable count) exceeds the
+  account's buying power, it places the affordable prefix and reports the rest as skipped (top up or
+  pass `--limit`). One-gate model: `--live-write` alone is the whole gate now — no env var needed.
+  Verify after: `node cli/dist/index.js history --account <account_number> --days 1` (order history
+  is the only proof an order happened).
+
 ## Execution safeties — checks and balances (added 2026-06-11)
 
 - [x] **`pretrade` gate command** (BUILT 2026-06-11: CLI `pretrade` + MCP `robinhood_pretrade`, PASS/WARN/BLOCK checklist, marketability left as manual gated POST): one shot that runs buying power + options collateral + marketability +

--- a/TODO.md
+++ b/TODO.md
@@ -35,7 +35,7 @@
 - [ ] **Doc contradictions to reconcile (found 2026-06-11, 9 items)**: iron-condor leg names differ
   between SKILL.md sections (catalog JSON ids are authoritative); naked-short-call leg id; after-hours
   options self-contradiction in SKILL.md; wash-sale strictness differs between rolling deep-dive and
-  tax doc; SKILL 38 vs TODO 37 tool count; account mask …7523 vs ••••2523; `?account=` vs
+  tax doc; SKILL 38 vs TODO 37 tool count; account-mask format inconsistent between two docs; `?account=` vs
   `?account_number=` in order-templates doc; PDT-lifted vs vestigial PDT toggles; "18 strategy
   workflows" vs 20 catalog ids.
 
@@ -198,13 +198,7 @@ verified, 40 inferred). That number is *not* a 219-item backlog — read it corr
 - [ ] Tax-loss harvesting helper (FRCB is $0.01, LWLG bleeding, UI underwater)
 
 ### Portfolio snapshot (Jun 3 live)
-| Account | Value |
-|---------|-------|
-| ••••6346 IRA Roth | $[redacted] (equity $[redacted] + options $[redacted]) |
-| ••••0497 far 9mo plus | $[redacted] (equity $[redacted] + options $[redacted], margin $[redacted]) |
-| ••••9919 near 3mo-roll | $[redacted] (equity $[redacted] + options $[redacted]) |
-| ••••9911 Agentic | $0 |
-| ••••2523 Agentic-long | $0 |
-| **TOTAL** | **$[redacted]** |
+_Redacted — real account tails and exact balances removed. Pull a live snapshot with `portfolio` /
+`accounts` when you need current numbers; don't commit real balances to the repo._
 
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,67 @@
 - [ ] Auto-journal nudge — after a fill, prompt a `review note` so film-study notes accumulate at the moment of the trade.
 - [ ] `exposure` — concentration by underlying/sector + portfolio-wide net Greeks.
 
+## Watchlist writes — add/remove/create — SHIPPED 2026-06-15
+
+The watchlist surface is now read **+ write**, wired across all three places behind the double gate.
+**Correction to the original assumption:** the write endpoint is **`discovery/lists/items/`**, NOT
+`midlands/lists/items/` — captured + verified live 2026-06-15 (the `midlands/lists/*` entries are
+unrelated read routes). Contract: `POST discovery/lists/items/` with a list-id-keyed batch body
+`{ "<list_id>": [ {object_id, object_type, operation: create|delete} ] }`; create = `POST
+discovery/lists/` (201); delete-list = `DELETE discovery/lists/{id}/` (204). Full write-up in
+`docs/undocumented-surface.md`.
+
+- [x] **Captured the write contract** (CDP network capture, then API-verified add/remove/create/delete).
+- [x] **Route map** — added `discovery/lists/items/` POST (`write-mutate`); create/delete-list entries
+  already present. Rebuilt + regenerated api-map markdown/openapi/curl.
+- [x] **Engine** (`cli/src/lib.ts`) — `resolveInstrumentId`, `resolveWatchlist`, `watchlistMutateItems`,
+  `createWatchlist`, `deleteWatchlist` — all through `gatedBrokerageWrite`. No logic in the front doors.
+- [x] **CLI** — `watchlist add|remove <list> <SYM...>`, `watchlist create <name>` (thin wrappers).
+- [x] **MCP** — `robinhood_watchlist_add|remove|create` (tool count 50 → 53).
+- [x] **Test** — `cli/test/watchlist-write.test.ts` (method + URL + body shape); `mcp-tool-count` bumped.
+- [x] **Live-verified** — created "Homie index" + "Og handle fund", batched adds, add→remove round-trip
+  (all 200/201, readbacks confirmed) + recipes added for the intent router.
+
+## Undocumented route-body audit (2026-06-14)
+
+Audit of `api-map/brokerage-routes.json`: **219 of 310 routes are `fieldsSource: "undocumented"`** (51
+verified, 40 inferred). That number is *not* a 219-item backlog — read it correctly:
+
+- **137 are `sensitive-read` GETs** (balances, PII, profile, portfolios). They are **usable today** — you
+  call them and read the response; the empty `fields` only means the *response shape* isn't catalogued.
+  Optional polish (backfill response fields for nicer typed output), **not** a capability blocker.
+- **50 are plain `read`** — same story, usable now.
+- **32 are write-tier** (`write-safe`/`write-mutate`/`write-or-sensitive`/`destructive`) — these are the
+  ones where a **missing request body = the capability can't be used** (the watchlist-items case). Of
+  those 32: ~12 are **already wired** (the engine builds the body even though `fields` is empty: `orders/`
+  + cancel, `options/orders/` + cancel, `nummus/orders/` crypto + cancel, account-wide DRIP,
+  `recurring_schedules`, `marketability`/`review` via `pretrade`); 5 are **already tracked** below in
+  "Live auth needed" (sweep, instrument DRIP, `settings/margin`, slip/stock-lending, options_settings).
+
+### Genuinely untracked write bodies to reverse-engineer (CDP capture → fields + method → rebuild)
+
+- [ ] **Whole-watchlist CRUD** — `POST discovery/lists/` (create a custom list), `DELETE/PATCH
+  discovery/lists/{id}/` (delete/rename). Both `destructive`, category `watchlists`, empty fields.
+  Natural companion to the items add/remove in the Watchlist-writes section above — capture them in the
+  same session.
+- [ ] **DRIP enrollment** — `corp_actions/drip/enrollment/{account_number}/` (`write-or-sensitive`,
+  empty fields). Distinct from the account-wide `drip/account_settings/` toggle that's already built;
+  capture the enroll/unenroll body.
+- [ ] **Sweep enroll (alt host)** — `bonfire .../sms/sweep/agree_and_enroll` (`write-mutate`). Same cash-
+  sweep capability already tracked via `accounts/{account}/sweep_enrollment_state/`; capture both bodies
+  when doing the sweep toggle so we know which host the web app actually uses.
+
+### Explicitly NOT building (so nobody burns time capturing them)
+
+- **Money-movement cluster** — `ach/transfers/`, `ach/relationships/` (+ `/unlink/`), `wire/transfers`,
+  `acats/`, `nimbus/v1/asset_transfers`, `crypto-transfers/*`. These move **real cash off-platform**;
+  out of scope for a reads+trades tool by default. Revisit ONLY on an explicit decision to add
+  deposit/withdrawal automation.
+- **Telemetry / cosmetics** — `goku/*` log events, `app-comms/receipt/seen/`, upsell/promo/tooltip/
+  onboarding surfaces. No operator value.
+- **Sensitive identity writes** — `identi .../user_info/agreements/v2/sign/`, `subscription_fees/`. High
+  blast radius, near-zero operator benefit; leave parked.
+
 ## Social / showcase layer (parked 2026-06-11 — v2, after core)
 
 - [ ] **Trade cards + success graphics framework**: HTML template framework that renders a trade

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
   the PDF). Build: list + filter by type/year + download-all-1099s. Tax-season one-shot.
 - [x] **`margin` health command** (BUILT 2026-06-11: all-account scan, money-object unwrap, plain-English borrow line; MCP robinhood_margin): `margin/{account_number}/investing_info/` live-verified on the api
   host — amount_borrowed, margin_interest_rate, next_billing_date, projected intraday BP. Surface in
-  `portfolio` too: an account borrowing on margin should say so (live: …0497 borrowing $[redacted] @ rate).
+  `portfolio` too: an account borrowing on margin should say so.
 - [ ] **phoenix.robinhood.com is TLS-walled** (handshake refused, like ceres futures) — the app-only
   unified-balances host. Don't chase it; the per-account composition already covers balances.
 - [ ] **Options per-position P&L endpoint still unknown** (web UI shows it) — needs a CDP capture pass

--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -7991,6 +7991,30 @@
     "source": "manual"
   },
   {
+    "url": "https://api.robinhood.com/discovery/lists/items/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "watchlists"
+    ],
+    "risk": "write-mutate",
+    "methods": [
+      "POST"
+    ],
+    "summary": "Add or remove items in custom watchlists. Body is an object keyed by list_id -> array of {object_id (instrument UUID, NOT ticker), object_type (instrument|currency_pair|option_strategy), operation (create=add | delete=remove)}. Batches multiple items and multiple lists in one call. Reversible (add/remove items; not destructive like deleting a list).",
+    "bodyKeys": [
+      "object_id",
+      "object_type",
+      "operation"
+    ],
+    "source": "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)",
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [],
+    "fieldsSource": "verified"
+  },
+  {
     "url": "https://api.robinhood.com/discovery/lists/{id}/",
     "host": "api.robinhood.com",
     "categories": [

--- a/api-map/curl/brokerage-route-templates.sh
+++ b/api-map/curl/brokerage-route-templates.sh
@@ -603,6 +603,9 @@
 # sensitive-read GET https://bonfire.robinhood.com/margin/{id}/investing_info/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/margin/{id}/investing_info/'
 
+# sensitive-read GET https://api.robinhood.com/margin/{account_number}/investing_info/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/margin/{account_number}/investing_info/'
+
 # sensitive-read GET https://bonfire.robinhood.com/margin/{id}/settings/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/margin/{id}/settings/'
 
@@ -837,6 +840,9 @@
 # sensitive-read GET https://api.robinhood.com/discovery/lists/?owner_type=custom
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/discovery/lists/?owner_type=custom'
 
+# write-mutate POST https://api.robinhood.com/discovery/lists/items/
+# curl -sS -X POST -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/discovery/lists/items/'
+
 # destructive PATCH https://api.robinhood.com/discovery/lists/{id}/
 # curl -sS -X PATCH -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/discovery/lists/{id}/'
 
@@ -926,5 +932,8 @@
 
 # sensitive-read GET https://api.robinhood.com/orders/{0}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/orders/{0}/'
+
+# sensitive-read GET https://api.robinhood.com/options/orders/{0}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/orders/{0}/'
 
 # Zayd Khan // cold // www.zayd.wtf

--- a/api-map/markdown/brokerage-routes.md
+++ b/api-map/markdown/brokerage-routes.md
@@ -4,8 +4,8 @@ Source: reverse-engineered routes plus sanitized authenticated Chrome/CDP captur
 
 Personal repo semantics: mapped routes can be executed live with caller-owned `ROBINHOOD_BROKERAGE_TOKEN` or `ROBINHOOD_COOKIE`. Pass `--dry-run` when you want a non-sending test plan.
 
-Current count: 308 route templates.
-Risk counts: destructive=9, read=86, sensitive-read=190, write-mutate=10, write-or-sensitive=7, write-safe=6.
+Current count: 311 route templates.
+Risk counts: destructive=9, read=86, sensitive-read=192, write-mutate=11, write-or-sensitive=7, write-safe=6.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -211,6 +211,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | GET | account | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/buying_power_hub_view` |
 | sensitive-read | GET | account, telemetry-config | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/eligibility` |
 | sensitive-read | GET | account | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/investing_info/` |
+| sensitive-read | GET | account, margin | api.robinhood.com | live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10). | `https://api.robinhood.com/margin/{account_number}/investing_info/` |
 | sensitive-read | GET | account | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/margin/{id}/settings/` |
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/market_indices` |
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/onboarding/{id}/` |
@@ -289,6 +290,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | inferred | uncategorized | api.robinhood.com | community-seed | `https://api.robinhood.com/discovery/lists/user_items/` |
 | sensitive-read | inferred | uncategorized | api.robinhood.com | community-seed | `https://api.robinhood.com/discovery/lists/{0}/` |
 | sensitive-read | inferred | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/?owner_type=custom` |
+| write-mutate | POST | watchlists | api.robinhood.com | cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/) | `https://api.robinhood.com/discovery/lists/items/` |
 | destructive | PATCH,DELETE | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/{id}/` |
 | destructive | POST | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/` |
 | destructive | PATCH,DELETE | recurring | bonfire.robinhood.com | wire-writes 2026-05-29 | `https://bonfire.robinhood.com/recurring_schedules/{0}/` |
@@ -319,5 +321,6 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | read | GET | marketdata | api.robinhood.com | cdp-2026-06-04-injected-capture (observed; price historicals per symbol) | `https://api.robinhood.com/marketdata/historicals/{symbol}/` |
 | read | GET | options, marketdata | bonfire.robinhood.com | cdp-2026-06-04-injected-capture (observed; option strategy historical chart; strategy_code = {option_uuid}_S1) | `https://bonfire.robinhood.com/options/{strategy_code}/historical-chart/` |
 | sensitive-read | GET | orders | api.robinhood.com | self-extension 2026-06-09: single order status lookup by ID | `https://api.robinhood.com/orders/{0}/` |
+| sensitive-read | GET | options, orders | api.robinhood.com | self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order. | `https://api.robinhood.com/options/orders/{0}/` |
 
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-margin-7baccount-number-7d-investing-info.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-margin-7baccount-number-7d-investing-info.md
@@ -1,0 +1,17 @@
+# GET /margin/%7Baccount_number%7D/investing_info/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: account, margin
+Source: live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10).
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/margin/{account_number}/investing_info/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-7b0-7d.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-7b0-7d.md
@@ -1,0 +1,17 @@
+# GET /options/orders/%7B0%7D/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: options, orders
+Source: self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order.
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/orders/{0}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/post-api-robinhood-com-discovery-lists-items.md
+++ b/api-map/markdown/endpoints/post-api-robinhood-com-discovery-lists-items.md
@@ -1,0 +1,17 @@
+# POST /discovery/lists/items/
+
+Mutation: yes
+Risk: write-mutate
+
+Host: api.robinhood.com
+Categories: watchlists
+Source: cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/discovery/lists/items/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/robinhood-routes.md
+++ b/api-map/markdown/robinhood-routes.md
@@ -4,10 +4,10 @@ Source: official Robinhood Crypto Trading OpenAPI plus sanitized authenticated C
 
 Crypto operations are official Robinhood-published endpoints and should use Ed25519 signing. Brokerage/account operations are browser-backed route-map entries and use caller-owned brokerage token or browser cookie auth.
 
-Current count: 324 route entries.
+Current count: 327 route entries.
 Official Crypto route entries: 16.
-Brokerage/account route entries: 308.
-Risk counts: destructive=11, read=92, sensitive-read=196, write-mutate=12, write-or-sensitive=7, write-safe=6.
+Brokerage/account route entries: 311.
+Risk counts: destructive=11, read=92, sensitive-read=198, write-mutate=13, write-or-sensitive=7, write-safe=6.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -67,6 +67,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | yes | destructive | PATCH,DELETE | watchlists | api.robinhood.com | manual | `https://api.robinhood.com/discovery/lists/{id}/` |
 | no | sensitive-read | inferred |  | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/discovery/lists/default/` |
 | no | sensitive-read | inferred |  | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/discovery/lists/items/` |
+| yes | write-mutate | POST | watchlists | api.robinhood.com | cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/) | `https://api.robinhood.com/discovery/lists/items/` |
 | no | sensitive-read | inferred |  | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/discovery/lists/user_items/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/discovery/ratings/{id}/overview/` |
 | no | sensitive-read | GET | history-documents | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/dividends/` |
@@ -92,6 +93,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/instruments/{0}/splits/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/instruments/{id}/shorting/` |
 | no | read | GET | telemetry-config | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/kaizen/experiments/{id}/` |
+| no | sensitive-read | GET | account, margin | api.robinhood.com | live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10). | `https://api.robinhood.com/margin/{account_number}/investing_info/` |
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/margin/{account_number}/upgrade_restrictions` |
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/margin/{account_number}/upgrade_restrictions/` |
 | no | read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/margin/calls/` |
@@ -162,6 +164,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | yes | write-or-sensitive | PATCH | options, settings, account | api.robinhood.com | web-ui-capture-2026-06-03 (account/settings/investing toggle) | `https://api.robinhood.com/options/option_settings/{account_number}/` |
 | no | sensitive-read | GET | options, orders | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/options/orders/` |
 | yes | write-mutate | POST | account, options, trading | api.robinhood.com | self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders; supports legs[] for single/multi-leg. Double-gated. | `https://api.robinhood.com/options/orders/` |
+| no | sensitive-read | GET | options, orders | api.robinhood.com | self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order. | `https://api.robinhood.com/options/orders/{0}/` |
 | yes | destructive | POST | options, orders | api.robinhood.com | wire-writes 2026-05-29 | `https://api.robinhood.com/options/orders/{0}/cancel/` |
 | no | read | GET | options, trading | api.robinhood.com | cdp-2026-06-04-dram-option-order-flow (observed; collateral pre-check, order passed url-encoded in ?order={json}) | `https://api.robinhood.com/options/orders/collateral/` |
 | no | sensitive-read | inferred | account, options | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/options/positions/` |

--- a/api-map/openapi/robinhood-brokerage.openapi.json
+++ b/api-map/openapi/robinhood-brokerage.openapi.json
@@ -3885,6 +3885,37 @@
           "community-seed"
         ],
         "x-robinhood-seen-on": []
+      },
+      "post": {
+        "operationId": "brokerage_post_discovery_lists_items",
+        "summary": "Watchlists brokerage route",
+        "description": "Personal route map entry. Risk: write-mutate. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "watchlists"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "write-mutate",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/discovery/lists/items/"
+        ],
+        "x-robinhood-sources": [
+          "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200",
+          "the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)"
+        ],
+        "x-robinhood-seen-on": []
       }
     },
     "/discovery/lists/user_items/": {
@@ -6555,6 +6586,49 @@
           "stock-nvda-options",
           "stock-tsla"
         ]
+      }
+    },
+    "/margin/{account_number}/investing_info/": {
+      "get": {
+        "operationId": "brokerage_get_margin_account_number_investing_info",
+        "summary": "Account brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "account",
+          "margin"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/margin/{account_number}/investing_info/"
+        ],
+        "x-robinhood-sources": [
+          "live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10)."
+        ],
+        "x-robinhood-seen-on": []
       }
     },
     "/margin/{account_number}/upgrade_restrictions": {
@@ -10406,6 +10480,49 @@
         "x-robinhood-sources": [
           "self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders",
           "supports legs[] for single/multi-leg. Double-gated."
+        ],
+        "x-robinhood-seen-on": []
+      }
+    },
+    "/options/orders/{param_0}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_param_0",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "orders"
+        ],
+        "parameters": [
+          {
+            "name": "param_0",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder param_0. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/{0}/"
+        ],
+        "x-robinhood-sources": [
+          "self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order."
         ],
         "x-robinhood-seen-on": []
       }

--- a/api-map/openapi/robinhood-unified.openapi.json
+++ b/api-map/openapi/robinhood-unified.openapi.json
@@ -5823,6 +5823,38 @@
         ],
         "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"
+      },
+      "post": {
+        "operationId": "brokerage_post_discovery_lists_items",
+        "summary": "Watchlists brokerage route",
+        "description": "Personal route map entry. Risk: write-mutate. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "watchlists"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "write-mutate",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/discovery/lists/items/"
+        ],
+        "x-robinhood-sources": [
+          "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200",
+          "the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)"
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
       }
     },
     "/discovery/lists/user_items/": {
@@ -8543,6 +8575,50 @@
           "stock-nvda-options",
           "stock-tsla"
         ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/margin/{account_number}/investing_info/": {
+      "get": {
+        "operationId": "brokerage_get_margin_account_number_investing_info",
+        "summary": "Account brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "account",
+          "margin"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/margin/{account_number}/investing_info/"
+        ],
+        "x-robinhood-sources": [
+          "live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10)."
+        ],
+        "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"
       }
     },
@@ -12468,6 +12544,50 @@
         "x-robinhood-sources": [
           "self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders",
           "supports legs[] for single/multi-leg. Double-gated."
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/options/orders/{param_0}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_param_0",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "orders"
+        ],
+        "parameters": [
+          {
+            "name": "param_0",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder param_0. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/{0}/"
+        ],
+        "x-robinhood-sources": [
+          "self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order."
         ],
         "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"

--- a/api-map/recipes.json
+++ b/api-map/recipes.json
@@ -178,6 +178,45 @@
       "notes": "owner_type=custom is mandatory (handled internally)."
     },
     {
+      "id": "watchlist-add",
+      "intent": "Add tickers to a watchlist",
+      "triggers": [
+        "add to watchlist",
+        "add to my list",
+        "put on my watchlist"
+      ],
+      "command": "watchlist add <list> <SYM...> --live-write",
+      "mcpTool": "robinhood_watchlist_add",
+      "risk": "write-mutate",
+      "notes": "List resolved by name or id; tickers resolved to instrument UUIDs internally. Double-gated, dry-run by default."
+    },
+    {
+      "id": "watchlist-remove",
+      "intent": "Remove tickers from a watchlist",
+      "triggers": [
+        "remove from watchlist",
+        "take off my list",
+        "delete from watchlist"
+      ],
+      "command": "watchlist remove <list> <SYM...> --live-write",
+      "mcpTool": "robinhood_watchlist_remove",
+      "risk": "write-mutate",
+      "notes": "Same endpoint as add (operation=delete). Double-gated."
+    },
+    {
+      "id": "watchlist-create",
+      "intent": "Create a new watchlist",
+      "triggers": [
+        "make a watchlist",
+        "create a list",
+        "new watchlist"
+      ],
+      "command": "watchlist create <name> --live-write",
+      "mcpTool": "robinhood_watchlist_create",
+      "risk": "write-mutate",
+      "notes": "POST discovery/lists/ with display_name (+ optional icon emoji). Double-gated."
+    },
+    {
       "id": "accounts",
       "intent": "List all my accounts + capabilities",
       "triggers": [

--- a/api-map/robinhood-routes.json
+++ b/api-map/robinhood-routes.json
@@ -1502,6 +1502,30 @@
     "fieldsShape": "object"
   },
   {
+    "url": "https://api.robinhood.com/discovery/lists/items/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "watchlists"
+    ],
+    "risk": "write-mutate",
+    "methods": [
+      "POST"
+    ],
+    "summary": "Add or remove items in custom watchlists. Body is an object keyed by list_id -> array of {object_id (instrument UUID, NOT ticker), object_type (instrument|currency_pair|option_strategy), operation (create=add | delete=remove)}. Batches multiple items and multiple lists in one call. Reversible (add/remove items; not destructive like deleting a list).",
+    "bodyKeys": [
+      "object_id",
+      "object_type",
+      "operation"
+    ],
+    "source": "cdp-2026-06-14 watchlist-capture (verified live: add+remove each returned 200; the REAL endpoint is discovery/lists/items/, NOT midlands/lists/items/)",
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [],
+    "fieldsSource": "verified"
+  },
+  {
     "url_template": "https://api.robinhood.com/discovery/lists/user_items/",
     "method": "GET",
     "risk": "sensitive-read",
@@ -1576,8 +1600,35 @@
       "instrument_id",
       "page_size"
     ],
-    "fields": [],
-    "fieldsSource": "undocumented"
+    "fields": [
+      "account",
+      "active_instrument_id",
+      "amount",
+      "cash_dividend_id",
+      "days_early",
+      "drip_enabled",
+      "ex_dividend_date",
+      "fee",
+      "fx_order_id",
+      "gross_amount",
+      "id",
+      "instrument",
+      "is_early_dividend",
+      "is_primary_account",
+      "nra_withholding",
+      "paid_at",
+      "payable_date",
+      "position",
+      "rate",
+      "record_date",
+      "related_adjustments",
+      "state",
+      "url",
+      "withholding"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list",
+    "notes": "live-verified 2026-06-11: full dividend history (102 records on test account). First-class `dividends` command candidate: income by symbol/year, upcoming payouts via payable_date, per-dividend drip_enabled."
   },
   {
     "url": "https://api.robinhood.com/documents/",
@@ -1606,8 +1657,27 @@
       "type",
       "type__in"
     ],
-    "fields": [],
-    "fieldsSource": "undocumented"
+    "fields": [
+      "account",
+      "created_at",
+      "date",
+      "download_url",
+      "filetype",
+      "id",
+      "insert_1_url",
+      "insert_2_url",
+      "insert_3_url",
+      "insert_4_url",
+      "insert_5_url",
+      "insert_6_url",
+      "is_from_rhs",
+      "type",
+      "updated_at",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list",
+    "notes": "live-verified 2026-06-11: cursor-paginated. type values seen: 1099, 1099_crypto, 1099r_roth, 5498_roth, account_statement, trade_confirm. download_url serves the PDF — first-class `documents` command candidate (tax-season: pull all 1099s in one shot)."
   },
   {
     "url": "https://api.robinhood.com/documents/edocs_v2/custodial/",
@@ -2433,6 +2503,35 @@
     ],
     "fieldsSource": "verified",
     "fieldsShape": "object"
+  },
+  {
+    "url": "https://api.robinhood.com/margin/{account_number}/investing_info/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "account",
+      "margin"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "fields": [
+      "amount_borrowed",
+      "buying_power_with_margin",
+      "eligible_for_tiered_rates",
+      "gold_interest_exemption_amount",
+      "interest_exemption_amount",
+      "margin_available",
+      "margin_interest_rate",
+      "margin_limit_withheld_due_to_volatility",
+      "margin_used_including_cash_held",
+      "next_billing_date",
+      "projected_intraday_buying_power",
+      "projected_intraday_margin_available"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "object",
+    "source": "live-verified-2026-06-11 on the api host (200 with amount_borrowed/margin_interest_rate/next_billing_date). The margin-health read: answers 'am I borrowing, at what rate, billed when'. Sibling day_trades_card/ returns 404 (retired with the PDT elimination, FINRA 26-10)."
   },
   {
     "url": "https://api.robinhood.com/margin/{account_number}/upgrade_restrictions",
@@ -4421,6 +4520,22 @@
       "ref_id",
       "override_day_trade_checks"
     ],
+    "fields": [],
+    "fieldsSource": "undocumented"
+  },
+  {
+    "url": "https://api.robinhood.com/options/orders/{0}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "orders"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order.",
+    "summary": "Get a single options order by ID (state, legs, fills, price, quantity)",
     "fields": [],
     "fieldsSource": "undocumented"
   },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -38,6 +38,8 @@ import {
   getMarginHealth,
   tryBrokerageGetJson,
   gatedBrokerageWrite,
+  watchlistMutateItems,
+  createWatchlist,
   logTrade,
   placeEquityOrder,
   getOrderStatus,
@@ -3490,7 +3492,7 @@ program
     if (pendingRolls.length) process.stdout.write(`\n⏳ ${pendingRolls.length} pending kosher roll(s) — run roll-ledger list\n`);
   });
 
-const watchlist = new Command("watchlist").description("Inspect your custom watchlists (read)");
+const watchlist = new Command("watchlist").description("Inspect (read) and edit (add/remove/create, double-gated) your custom watchlists");
 
 watchlist
   .command("list")
@@ -3519,6 +3521,49 @@ watchlist
       rows.map((row: any) => ({ name: row.name, items: Number.isFinite(row.items) ? row.items : "—", emoji: row.emoji, id: row.id })),
       ["name", "items", "emoji", "id"]
     );
+  });
+
+watchlist
+  .command("add <list> <symbols...>")
+  .description("Add tickers to a custom watchlist (by name or id). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (list: string, symbols: string[], opts: { dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await watchlistMutateItems({ list, symbols, operation: "create", dryRun: opts.dryRun, liveWrite: opts.liveWrite });
+    if (out.result.dryRun && out.result.reason) process.stderr.write(`${out.result.reason}\n`);
+    if (opts.json) { printJson({ list: out.list, operation: "add", items: out.items, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
+    process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} add ${out.items.map((i) => i.symbol).join(", ")} -> "${out.list.display_name}" (${out.list.id})\n`);
+    if (out.result.body) process.stdout.write(`${out.result.body}\n`);
+  });
+
+watchlist
+  .command("remove <list> <symbols...>")
+  .description("Remove tickers from a custom watchlist (by name or id). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (list: string, symbols: string[], opts: { dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await watchlistMutateItems({ list, symbols, operation: "delete", dryRun: opts.dryRun, liveWrite: opts.liveWrite });
+    if (out.result.dryRun && out.result.reason) process.stderr.write(`${out.result.reason}\n`);
+    if (opts.json) { printJson({ list: out.list, operation: "remove", items: out.items, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
+    process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} remove ${out.items.map((i) => i.symbol).join(", ")} <- "${out.list.display_name}" (${out.list.id})\n`);
+    if (out.result.body) process.stdout.write(`${out.result.body}\n`);
+  });
+
+watchlist
+  .command("create <name>")
+  .description("Create a new custom watchlist. Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .option("--emoji <emoji>", "icon emoji for the list")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (name: string, opts: { emoji?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await createWatchlist({ displayName: name, iconEmoji: opts.emoji, dryRun: opts.dryRun, liveWrite: opts.liveWrite });
+    if (out.result.dryRun && out.result.reason) process.stderr.write(`${out.result.reason}\n`);
+    if (opts.json) { printJson({ displayName: name, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
+    process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} create watchlist "${name}"${opts.emoji ? ` ${opts.emoji}` : ""}\n`);
+    if (out.result.body) process.stdout.write(`${out.result.body}\n`);
   });
 
 program.addCommand(watchlist);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3241,12 +3241,13 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
-    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${r.shares.toFixed(6)} sh @ ~$${r.estimatedPrice.toFixed(2)} ≈ $${r.estimatedTotal.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
+    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });
@@ -3277,12 +3278,13 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
-    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${r.shares.toFixed(6)} sh @ ~$${r.estimatedPrice.toFixed(2)} ≈ $${r.estimatedTotal.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
+    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3241,13 +3241,14 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
     const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
-    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}${r.session ? `  [${r.session}]` : ""}\n`);
+    if (r.sessionWarning) process.stdout.write(`⚠️  ${r.sessionWarning}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });
@@ -3278,13 +3279,14 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
     const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
-    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}\n`);
+    process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}${r.session ? `  [${r.session}]` : ""}\n`);
+    if (r.sessionWarning) process.stdout.write(`⚠️  ${r.sessionWarning}\n`);
     if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -40,6 +40,8 @@ import {
   gatedBrokerageWrite,
   watchlistMutateItems,
   createWatchlist,
+  getWatchlistItems,
+  buyWatchlistBasket,
   logTrade,
   placeEquityOrder,
   getOrderStatus,
@@ -658,12 +660,16 @@ brokerage
     ...previous,
     value
   ])
+  .option("--query-param <name=value>", "append or replace a URL query-string value; repeatable", (value: string, previous: string[] = []) => [
+    ...previous,
+    value
+  ])
   .option("--body-json <json>", "JSON request body")
   .option("--dry-run", "print execution plan without sending")
   .option("--live-write", "permit a live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
   .option("--full", "print full response body instead of bounded preview")
   .option("--json", "emit JSON")
-  .action(async (query: string, options: { method?: string; param?: string[]; bodyJson?: string; dryRun?: boolean; liveWrite?: boolean; full?: boolean; json?: boolean }) => {
+  .action(async (query: string, options: { method?: string; param?: string[]; queryParam?: string[]; bodyJson?: string; dryRun?: boolean; liveWrite?: boolean; full?: boolean; json?: boolean }) => {
     const matches = filterBrokerageRoutes(loadBrokerageRoutes(), { query });
     const route = selectRouteByQueryAndMethod(matches, query, options.method);
     if (!route) {
@@ -683,6 +689,7 @@ brokerage
       route,
       method: options.method,
       params: parseParamAssignments(options.param),
+      query: parseParamAssignments(options.queryParam),
       body: parseJsonBody(options.bodyJson),
       dryRun: effectiveDryRun
     });
@@ -3564,6 +3571,52 @@ watchlist
     if (opts.json) { printJson({ displayName: name, dryRun: out.result.dryRun, status: out.result.status, body: out.result.body }); return; }
     process.stdout.write(`${out.result.dryRun ? "DRY-RUN" : out.result.status} create watchlist "${name}"${opts.emoji ? ` ${opts.emoji}` : ""}\n`);
     if (out.result.body) process.stdout.write(`${out.result.body}\n`);
+  });
+
+watchlist
+  .command("items <list>")
+  .description("List a custom watchlist's tickers resolved live — symbol, price, and an equity-buyable flag (by name or id). Read.")
+  .option("--json", "emit JSON")
+  .action(async (list: string, opts: { json?: boolean }) => {
+    const { list: wl, items } = await getWatchlistItems(list);
+    if (opts.json) { printJson({ list: wl, items }); return; }
+    process.stdout.write(`"${wl.display_name}" (${wl.id}) — ${items.length} item(s); ${items.filter((i) => i.tradable).length} equity-buyable\n`);
+    printTable(
+      items.map((i) => ({ symbol: i.symbol ?? "—", price: i.price ?? "—", type: i.object_type, buyable: i.tradable ? "yes" : "no", name: i.name ?? "" })),
+      ["symbol", "price", "type", "buyable", "name"]
+    );
+  });
+
+watchlist
+  .command("buy <list>")
+  .description("Buy $<amount> of EACH equity-buyable ticker in a custom watchlist (BP-aware basket). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .requiredOption("--account <number>", "account number to buy into")
+  .option("--amount <dollars>", "dollars per ticker (Robinhood minimum $1.00)", "1")
+  .option("--limit <n>", "cap the number of tickers attempted")
+  .option("--delay <ms>", "pace between live sends (429 burst guard)", "2500")
+  .option("--force", "skip per-order dedup + the after-hours fractional pre-flight guard")
+  .option("--dry-run", "plan only, send nothing")
+  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--json", "emit JSON")
+  .action(async (list: string, opts: { account: string; amount?: string; limit?: string; delay?: string; force?: boolean; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
+    const out = await buyWatchlistBasket({
+      list,
+      amount: Number(opts.amount ?? "1"),
+      accountNumber: opts.account,
+      limit: opts.limit ? Number(opts.limit) : undefined,
+      delayMs: opts.delay ? Number(opts.delay) : undefined,
+      force: opts.force,
+      dryRun: opts.dryRun,
+      liveWrite: opts.liveWrite
+    });
+    if (opts.json) { printJson(out); return; }
+    const tag = out.dryRun ? "DRY-RUN" : "LIVE";
+    process.stdout.write(`${tag} basket buy $${out.amountPerTicker.toFixed(2)} × each → ${out.account} — "${out.list.display_name}"\n`);
+    process.stdout.write(`items ${out.counts.items} | tradable ${out.counts.tradable} | attempted ${out.counts.attempted} | placed ${out.counts.placed} | skipped ${out.counts.skipped} | failed ${out.counts.failed} | blocked ${out.counts.blocked}${out.buyingPower !== undefined ? ` | BP $${out.buyingPower.toFixed(2)}` : ""}\n`);
+    printTable(
+      out.legs.map((l) => ({ symbol: l.symbol, status: l.status, total: l.estimatedTotal != null ? `$${l.estimatedTotal.toFixed(2)}` : "—", note: (l.reason ?? l.sessionWarning ?? "").slice(0, 80) })),
+      ["symbol", "status", "total", "note"]
+    );
   });
 
 program.addCommand(watchlist);

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -2478,6 +2478,145 @@ export async function logTrade(entry: Record<string, unknown>) {
   } catch { /* best-effort */ }
 }
 
+// ───────────────────────── Watchlist writes (shared CLI + MCP) ─────────────────────────
+// Robinhood custom watchlists ("Lists") are USER-level, NOT account-scoped — one set of lists per
+// login, shown across every account. The write surface is discovery/lists/* (captured + verified live
+// 2026-06-14 — the REAL endpoint is discovery/lists/items/, NOT the midlands/lists/items/ the route map
+// once assumed):
+//   add/remove items : POST   discovery/lists/items/   body { "<list_id>": [ {object_id, object_type, operation} ] }
+//   create a list    : POST   discovery/lists/         body { display_name, icon_emoji? }  (201)
+//   delete a list    : DELETE discovery/lists/{id}/    (204)
+// object_id is the instrument UUID (resolved from a ticker via instruments/?symbol=), never the symbol.
+// operation: "create" = add, "delete" = remove. Both ride the same items endpoint. As with every write
+// here, these go through gatedBrokerageWrite — dry-run unless BOTH gates (liveWrite + env) are set.
+
+export const DISCOVERY_LISTS_URL = "https://api.robinhood.com/discovery/lists/";
+export const DISCOVERY_LISTS_ITEMS_URL = "https://api.robinhood.com/discovery/lists/items/";
+
+/** Resolve an equity ticker to its Robinhood instrument UUID (instruments/?symbol=). */
+export async function resolveInstrumentId(
+  symbol: string,
+  deps: { getJson?: typeof brokerageGetJson } = {}
+): Promise<string> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const sym = symbol.trim().toUpperCase();
+  const inst = (await getJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol: sym })).results?.[0];
+  if (!inst?.id) throw new Error(`Symbol ${sym} not found (instruments/?symbol= returned no match).`);
+  return inst.id as string;
+}
+
+export interface WatchlistRef {
+  id: string;
+  display_name: string;
+  allowed_object_types: string[];
+}
+
+/** Resolve a custom watchlist by id or (case-insensitive) display_name. Reads owner_type=custom only. */
+export async function resolveWatchlist(
+  nameOrId: string,
+  deps: { getJson?: typeof brokerageGetJson } = {}
+): Promise<WatchlistRef> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const data = await getJson(DISCOVERY_LISTS_URL, {}, { owner_type: "custom" });
+  const lists: any[] = Array.isArray(data?.results) ? data.results : [];
+  const q = nameOrId.trim();
+  const match =
+    lists.find((l) => l.id === q) ??
+    lists.find((l) => String(l.display_name ?? "").toLowerCase() === q.toLowerCase());
+  if (!match) {
+    const names = lists.map((l) => l.display_name).filter(Boolean).join(", ") || "(none)";
+    throw new Error(`No custom watchlist matches "${nameOrId}". Existing custom lists: ${names}.`);
+  }
+  return { id: match.id, display_name: match.display_name, allowed_object_types: match.allowed_object_types ?? [] };
+}
+
+export interface WatchlistMutateInput {
+  /** List name or id. */
+  list: string;
+  symbols: string[];
+  /** "create" = add, "delete" = remove. */
+  operation: "create" | "delete";
+  /** Robinhood object type; defaults to "instrument" (equities). */
+  objectType?: string;
+  dryRun?: boolean;
+  liveWrite?: boolean;
+}
+
+export interface WatchlistMutateDeps {
+  getJson?: typeof brokerageGetJson;
+  write?: typeof gatedBrokerageWrite;
+  resolveInstrument?: (symbol: string) => Promise<string>;
+}
+
+/**
+ * Add or remove tickers in a custom watchlist. Resolves the list (by name/id) and each ticker (to an
+ * instrument UUID), builds the list-keyed batch body, and sends it through the double-gated write path.
+ */
+export async function watchlistMutateItems(input: WatchlistMutateInput, deps: WatchlistMutateDeps = {}) {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const write = deps.write ?? gatedBrokerageWrite;
+  const objectType = input.objectType ?? "instrument";
+  const resolveInstrument = deps.resolveInstrument ?? ((s: string) => resolveInstrumentId(s, { getJson }));
+  const symbols = input.symbols.map((s) => s.trim().toUpperCase()).filter(Boolean);
+  if (symbols.length === 0) throw new Error("No symbols given.");
+  const wl = await resolveWatchlist(input.list, { getJson });
+
+  const resolved: { symbol: string; object_id: string }[] = [];
+  for (const sym of symbols) {
+    const object_id = objectType === "instrument" ? await resolveInstrument(sym) : sym;
+    resolved.push({ symbol: sym, object_id });
+  }
+  const body = {
+    [wl.id]: resolved.map((r) => ({ object_id: r.object_id, object_type: objectType, operation: input.operation }))
+  };
+  const verb = input.operation === "create" ? "add" : "remove";
+  const result = await write({
+    url: DISCOVERY_LISTS_ITEMS_URL,
+    method: "POST",
+    body,
+    dryRun: input.dryRun,
+    liveWrite: input.liveWrite,
+    logContext: `watchlist ${verb}: ${symbols.join(",")} ${verb === "add" ? "->" : "<-"} ${wl.display_name}`
+  });
+  return { list: wl, operation: input.operation, items: resolved, body, result };
+}
+
+/** Create a new custom watchlist (POST discovery/lists/). Double-gated. */
+export async function createWatchlist(
+  input: { displayName: string; iconEmoji?: string; dryRun?: boolean; liveWrite?: boolean },
+  deps: { write?: typeof gatedBrokerageWrite } = {}
+) {
+  const write = deps.write ?? gatedBrokerageWrite;
+  const body: Record<string, unknown> = { display_name: input.displayName };
+  if (input.iconEmoji) body.icon_emoji = input.iconEmoji;
+  const result = await write({
+    url: DISCOVERY_LISTS_URL,
+    method: "POST",
+    body,
+    dryRun: input.dryRun,
+    liveWrite: input.liveWrite,
+    logContext: `watchlist create: ${input.displayName}`
+  });
+  return { displayName: input.displayName, body, result };
+}
+
+/** Delete a custom watchlist by id (DELETE discovery/lists/{id}/). Double-gated; irreversible. */
+export async function deleteWatchlist(
+  input: { id: string; dryRun?: boolean; liveWrite?: boolean },
+  deps: { write?: typeof gatedBrokerageWrite } = {}
+) {
+  const write = deps.write ?? gatedBrokerageWrite;
+  const result = await write({
+    url: "https://api.robinhood.com/discovery/lists/{id}/",
+    method: "DELETE",
+    params: { id: input.id },
+    dryRun: input.dryRun,
+    liveWrite: input.liveWrite,
+    logContext: `watchlist delete: ${input.id}`
+  });
+  return { id: input.id, result };
+}
+
 // ───────────────────────── Equity order engine (shared CLI + MCP) ─────────────────────────
 // The order-construction path is the dangerous one to duplicate (alignment invariant): the CLI
 // `buy`/`sell` commands and the MCP `robinhood_buy`/`robinhood_sell` tools both call

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -1478,12 +1478,16 @@ export function planBrokerageRequest(input: {
   route: BrokerageRoute;
   method?: string;
   params?: Record<string, string>;
+  /** Arbitrary ?key=value query params appended AFTER route matching (parity with planCryptoRequest).
+   *  The route map matches on the path, so query params are applied here — this is what lets a caller
+   *  read e.g. discovery/lists/items/?list_id=... through `brokerage execute` instead of a one-off script. */
+  query?: Record<string, string>;
   body?: unknown;
   dryRun?: boolean;
 }): PlannedBrokerageRequest {
   const params = input.params ?? {};
   const missingParams: string[] = [];
-  const url = input.route.url.replace(/\{([^}]+)\}/g, (_match, name: string) => {
+  let url = input.route.url.replace(/\{([^}]+)\}/g, (_match, name: string) => {
     // Alias-aware: a route's {account_number} token is satisfied by a legacy --param account=/num= and
     // vice-versa, so the standardized map and pre-rename callers both resolve.
     const value = resolveParamValue(params, name);
@@ -1493,6 +1497,11 @@ export function planBrokerageRequest(input: {
     }
     return encodeURIComponent(value);
   });
+  if (input.query && Object.keys(input.query).length > 0) {
+    const parsed = new URL(url);
+    for (const [k, v] of Object.entries(input.query)) parsed.searchParams.set(k, v);
+    url = parsed.toString();
+  }
   const method = (input.method ?? inferBrokerageMethod(input.route)).toUpperCase();
   const warnings = riskWarnings(input.route.risk);
   const mutatesAccount = riskMutatesAccount(input.route.risk);
@@ -2617,6 +2626,173 @@ export async function deleteWatchlist(
   return { id: input.id, result };
 }
 
+export interface WatchlistItem {
+  symbol: string | null;
+  name: string | null;
+  object_type: string;
+  object_id: string | null;
+  us_tradability: string | null;
+  state: string | null;
+  /** True only for an active, US-tradable EQUITY instrument — i.e. something a $X basket buy can hit.
+   *  Futures/index/currency_pair entries (allowed on a list) are NOT equity-buyable and resolve false. */
+  tradable: boolean;
+  price: number | null;
+}
+
+/**
+ * Read a custom watchlist's ITEMS resolved to tickers. The list-metadata read (`watchlist list`) returns
+ * sizes only; the items live at discovery/lists/items/?list_id=&owner_type=custom and come back already
+ * carrying symbol + tradability + a live price. This is the read half of "operate on a watchlist" — no
+ * one-off script required. Reads are live and free (no gate).
+ */
+export async function getWatchlistItems(
+  nameOrId: string,
+  deps: { getJson?: typeof brokerageGetJson } = {}
+): Promise<{ list: WatchlistRef; items: WatchlistItem[] }> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const wl = await resolveWatchlist(nameOrId, { getJson });
+  const data = await getJson(DISCOVERY_LISTS_ITEMS_URL, {}, { list_id: wl.id, owner_type: "custom" });
+  const results: any[] = Array.isArray(data?.results) ? data.results : [];
+  const items: WatchlistItem[] = results.map((r) => {
+    const object_type = String(r.object_type ?? "instrument");
+    return {
+      symbol: r.symbol ?? r?.item?.symbol ?? null,
+      name: r.name ?? null,
+      object_type,
+      object_id: r.object_id ?? r.id ?? null,
+      us_tradability: r.us_tradability ?? null,
+      state: r.state ?? null,
+      tradable: object_type === "instrument" && r.us_tradability === "tradable" && r.state === "active" && Boolean(r.symbol),
+      price: r.price != null && Number.isFinite(Number(r.price)) ? Number(r.price) : null
+    };
+  });
+  return { list: wl, items };
+}
+
+export interface WatchlistBasketBuyInput {
+  /** List name or id. */
+  list: string;
+  /** Dollars per ticker (Robinhood minimum is $1.00). */
+  amount: number;
+  accountNumber: string;
+  dryRun?: boolean;
+  liveWrite?: boolean;
+  /** Skip per-order dedup AND the after-hours fractional pre-flight guard. */
+  force?: boolean;
+  /** Cap the number of tickers attempted (after tradability + BP filtering). */
+  limit?: number;
+  /** Pace between LIVE sends to respect Robinhood's fractional burst limit (~9 then 429). Default 2500ms. */
+  delayMs?: number;
+}
+
+export interface WatchlistBasketLeg {
+  symbol: string;
+  status: "placed" | "queued" | "dry-run" | "skipped" | "failed" | "blocked";
+  reason?: string;
+  shares?: number;
+  estimatedTotal?: number;
+  orderId?: string | null;
+  evidenceConfirmed?: boolean | null;
+  sessionWarning?: string;
+}
+
+export interface WatchlistBasketBuyResult {
+  list: WatchlistRef;
+  account: string;
+  amountPerTicker: number;
+  buyingPower?: number;
+  dryRun: boolean;
+  counts: { items: number; tradable: number; attempted: number; placed: number; skipped: number; failed: number; blocked: number };
+  legs: WatchlistBasketLeg[];
+}
+
+/**
+ * Buy $amount of EACH tradable item in a custom watchlist — the "operate on a watchlist" execution half.
+ * Thin loop over the shared `placeEquityOrder` engine, so every per-ticker order inherits the OTC/
+ * fractional guard, dedup, ref_id idempotency, the after-hours pre-flight guard, trade-log + evidence,
+ * AND the double write-gate (dry-run unless liveWrite + ROBINHOOD_ALLOW_LIVE_WRITE=1). BP-aware: reads
+ * the account's buying power and only attempts what fits ($amount each), so an underfunded basket places
+ * the affordable prefix and reports the rest as skipped rather than hammering doomed orders.
+ */
+export async function buyWatchlistBasket(
+  input: WatchlistBasketBuyInput,
+  deps: { getJson?: typeof brokerageGetJson; placeOrder?: typeof placeEquityOrder; sleep?: (ms: number) => Promise<void> } = {}
+): Promise<WatchlistBasketBuyResult> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const placeOrder = deps.placeOrder ?? placeEquityOrder;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const amount = Number(input.amount);
+  if (!Number.isFinite(amount) || amount <= 0) throw new Error("amount must be a positive dollar value (Robinhood minimum is $1.00).");
+  const delayMs = input.delayMs ?? 2500;
+  const liveWrite = !input.dryRun && !!input.liveWrite;
+
+  const { list, items } = await getWatchlistItems(input.list, { getJson });
+  const tradable = items.filter((i) => i.tradable && i.symbol);
+  const legs: WatchlistBasketLeg[] = [];
+
+  // Non-equity / non-tradable members are skipped loudly (futures/index/currency_pair, halted, etc.).
+  for (const i of items.filter((x) => !x.tradable)) {
+    legs.push({ symbol: i.symbol ?? i.object_id ?? "?", status: "skipped", reason: `not equity-buyable (object_type=${i.object_type}, us_tradability=${i.us_tradability ?? "?"}, state=${i.state ?? "?"})` });
+  }
+
+  // BP-aware sizing: read buying power once and only attempt what fits.
+  let buyingPower: number | undefined;
+  try {
+    const bp = await getJson("https://api.robinhood.com/accounts/{num}/buying_power_breakdown", { num: input.accountNumber });
+    const v = Number(bp?.buying_power);
+    if (Number.isFinite(v)) buyingPower = v;
+  } catch { /* best-effort: if BP read fails, attempt all and let per-order rejection report */ }
+
+  let candidates = tradable;
+  if (input.limit && input.limit > 0) candidates = candidates.slice(0, input.limit);
+  let affordable = candidates;
+  if (buyingPower !== undefined) {
+    const maxN = Math.floor(buyingPower / amount);
+    if (candidates.length > maxN) {
+      affordable = candidates.slice(0, maxN);
+      for (const i of candidates.slice(maxN)) {
+        legs.push({ symbol: i.symbol as string, status: "skipped", reason: `insufficient buying power — basket of ${candidates.length}×$${amount.toFixed(2)}=$${(candidates.length * amount).toFixed(2)} exceeds BP $${buyingPower.toFixed(2)}; placed the first ${maxN}` });
+      }
+    }
+  }
+
+  let placed = 0;
+  for (let idx = 0; idx < affordable.length; idx++) {
+    const sym = affordable[idx].symbol as string;
+    let res: EquityOrderResult;
+    try {
+      res = await placeOrder({ symbol: sym, accountNumber: input.accountNumber, side: "buy", amount, liveWrite, force: input.force });
+    } catch (e: any) {
+      const msg = String(e?.message ?? e);
+      const nonBuyable = /fractional|otc/i.test(msg);
+      legs.push({ symbol: sym, status: nonBuyable ? "skipped" : "failed", reason: msg });
+      continue;
+    }
+    if (res.preflightBlocked) {
+      legs.push({ symbol: sym, status: "blocked", reason: res.sessionWarning, sessionWarning: res.sessionWarning });
+    } else if (res.dryRun) {
+      legs.push({ symbol: sym, status: "dry-run", shares: res.shares, estimatedTotal: res.estimatedTotal, sessionWarning: res.sessionWarning });
+    } else if (res.evidence?.confirmed === true) {
+      legs.push({ symbol: sym, status: "placed", shares: res.shares, estimatedTotal: res.estimatedTotal, orderId: res.orderId, evidenceConfirmed: true, sessionWarning: res.sessionWarning });
+      placed++;
+    } else {
+      legs.push({ symbol: sym, status: "failed", reason: res.evidence?.warning ?? res.sessionWarning ?? `live send returned ${res.httpStatus} — unconfirmed`, orderId: res.orderId, evidenceConfirmed: res.evidence?.confirmed ?? null, sessionWarning: res.sessionWarning });
+    }
+    if (liveWrite && delayMs > 0 && idx < affordable.length - 1) await sleep(delayMs);
+  }
+
+  return {
+    list, account: input.accountNumber, amountPerTicker: amount, buyingPower, dryRun: !liveWrite,
+    counts: {
+      items: items.length, tradable: tradable.length, attempted: affordable.length, placed,
+      skipped: legs.filter((l) => l.status === "skipped").length,
+      failed: legs.filter((l) => l.status === "failed").length,
+      blocked: legs.filter((l) => l.status === "blocked").length
+    },
+    legs
+  };
+}
+
 // ───────────────────────── Equity order engine (shared CLI + MCP) ─────────────────────────
 // The order-construction path is the dangerous one to duplicate (alignment invariant): the CLI
 // `buy`/`sell` commands and the MCP `robinhood_buy`/`robinhood_sell` tools both call
@@ -2753,11 +2929,14 @@ export interface EquityOrderResult {
   sessionWarning?: string;
   live: boolean;
   dryRun: boolean;
+  /** True when the engine PRE-EMPTED the send (nothing was attempted) — e.g. a fractional dollar-market
+   *  order outside regular hours, which Robinhood rejects (HTTP 500). `force` bypasses the guard. */
+  preflightBlocked?: boolean;
   refId: string;
   orderId: string | null;
   state: string | null;
   httpStatus: number | string;
-  result: Awaited<ReturnType<typeof gatedBrokerageWrite>>;
+  result?: Awaited<ReturnType<typeof gatedBrokerageWrite>>;
   /** Post-send order-history re-read (live sends only) — failure mode #20 encoded in code. */
   evidence?: OrderEvidence;
 }
@@ -2887,6 +3066,22 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
     } else if (isMarket) {
       sessionWarning = `Session is ${session}: a market order will QUEUE to the next regular session — it will not fill now. Use a limit order for extended-hours execution.`;
     }
+  }
+
+  // PRE-FLIGHT GUARD (failure mode: silent 500): a fractional dollar-MARKET order outside regular hours
+  // is REJECTED by Robinhood with HTTP 500 — it does NOT queue (fractional/market orders only fill in
+  // regular hours). Eating that raw 500 looks like an opaque failure. Pre-empt it with a clear,
+  // actionable result and send NOTHING. `force` bypasses (e.g. to capture the live error for research).
+  if (dollarBased && session && session !== "regular" && !input.force) {
+    const reason = `Pre-flight: a fractional $${input.amount} ${side} of ${symbol} can't be placed during ${session} — Robinhood rejects dollar/market orders outside regular hours (they only fill in the regular session). Wait for the regular session, or buy whole shares with a limit. Pass force to attempt anyway.`;
+    return {
+      symbol, account: input.accountNumber, side, shares,
+      estimatedPrice: last, estimatedTotal: shares * last,
+      type: "market", otcAutoLimit, dollarBased,
+      session, sessionWarning: reason,
+      live: false, dryRun: false, preflightBlocked: true,
+      refId, orderId: null, state: null, httpStatus: 0
+    };
   }
 
   const baseBody: Record<string, unknown> = {

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -2506,6 +2506,71 @@ export function filterRecentPending(orders: any[], side: "buy" | "sell", nowMs: 
   });
 }
 
+// ── Market-session awareness ────────────────────────────────────────────────────────────────────
+// The order body's `market_hours` and the "will it fill now or queue?" question both depend on the
+// CURRENT US-equity session. We derive it from Robinhood's OWN market-hours endpoint (holiday- and
+// half-day-aware — never a hardcoded 9:30–16:00 clock), with an ET-clock fallback only if that read
+// fails. Zayd Khan // cold // www.zayd.wtf
+export type MarketSession = "pre_market" | "regular" | "after_hours" | "closed";
+
+export interface MarketSessionInfo {
+  session: MarketSession;
+  /** Is today a trading day at all (false on weekends/holidays). */
+  isTradingDay: boolean;
+  /** True when authoritative RH hours were used; false when the ET-clock fallback was. */
+  authoritative: boolean;
+}
+
+/** ET calendar date `YYYY-MM-DD` for an epoch ms — DST-correct via Intl (en-CA yields ISO order). */
+export function etDateString(nowMs: number): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/New_York", year: "numeric", month: "2-digit", day: "2-digit"
+  }).format(new Date(nowMs));
+}
+
+/** ET-clock session heuristic — the fallback ONLY (no holiday/half-day awareness). */
+export function etClockSession(nowMs: number): MarketSession {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York", weekday: "short", hour: "2-digit", minute: "2-digit", hourCycle: "h23"
+  }).formatToParts(new Date(nowMs));
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  const wd = get("weekday");
+  if (wd === "Sat" || wd === "Sun") return "closed";
+  const mins = (Number(get("hour")) % 24) * 60 + Number(get("minute"));
+  if (mins >= 9 * 60 + 30 && mins < 16 * 60) return "regular";
+  if (mins >= 4 * 60 && mins < 9 * 60 + 30) return "pre_market";
+  if (mins >= 16 * 60 && mins < 20 * 60) return "after_hours";
+  return "closed";
+}
+
+/**
+ * Classify the current US-equity session from Robinhood's authoritative hours endpoint.
+ * Best-effort: any read failure falls back to the ET clock (still useful, just holiday-blind).
+ */
+export async function computeMarketSession(
+  deps: { getJson?: typeof brokerageGetJson; now?: () => number } = {}
+): Promise<MarketSessionInfo> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const nowMs = (deps.now ?? Date.now)();
+  let hours: any;
+  try {
+    hours = await getJson("https://api.robinhood.com/markets/{market}/hours/{date}/", {
+      market: "XNYS", date: etDateString(nowMs)
+    });
+  } catch {
+    return { session: etClockSession(nowMs), isTradingDay: etClockSession(nowMs) !== "closed", authoritative: false };
+  }
+  if (!hours?.is_open) return { session: "closed", isTradingDay: false, authoritative: true };
+  const t = (s?: string) => (s ? Date.parse(s) : NaN);
+  const open = t(hours.opens_at), close = t(hours.closes_at);
+  const extOpen = t(hours.extended_opens_at), extClose = t(hours.extended_closes_at);
+  let session: MarketSession = "closed";
+  if (Number.isFinite(open) && Number.isFinite(close) && nowMs >= open && nowMs < close) session = "regular";
+  else if (Number.isFinite(extOpen) && Number.isFinite(open) && nowMs >= extOpen && nowMs < open) session = "pre_market";
+  else if (Number.isFinite(close) && Number.isFinite(extClose) && nowMs >= close && nowMs < extClose) session = "after_hours";
+  return { session, isTradingDay: true, authoritative: true };
+}
+
 export interface EquityOrderInput {
   symbol: string;
   accountNumber: string;
@@ -2527,6 +2592,8 @@ export interface EquityOrderDeps {
   write?: typeof gatedBrokerageWrite;
   log?: typeof logTrade;
   now?: () => number;
+  /** Injectable session detector (tests pass a fake; default reads RH's live hours). */
+  getMarketSession?: typeof computeMarketSession;
 }
 
 export interface EquityOrderResult {
@@ -2541,6 +2608,10 @@ export interface EquityOrderResult {
   otcAutoLimit: boolean;
   /** True when the send used the native `dollar_based_amount` fractional body (dollar-notional market order on a fractional-tradable name) rather than a computed quantity. */
   dollarBased: boolean;
+  /** Detected US-equity session at send time (`regular`/`pre_market`/`after_hours`/`closed`); undefined if detection was skipped/failed. */
+  session?: MarketSession;
+  /** Set when the order will QUEUE rather than fill now (e.g. a fractional/market order placed outside regular hours). */
+  sessionWarning?: string;
   live: boolean;
   dryRun: boolean;
   refId: string;
@@ -2569,6 +2640,7 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
   const write = deps.write ?? gatedBrokerageWrite;
   const log = deps.log ?? logTrade;
   const now = deps.now ?? Date.now;
+  const getMarketSession = deps.getMarketSession ?? computeMarketSession;
   const symbol = input.symbol.toUpperCase();
   const side = input.side;
   if (!input.amount && !input.shares) throw new Error("Must specify amount (dollars) or shares (quantity)");
@@ -2659,6 +2731,25 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
   // collar is the one thing Robinhood rejects on the dollar path). Missing/one-sided book → the field
   // is omitted rather than sent as 0/NaN. Zayd Khan // cold // www.zayd.wtf
   const dollarBased = input.amount != null && !otc && isMarket;
+
+  // Session awareness — detect the CURRENT session so the order can (a) carry the right `market_hours`
+  // and (b) tell the operator whether it fills NOW or queues to the next regular session. Best-effort:
+  // a detection failure never blocks a send (session stays undefined, no warning). Fractional dollar
+  // orders are regular-hours-only, so their `market_hours` is always "regular_hours" — but when placed
+  // off-session we say so loudly, because "queued, not filled" is exactly the surprise to prevent.
+  let session: MarketSession | undefined;
+  let sessionWarning: string | undefined;
+  try {
+    session = (await getMarketSession({ getJson, now })).session;
+  } catch { /* best-effort — leave session undefined */ }
+  if (session && session !== "regular") {
+    if (dollarBased) {
+      sessionWarning = `Session is ${session}: fractional dollar orders fill ONLY in regular hours, so this will QUEUE to the next regular session — it will not fill now.`;
+    } else if (isMarket) {
+      sessionWarning = `Session is ${session}: a market order will QUEUE to the next regular session — it will not fill now. Use a limit order for extended-hours execution.`;
+    }
+  }
+
   const baseBody: Record<string, unknown> = {
     account: `https://api.robinhood.com/accounts/${input.accountNumber}/`,
     instrument: `https://api.robinhood.com/instruments/${iid}/`,
@@ -2739,6 +2830,8 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
     type: isMarket ? "market" : "limit",
     otcAutoLimit,
     dollarBased,
+    session,
+    sessionWarning,
     live: !result.dryRun, dryRun: result.dryRun, refId,
     orderId: (rb as any)?.id ?? (rb as any)?.url ?? null,
     state: (rb as any)?.state ?? null,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -2539,6 +2539,8 @@ export interface EquityOrderResult {
   type: "market" | "limit";
   /** True when an OTC order with no explicit limit was auto-limited at the marketable side (buy=ask, sell=bid). */
   otcAutoLimit: boolean;
+  /** True when the send used the native `dollar_based_amount` fractional body (dollar-notional market order on a fractional-tradable name) rather than a computed quantity. */
+  dollarBased: boolean;
   live: boolean;
   dryRun: boolean;
   refId: string;
@@ -2644,23 +2646,52 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
 
   // 5. Send (ref_id = broker-level idempotency; a 429 retries the SAME ref_id safely).
   const refId = `${symbol}-${input.accountNumber}-${now()}`;
+
+  // Body shape — two faithful forms, matching what robinhood.com itself sends:
+  //   • Dollar-notional MARKET order on a fractional-tradable (non-OTC) name → the NATIVE fractional
+  //     body: `dollar_based_amount {amount,currency_code}` (NOT a computed quantity) plus the live
+  //     bid/ask collar (`bid_price`/`ask_price`/`bid_ask_timestamp`), `market_hours`, and
+  //     `position_effect`. This is the exact body the web app posts for "$X of AAPL", and lets the
+  //     broker — not us — derive the fill quantity from the dollar amount. (Capture: 2026-06-14.)
+  //   • Everything else (whole shares, any limit order, OTC) → the quantity+price body. OTC and limit
+  //     orders have no native dollar form; shares are already exact.
+  // The collar fields come from the SAME live quote fetched above, so the timestamp is fresh (a stale
+  // collar is the one thing Robinhood rejects on the dollar path). Missing/one-sided book → the field
+  // is omitted rather than sent as 0/NaN. Zayd Khan // cold // www.zayd.wtf
+  const dollarBased = input.amount != null && !otc && isMarket;
+  const baseBody: Record<string, unknown> = {
+    account: `https://api.robinhood.com/accounts/${input.accountNumber}/`,
+    instrument: `https://api.robinhood.com/instruments/${iid}/`,
+    symbol,
+    type: isMarket ? "market" : "limit",
+    time_in_force: tif,
+    trigger: "immediate",
+    side,
+    order_form_version: "7",
+    ref_id: refId
+  };
+  let body: Record<string, unknown>;
+  if (dollarBased) {
+    const bid = Number(q?.bid_price);
+    const ask = Number(q?.ask_price);
+    body = {
+      ...baseBody,
+      dollar_based_amount: { amount: Number(input.amount).toFixed(2), currency_code: "USD" },
+      market_hours: "regular_hours",
+      position_effect: side === "buy" ? "open" : "close",
+      ...(Number.isFinite(bid) && bid > 0 ? { bid_price: bid.toFixed(2) } : {}),
+      ...(Number.isFinite(ask) && ask > 0 ? { ask_price: ask.toFixed(2) } : {}),
+      ...(q?.updated_at ? { bid_ask_timestamp: String(q.updated_at) } : {})
+    };
+  } else {
+    body = { ...baseBody, quantity: String(shares), price };
+  }
+
   const result = await write({
     skipTradeLog: true, // placeEquityOrder writes its own richer log entry below — avoid double-logging
     url: "https://api.robinhood.com/orders/",
     method: "POST",
-    body: {
-      account: `https://api.robinhood.com/accounts/${input.accountNumber}/`,
-      instrument: `https://api.robinhood.com/instruments/${iid}/`,
-      symbol,
-      type: isMarket ? "market" : "limit",
-      time_in_force: tif,
-      trigger: "immediate",
-      side,
-      quantity: String(shares),
-      price,
-      order_form_version: "7",
-      ref_id: refId
-    },
+    body,
     dryRun: !liveWrite,
     liveWrite
   });
@@ -2707,6 +2738,7 @@ export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrde
     estimatedPrice: last, estimatedTotal: shares * last,
     type: isMarket ? "market" : "limit",
     otcAutoLimit,
+    dollarBased,
     live: !result.dryRun, dryRun: result.dryRun, refId,
     orderId: (rb as any)?.id ?? (rb as any)?.url ?? null,
     state: (rb as any)?.state ?? null,

--- a/cli/test/dividends-documents-margin.test.ts
+++ b/cli/test/dividends-documents-margin.test.ts
@@ -237,7 +237,7 @@ describe("listDocuments — prefix type filter, tax-year filter, account filter"
   it("account filter is exact; records expose accountLast4 + downloadUrl; newest first", async () => {
     const r = await listDocuments({ accountNumber: "222222222" }, deps);
     expect(r.count).toBe(1);
-    expect(r.documents[0]).toMatchObject({ id: "d3", accountLast4: "6346", downloadUrl: "u3" });
+    expect(r.documents[0]).toMatchObject({ id: "d3", accountLast4: "2222", downloadUrl: "u3" });
     const all = await listDocuments({}, deps);
     expect(all.documents[0].id).toBe("d1");  // 2026-02-11 sorts first
   });
@@ -292,7 +292,7 @@ describe("getMarginHealth — multi-account scan with silent per-account degrada
   it("a 404 account degrades SILENTLY into skipped — the other accounts still report", async () => {
     const r = await getMarginHealth(undefined, deps);
     expect(r.accounts).toHaveLength(2);
-    expect(r.skipped).toEqual(["…6346"]);
+    expect(r.skipped).toEqual(["…2222"]);
     expect(r.scanned).toHaveLength(3);
     expect(r.warnings).toEqual([]);
   });

--- a/cli/test/equity-order.test.ts
+++ b/cli/test/equity-order.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   DEDUP_WINDOW_MS,
+  etClockSession,
+  computeMarketSession,
   extractOrderId,
   filterRecentPending,
   getOrderStatus,
-  placeEquityOrder
+  placeEquityOrder,
+  type MarketSession
 } from "../src/lib.js";
 
 // Golden-behavior tests for the shared equity-order engine — the single code path behind the CLI
@@ -22,6 +25,7 @@ interface Fix {
   pendingOrders: any[];
   writeResult: { status: number; dryRun: boolean; body: unknown };
   orderListThrows?: boolean;
+  session: MarketSession;
 }
 
 function makeDeps(overrides: Partial<Fix> = {}) {
@@ -30,11 +34,13 @@ function makeDeps(overrides: Partial<Fix> = {}) {
     quote: { last_trade_price: "100.00", instrument_id: "iid-123" },
     pendingOrders: [],
     writeResult: { status: 0, dryRun: true, body: "{}" },
+    session: "regular",
     ...overrides
   };
   const calls = { writes: [] as any[], logs: [] as any[], orderListQueries: 0 };
   const deps = {
     now: () => NOW,
+    getMarketSession: async () => ({ session: fix.session, isTradingDay: fix.session !== "closed", authoritative: true }),
     getJson: async (url: string) => {
       if (url.includes("instruments/?symbol")) return { results: fix.instrument ? [fix.instrument] : [] };
       if (url.includes("marketdata/quotes")) return { results: fix.quote ? [fix.quote] : [] };
@@ -298,6 +304,84 @@ describe("placeEquityOrder — live-send dedup & logging", () => {
     expect(calls.logs).toHaveLength(1);
     expect(calls.logs[0]).toMatchObject({ symbol: "AAPL", account: "A1", side: "buy", refId: `AAPL-A1-${NOW}`, orderId: "ord-1", httpStatus: 201 });
     expect(r).toMatchObject({ live: true, dryRun: false, orderId: "ord-1", state: "queued", httpStatus: 201 });
+  });
+});
+
+describe("placeEquityOrder — session awareness", () => {
+  it("regular hours: no queue warning, session attached", async () => {
+    const { deps } = makeDeps({ session: "regular", quote: { last_trade_price: "100.00", bid_price: "99.98", ask_price: "100.02", updated_at: "t", instrument_id: "iid-123" } });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+    expect(r.session).toBe("regular");
+    expect(r.sessionWarning).toBeUndefined();
+  });
+
+  it("off-session dollar order: market_hours stays regular_hours BUT a loud queue warning is attached", async () => {
+    for (const session of ["pre_market", "after_hours", "closed"] as MarketSession[]) {
+      const { deps, calls } = makeDeps({ session });
+      const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+      // Fractional dollar orders are regular-hours-only — the body value never changes…
+      expect(calls.writes[0].body).toMatchObject({ market_hours: "regular_hours", dollar_based_amount: { amount: "250.00", currency_code: "USD" } });
+      // …but the operator is told it will QUEUE, not fill now.
+      expect(r.session).toBe(session);
+      expect(r.sessionWarning).toMatch(/QUEUE to the next regular session/);
+      expect(r.sessionWarning).toContain(session);
+    }
+  });
+
+  it("off-session whole-share MARKET order warns it will queue (suggests a limit for extended hours)", async () => {
+    const { deps } = makeDeps({ session: "after_hours" });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", shares: 3 }, deps);
+    expect(r.sessionWarning).toMatch(/market order will QUEUE/);
+    expect(r.sessionWarning).toMatch(/limit order for extended-hours/);
+  });
+
+  it("off-session LIMIT order gets NO queue warning (a limit can rest/execute extended)", async () => {
+    const { deps } = makeDeps({ session: "after_hours" });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", shares: 3, limitPrice: 95.5 }, deps);
+    expect(r.session).toBe("after_hours");
+    expect(r.sessionWarning).toBeUndefined();
+  });
+
+  it("a failed session detection never blocks the send (session undefined, no warning)", async () => {
+    const { deps, calls } = makeDeps({ session: "closed" });
+    (deps as any).getMarketSession = async () => { throw new Error("hours endpoint down"); };
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+    expect(r.session).toBeUndefined();
+    expect(r.sessionWarning).toBeUndefined();
+    expect(calls.writes).toHaveLength(1); // order still planned
+  });
+});
+
+describe("computeMarketSession — authoritative RH hours classification", () => {
+  // 2026-06-12 hours (real shape): regular 13:30Z–20:00Z, extended 11:00Z–00:00Z(+1).
+  const HOURS = { is_open: true, opens_at: "2026-06-12T13:30:00Z", closes_at: "2026-06-12T20:00:00Z", extended_opens_at: "2026-06-12T11:00:00Z", extended_closes_at: "2026-06-13T00:00:00Z" };
+  const at = (iso: string) => ({ getJson: (async () => HOURS) as any, now: () => Date.parse(iso) });
+
+  it("classifies regular / pre_market / after_hours / closed from the live window", async () => {
+    expect((await computeMarketSession(at("2026-06-12T15:00:00Z"))).session).toBe("regular");
+    expect((await computeMarketSession(at("2026-06-12T12:00:00Z"))).session).toBe("pre_market");
+    expect((await computeMarketSession(at("2026-06-12T22:00:00Z"))).session).toBe("after_hours");
+    expect((await computeMarketSession(at("2026-06-12T02:00:00Z"))).session).toBe("closed");
+  });
+
+  it("a non-trading day (is_open:false) is closed and not a trading day", async () => {
+    const r = await computeMarketSession({ getJson: (async () => ({ is_open: false })) as any, now: () => Date.parse("2026-06-14T15:00:00Z") });
+    expect(r).toMatchObject({ session: "closed", isTradingDay: false, authoritative: true });
+  });
+
+  it("falls back to the ET clock (non-authoritative) when the hours read fails", async () => {
+    const r = await computeMarketSession({ getJson: (async () => { throw new Error("down"); }) as any, now: () => Date.parse("2026-06-12T15:00:00Z") });
+    expect(r.authoritative).toBe(false);
+    expect(r.session).toBe("regular"); // 15:00Z Fri = 11:00 ET → regular
+  });
+});
+
+describe("etClockSession — fallback heuristic", () => {
+  it("maps ET wall-clock windows and treats weekends as closed", () => {
+    expect(etClockSession(Date.parse("2026-06-12T15:00:00Z"))).toBe("regular");    // Fri 11:00 ET
+    expect(etClockSession(Date.parse("2026-06-12T12:00:00Z"))).toBe("pre_market"); // Fri 08:00 ET
+    expect(etClockSession(Date.parse("2026-06-12T22:30:00Z"))).toBe("after_hours");// Fri 18:30 ET
+    expect(etClockSession(Date.parse("2026-06-14T16:00:00Z"))).toBe("closed");     // Sunday
   });
 });
 

--- a/cli/test/equity-order.test.ts
+++ b/cli/test/equity-order.test.ts
@@ -315,17 +315,28 @@ describe("placeEquityOrder — session awareness", () => {
     expect(r.sessionWarning).toBeUndefined();
   });
 
-  it("off-session dollar order: market_hours stays regular_hours BUT a loud queue warning is attached", async () => {
+  it("off-session dollar order is PRE-EMPTED (Robinhood 500s it) — nothing sent, clear reason", async () => {
+    // Field-verified 2026-06-15: a fractional dollar-MARKET order placed after hours returns HTTP 500
+    // (it does NOT queue). The engine pre-empts the doomed send instead of eating a raw 500.
     for (const session of ["pre_market", "after_hours", "closed"] as MarketSession[]) {
       const { deps, calls } = makeDeps({ session });
       const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
-      // Fractional dollar orders are regular-hours-only — the body value never changes…
-      expect(calls.writes[0].body).toMatchObject({ market_hours: "regular_hours", dollar_based_amount: { amount: "250.00", currency_code: "USD" } });
-      // …but the operator is told it will QUEUE, not fill now.
+      expect(r.preflightBlocked).toBe(true);
+      expect(r.live).toBe(false);
+      expect(r.dryRun).toBe(false);
+      expect(calls.writes).toHaveLength(0); // NOTHING was sent
       expect(r.session).toBe(session);
-      expect(r.sessionWarning).toMatch(/QUEUE to the next regular session/);
+      expect(r.sessionWarning).toMatch(/can't be placed during/);
       expect(r.sessionWarning).toContain(session);
     }
+  });
+
+  it("force bypasses the off-session pre-flight guard and sends anyway (for capture/research)", async () => {
+    const { deps, calls } = makeDeps({ session: "after_hours" });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250, force: true }, deps);
+    expect(r.preflightBlocked).toBeFalsy();
+    expect(calls.writes[0].body).toMatchObject({ market_hours: "regular_hours", dollar_based_amount: { amount: "250.00", currency_code: "USD" } });
+    expect(r.sessionWarning).toMatch(/QUEUE to the next regular session/);
   });
 
   it("off-session whole-share MARKET order warns it will queue (suggests a limit for extended hours)", async () => {

--- a/cli/test/equity-order.test.ts
+++ b/cli/test/equity-order.test.ts
@@ -183,8 +183,9 @@ describe("placeEquityOrder — validation & guards", () => {
 });
 
 describe("placeEquityOrder — order body & dry-run semantics", () => {
-  it("builds the exact market-buy body: 4dp sizing, ref_id, order_form_version 7, gfd", async () => {
-    const { deps, calls } = makeDeps();
+  it("dollar-notional market buy uses the NATIVE dollar_based_amount body + live collar (web parity, not a computed quantity)", async () => {
+    // Fractional-tradable name, dollar sizing, market → the body robinhood.com itself posts.
+    const { deps, calls } = makeDeps({ quote: { last_trade_price: "100.00", bid_price: "99.98", ask_price: "100.02", updated_at: "2026-06-14T20:00:00Z", instrument_id: "iid-123" } });
     const r = await placeEquityOrder({ symbol: "aapl", accountNumber: "A1", side: "buy", amount: 250 }, deps);
 
     expect(calls.writes).toHaveLength(1);
@@ -200,18 +201,61 @@ describe("placeEquityOrder — order body & dry-run semantics", () => {
       time_in_force: "gfd",
       trigger: "immediate",
       side: "buy",
-      quantity: "2.5",
-      price: "100.00",
+      dollar_based_amount: { amount: "250.00", currency_code: "USD" },
+      market_hours: "regular_hours",
+      position_effect: "open",
+      bid_price: "99.98",
+      ask_price: "100.02",
+      bid_ask_timestamp: "2026-06-14T20:00:00Z",
       order_form_version: "7",
       ref_id: `AAPL-A1-${NOW}`
     });
-    expect(r).toMatchObject({ symbol: "AAPL", shares: 2.5, estimatedTotal: 250, type: "market", dryRun: true, live: false, refId: `AAPL-A1-${NOW}` });
+    // The native dollar body carries NO computed quantity/price — the broker derives the fill.
+    expect(w.body).not.toHaveProperty("quantity");
+    expect(w.body).not.toHaveProperty("price");
+    // The result still reports the informational share estimate for display.
+    expect(r).toMatchObject({ symbol: "AAPL", shares: 2.5, estimatedTotal: 250, type: "market", dollarBased: true, dryRun: true, live: false, refId: `AAPL-A1-${NOW}` });
   });
 
-  it("limit orders use gtc and the 2dp limit price", async () => {
+  it("a dollar-notional sell uses position_effect:close", async () => {
+    const { deps, calls } = makeDeps({ quote: { last_trade_price: "100.00", bid_price: "99.98", ask_price: "100.02", updated_at: "2026-06-14T20:00:00Z", instrument_id: "iid-123" } });
+    await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", amount: 50 }, deps);
+    expect(calls.writes[0].body).toMatchObject({ dollar_based_amount: { amount: "50.00", currency_code: "USD" }, position_effect: "close", side: "sell" });
+  });
+
+  it("the dollar body omits collar fields on a one-sided/dead book rather than sending 0/NaN", async () => {
+    const { deps, calls } = makeDeps({ quote: { last_trade_price: "100.00", bid_price: "0.00", ask_price: null, instrument_id: "iid-123" } });
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250 }, deps);
+    const b = calls.writes[0].body;
+    expect(b).toMatchObject({ dollar_based_amount: { amount: "250.00", currency_code: "USD" }, market_hours: "regular_hours", position_effect: "open" });
+    expect(b).not.toHaveProperty("bid_price");
+    expect(b).not.toHaveProperty("ask_price");
+    expect(b).not.toHaveProperty("bid_ask_timestamp");
+    expect(r.dollarBased).toBe(true);
+  });
+
+  it("SHARE sizing keeps the quantity+price body (no dollar form), gfd market", async () => {
     const { deps, calls } = makeDeps();
-    await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", shares: 3, limitPrice: 95.5 }, deps);
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", shares: 2.5 }, deps);
+    expect(calls.writes[0].body).toMatchObject({ type: "market", time_in_force: "gfd", quantity: "2.5", price: "100.00", order_form_version: "7" });
+    expect(calls.writes[0].body).not.toHaveProperty("dollar_based_amount");
+    expect(r.dollarBased).toBe(false);
+  });
+
+  it("limit orders use gtc and the 2dp limit price (quantity body, never dollar)", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", shares: 3, limitPrice: 95.5 }, deps);
     expect(calls.writes[0].body).toMatchObject({ type: "limit", time_in_force: "gtc", price: "95.50", side: "sell", quantity: "3" });
+    expect(calls.writes[0].body).not.toHaveProperty("dollar_based_amount");
+    expect(r.dollarBased).toBe(false);
+  });
+
+  it("a dollar-notional LIMIT order stays on the quantity+price body (dollar form is market-only)", async () => {
+    const { deps, calls } = makeDeps();
+    const r = await placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "buy", amount: 250, limitPrice: 99 }, deps);
+    expect(calls.writes[0].body).toMatchObject({ type: "limit", quantity: "2.5", price: "99.00" });
+    expect(calls.writes[0].body).not.toHaveProperty("dollar_based_amount");
+    expect(r.dollarBased).toBe(false);
   });
 
   it("dry-run never queries the pending-order list and never logs a trade", async () => {

--- a/cli/test/mcp-tool-count.test.ts
+++ b/cli/test/mcp-tool-count.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Tool-count guard. The MCP server's tool count is referenced by a hard number in SKILL.md,
+// AGENTS.md, and README — and it has rotted before (docs said 38 / 40+ / 48 while the source
+// registered 50; see claims-audit CNT-1/2/6). This test forces anyone who adds or removes a
+// tool to CONSCIOUSLY bump the expected count here, which is the reminder to also fix the docs.
+// It is deterministic and offline: it parses mcp/src/server.ts source, no server boot, no network.
+
+const EXPECTED_TOOL_COUNT = 53;
+const FAIL_MSG =
+  "tool count changed — update SKILL.md/AGENTS.md/README tool-count references and this test.";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const serverSrc = readFileSync(resolve(here, "../../mcp/src/server.ts"), "utf8");
+
+describe("MCP tool-count guard", () => {
+  it(`registers exactly ${EXPECTED_TOOL_COUNT} tools via registerTool`, () => {
+    const registerCalls = serverSrc.match(/\bregisterTool\s*\(/g) ?? [];
+    expect(registerCalls.length, FAIL_MSG).toBe(EXPECTED_TOOL_COUNT);
+  });
+
+  it(`declares exactly ${EXPECTED_TOOL_COUNT} distinct robinhood_* tool names`, () => {
+    const names = new Set(
+      [...serverSrc.matchAll(/"(robinhood_[a-z0-9_]+)"/g)].map((m) => m[1])
+    );
+    expect(names.size, FAIL_MSG).toBe(EXPECTED_TOOL_COUNT);
+  });
+
+  it("the registerTool count matches the distinct-name count (no dupes, no untitled regs)", () => {
+    const registerCalls = (serverSrc.match(/\bregisterTool\s*\(/g) ?? []).length;
+    const names = new Set(
+      [...serverSrc.matchAll(/"(robinhood_[a-z0-9_]+)"/g)].map((m) => m[1])
+    ).size;
+    expect(registerCalls, FAIL_MSG).toBe(names);
+  });
+});
+
+// Zayd Khan // cold // www.zayd.wtf

--- a/cli/test/mcp-tool-count.test.ts
+++ b/cli/test/mcp-tool-count.test.ts
@@ -3,15 +3,16 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
-// Tool-count guard. The MCP server's tool count is referenced by a hard number in SKILL.md,
-// AGENTS.md, and README — and it has rotted before (docs said 38 / 40+ / 48 while the source
-// registered 50; see claims-audit CNT-1/2/6). This test forces anyone who adds or removes a
-// tool to CONSCIOUSLY bump the expected count here, which is the reminder to also fix the docs.
+// Tool-count guard. The docs (SKILL.md / AGENTS.md / README) deliberately express the tool count
+// via `tools/list`, never a hard number — it rotted before when they hardcoded it (docs said
+// 38 / 40+ / 48 / 50 while the source kept growing; see claims-audit CNT-1/2/6). This test is the
+// SOLE sanctioned literal: it forces anyone who adds or removes a tool to CONSCIOUSLY bump the
+// expected count here — do NOT re-introduce a hardcoded count into the docs.
 // It is deterministic and offline: it parses mcp/src/server.ts source, no server boot, no network.
 
-const EXPECTED_TOOL_COUNT = 53;
+const EXPECTED_TOOL_COUNT = 55;
 const FAIL_MSG =
-  "tool count changed — update SKILL.md/AGENTS.md/README tool-count references and this test.";
+  "tool count changed — bump EXPECTED_TOOL_COUNT here (the only sanctioned hardcode). Docs express the count via `tools/list`, never a literal — do NOT add a number back to them.";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const serverSrc = readFileSync(resolve(here, "../../mcp/src/server.ts"), "utf8");

--- a/cli/test/watchlist-write.test.ts
+++ b/cli/test/watchlist-write.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  watchlistMutateItems,
+  createWatchlist,
+  resolveWatchlist,
+  DISCOVERY_LISTS_URL,
+  DISCOVERY_LISTS_ITEMS_URL
+} from "../src/lib.js";
+
+// Injected-deps, no live network. Pins the verified discovery/lists write contract (captured
+// 2026-06-14): items add/remove POST discovery/lists/items/ with a list-id-keyed batch body, and
+// create POST discovery/lists/. Asserts method + URL + body shape end-to-end through the engine.
+
+const LISTS_FIXTURE = {
+  results: [
+    { id: "LID-1", display_name: "Homie index", allowed_object_types: ["instrument"] },
+    { id: "LID-2", display_name: "Uranium", allowed_object_types: ["instrument"] }
+  ]
+};
+
+function fakeGetJson() {
+  return async (url: string) => {
+    if (url.includes("/discovery/lists/")) return LISTS_FIXTURE;
+    throw new Error(`unexpected getJson url: ${url}`);
+  };
+}
+
+describe("watchlist writes — discovery/lists contract", () => {
+  it("resolveWatchlist matches by case-insensitive display_name", async () => {
+    const wl = await resolveWatchlist("homie INDEX", { getJson: fakeGetJson() as any });
+    expect(wl.id).toBe("LID-1");
+    expect(wl.display_name).toBe("Homie index");
+  });
+
+  it("resolveWatchlist matches by id and throws on no match", async () => {
+    const wl = await resolveWatchlist("LID-2", { getJson: fakeGetJson() as any });
+    expect(wl.display_name).toBe("Uranium");
+    await expect(resolveWatchlist("nope", { getJson: fakeGetJson() as any })).rejects.toThrow(/No custom watchlist/);
+  });
+
+  it("ADD builds a list-keyed batch body with operation=create against discovery/lists/items/", async () => {
+    let captured: any;
+    const out = await watchlistMutateItems(
+      { list: "Homie index", symbols: ["googl", "msft"], operation: "create", dryRun: true },
+      {
+        getJson: fakeGetJson() as any,
+        resolveInstrument: async (s: string) => `uuid-${s.toUpperCase()}`,
+        write: async (opts: any) => { captured = opts; return { status: 200, dryRun: true }; }
+      }
+    );
+    expect(captured.method).toBe("POST");
+    expect(captured.url).toBe(DISCOVERY_LISTS_ITEMS_URL);
+    expect(captured.body).toEqual({
+      "LID-1": [
+        { object_id: "uuid-GOOGL", object_type: "instrument", operation: "create" },
+        { object_id: "uuid-MSFT", object_type: "instrument", operation: "create" }
+      ]
+    });
+    expect(out.items).toEqual([
+      { symbol: "GOOGL", object_id: "uuid-GOOGL" },
+      { symbol: "MSFT", object_id: "uuid-MSFT" }
+    ]);
+  });
+
+  it("REMOVE uses operation=delete on the same endpoint", async () => {
+    let captured: any;
+    await watchlistMutateItems(
+      { list: "LID-1", symbols: ["AAPL"], operation: "delete", dryRun: true },
+      {
+        getJson: fakeGetJson() as any,
+        resolveInstrument: async () => "uuid-AAPL",
+        write: async (opts: any) => { captured = opts; return { status: 200, dryRun: true }; }
+      }
+    );
+    expect(captured.body).toEqual({ "LID-1": [{ object_id: "uuid-AAPL", object_type: "instrument", operation: "delete" }] });
+  });
+
+  it("ADD rejects when no symbols are given", async () => {
+    await expect(
+      watchlistMutateItems(
+        { list: "Homie index", symbols: [], operation: "create", dryRun: true },
+        { getJson: fakeGetJson() as any, resolveInstrument: async () => "x", write: async () => ({ status: 200, dryRun: true }) }
+      )
+    ).rejects.toThrow(/No symbols/);
+  });
+
+  it("CREATE posts display_name (+ optional emoji) to discovery/lists/", async () => {
+    let captured: any;
+    await createWatchlist(
+      { displayName: "Og handle fund", iconEmoji: "🛰️", dryRun: true },
+      { write: async (opts: any) => { captured = opts; return { status: 201, dryRun: true }; } }
+    );
+    expect(captured.method).toBe("POST");
+    expect(captured.url).toBe(DISCOVERY_LISTS_URL);
+    expect(captured.body).toEqual({ display_name: "Og handle fund", icon_emoji: "🛰️" });
+  });
+});
+
+// Zayd Khan // cold // www.zayd.wtf

--- a/docs/index-options-1256-conclusion-2026-06-04.md
+++ b/docs/index-options-1256-conclusion-2026-06-04.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-04
 **Method:** read-only / dry-run only. `brokerage search`, authed GET via `scripts/rh-get.mjs`. No `--live-write`, no `ROBINHOOD_ALLOW_LIVE_WRITE`, no orders placed.
-**Account context used for chain reads:** `111111111` (individual/cash).
+**Account context used for chain reads:** `{account_number}` (individual/cash).
 
 ---
 
@@ -58,7 +58,7 @@ The equity `instruments/` table has **no row** for any index — consistent with
 This is the decisive endpoint:
 
 ```
-GET options/chains/?account_number=111111111&underlying_symbol=SPX
+GET options/chains/?account_number={account_number}&underlying_symbol=SPX
   → SPX  (id a9f69c4e-9393-4554-9849-271f0297e70b)  can_open_position=true
   → SPXW (id 7a7fa2b1-b65e-4c75-a0b3-7f62749bee0a)  can_open_position=true
 GET ...underlying_symbol=XSP → XSP (bf82fd28-...) can_open_position=true
@@ -132,7 +132,7 @@ Corrected position:
 
 ### Caveats / open items (not blockers to the core finding)
 
-1. **Account entitlement.** Chain reads returned `can_open_position: true` for account `111111111`, but actually opening index-option positions may require an options-trading approval tier / index-options entitlement. Not order-tested (read/dry-run only by instruction). Verify entitlement before assuming executability.
+1. **Account entitlement.** Chain reads returned `can_open_position: true` for account `{account_number}`, but actually opening index-option positions may require an options-trading approval tier / index-options entitlement. Not order-tested (read/dry-run only by instruction). Verify entitlement before assuming executability.
 2. **No explicit settlement/exercise-style field** is returned by RH's option-instrument payload; cash-settled/European is inferred from `underlying_type=index` + empty `underlying_instruments` (the standard CBOE structure for these products). A live order ticket or a placed-then-cancelled dry-run would corroborate, but was out of scope here.
 3. **Min-tick differs** from equity options: SPX uses `below_tick 0.05 / above_tick 0.10, cutoff 3.00` (vs SPY's 0.01/0.01/0.00). Any future order math must read the chain's `min_ticks` (the repo already warns about per-chain ticks).
 
@@ -158,7 +158,7 @@ node cli/dist/index.js brokerage search "SPX" --json    # → ETFs only
 node scripts/rh-get.mjs "https://api.robinhood.com/instruments/?symbol=SPX"   # → results: []
 
 # the real index chains
-node scripts/rh-get.mjs "https://api.robinhood.com/options/chains/?account_number=111111111&underlying_symbol=SPX"
+node scripts/rh-get.mjs "https://api.robinhood.com/options/chains/?account_number={account_number}&underlying_symbol=SPX"
 node scripts/rh-get.mjs "https://api.robinhood.com/options/chains/a9f69c4e-9393-4554-9849-271f0297e70b/"   # underlying_instruments: []
 node scripts/rh-get.mjs "https://api.robinhood.com/options/instruments/?chain_id=a9f69c4e-9393-4554-9849-271f0297e70b&expiration_dates=2026-06-18&state=active&type=call"  # underlying_type: index
 node scripts/rh-get.mjs "https://api.robinhood.com/marketdata/options/?ids=89a6f0e5-95f1-4f96-bc88-4c7f7cd25d4f"  # live mark/bid/ask/OI

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -91,6 +91,29 @@ Current counts after the 2026-06-03 options/account-settings hardening pass:
 - Reference impl: `cli/src/index.ts` `brokerage buy` / `brokerage search`, `scripts/equity-buy.mjs`,
   `scripts/rh-get.mjs`. Receipts (account numbers + order ids) stay in gitignored `info/`.
 
+## 2026-06-15 — Watchlist write surface (`discovery/lists/items/`)
+
+Captured live to wire `watchlist add/remove/create` across CLI + MCP. **Corrects a prior assumption**:
+the write endpoint is `discovery/lists/items/`, *not* `midlands/lists/items/` (the `midlands/lists/*`
+entries are unrelated read routes).
+
+1. **Discovery source.** CDP network capture on `robinhood.com` (Add-to-Lists modal → Save), then
+   independently API-verified each verb with the session bearer.
+2. **Request method + body shape.**
+   - Add/remove items — `POST https://api.robinhood.com/discovery/lists/items/`, body keyed by list id:
+     `{ "<list_id>": [ { "object_id": "<instrument_uuid>", "object_type": "instrument", "operation": "create" | "delete" } ] }`
+     (`create` = add, `delete` = remove; batches many items / many lists in one call). `object_id` is the
+     instrument UUID (resolve via `instruments/?symbol=`), never the ticker. `object_type` mirrors the
+     list's `allowed_object_types` (`instrument` for equities, `currency_pair`/`option_strategy` otherwise).
+   - Create list — `POST https://api.robinhood.com/discovery/lists/`, body `{ "display_name": "...", "icon_emoji"?: "..." }` → 201 (server defaults emoji 💡 + the standard equity `allowed_object_types`).
+   - Delete list — `DELETE https://api.robinhood.com/discovery/lists/{id}/` → 204.
+3. **Auth/session.** Web-session bearer (`Authorization: Bearer …`) + the standard web headers (origin/referer/`x-robinhood-web-app-version`). Same auth as every other brokerage write.
+4. **Response shape.** Items POST echoes the request body (200). Create returns the full list object (id, display_name, owner UUID, allowed_object_types, item_count). Lists are **user-level, not account-scoped** — no `account_number` anywhere.
+5. **Rate-limit behavior.** None observed across the capture + verification writes.
+6. **Risk classification.** `discovery/lists/items/` POST = `write-mutate` (reversible add/remove);
+   `discovery/lists/` POST + `discovery/lists/{id}/` PATCH/DELETE = `destructive`. All double-gated; safe
+   for `brokerage execute` only behind both write gates. Wired as first-class `watchlist add/remove/create`.
+
 When a new undocumented route is discovered, record:
 
 1. Discovery source.

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -58,8 +58,14 @@ Current counts after the 2026-06-03 options/account-settings hardening pass:
   `x-robinhood-web-app-version`, `x-hyper-ex: enabled`, web `user-agent`, `origin`/`referer` —
   and (2) `order_form_version: 7` + a live bid/ask collar
   (`bid_price`/`ask_price`/`bid_ask_timestamp`) + `market_hours` + `position_effect: open`.
-  Fractional buys use `dollar_based_amount: {amount, currency_code}` (server computes shares);
-  whole-share/OTC buys use `price` + `quantity`. Full body shapes in `AGENTS.md`.
+  Dollar-notional MARKET orders on a fractional-tradable name use the NATIVE
+  `dollar_based_amount: {amount, currency_code}` body — the broker derives the fill quantity, and
+  NO `quantity`/`price` is sent (matching robinhood.com exactly; engine parity landed 2026-06-14,
+  `placeEquityOrder`, pinned by `equity-order.test.ts`). The collar (`bid_price`/`ask_price`/
+  `bid_ask_timestamp`) is taken from the same live quote so it is fresh — a stale collar is the one
+  thing the dollar path rejects on; a one-sided/dead book omits the collar fields rather than sending
+  0/NaN. Whole-share, any LIMIT order, and OTC all use `price` + `quantity` (no native dollar form).
+  Full body shapes in `AGENTS.md`.
 - **OTC names** (`otc_market_tier` non-empty, `fractional_tradability: "position_closing_only"`,
   e.g. RNECY) **reject `type: market`** — buy AND sell are both supported, but only as whole
   shares with a marketable **limit** at the marketable side (buy at the ask, sell at the bid;

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -66,6 +66,14 @@ Current counts after the 2026-06-03 options/account-settings hardening pass:
   thing the dollar path rejects on; a one-sided/dead book omits the collar fields rather than sending
   0/NaN. Whole-share, any LIMIT order, and OTC all use `price` + `quantity` (no native dollar form).
   Full body shapes in `AGENTS.md`.
+- **Session awareness (`markets/{mic}/hours/{date}/`, verified live).** The engine classifies the
+  CURRENT US-equity session from Robinhood's own hours endpoint — `is_open` + `opens_at`/`closes_at`
+  (regular) + `extended_opens_at`/`extended_closes_at` — so it is holiday- and half-day-aware (never a
+  hardcoded 9:30–16:00 clock; the ET-clock heuristic is the fallback only). Fractional dollar orders
+  stay `market_hours: "regular_hours"` (the only value RH accepts there), but `placeEquityOrder` now
+  returns the detected `session` and a `sessionWarning` when a fractional/market order is placed
+  off-session — it will QUEUE to the next regular session, not fill now. Pinned by
+  `equity-order.test.ts` (`computeMarketSession` classification + the queue warnings). Landed 2026-06-14.
 - **OTC names** (`otc_market_tier` non-empty, `fractional_tradability: "position_closing_only"`,
   e.g. RNECY) **reject `type: market`** — buy AND sell are both supported, but only as whole
   shares with a marketable **limit** at the marketable side (buy at the ask, sell at the bid;

--- a/knowledge/accounts.md
+++ b/knowledge/accounts.md
@@ -60,9 +60,9 @@ Almost every Robinhood surface is account-scoped, and the bare endpoints + web U
 
 The headline balance is a mirage. On a **margin account, `cash` can be negative — that is the
 margin loan**, `equity` is net liquidation value, and the spendable figure is a small
-buying-power number that splits by purpose. Live example (2026-06-04, account …0497): equity
-≈ $[redacted], market value ≈ $[redacted], `cash` ≈ **$[redacted]** (margin debit), actual `buying_power` ≈
-**$[redacted]**.
+buying-power number that splits by purpose. On a margin account `equity` is the net liquidation
+value, `cash` can be **negative** (the margin loan), and the actual `buying_power` is typically a
+small fraction of either — read it live with `portfolio` / `margin`; never infer it from the headline.
 
 Read the family before sizing any order:
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -24,6 +24,7 @@ import {
   planBrokerageRequest,
   planCryptoRequest,
   resolveLiveWriteGate,
+  riskIsWrite,
   selectRouteByQueryAndMethod,
   brokerageGetJson,
   brokerageGetAllResults,
@@ -80,6 +81,18 @@ function jsonResponse(value: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }]
   };
+}
+
+// Make the execution state of a WRITE tool UNMISSABLE. The operator runs live by default, so the
+// dangerous failure is a dry-run response that READS like a success — an agent (or human) sees an
+// order id / 201 / plan and assumes it's done. `executed` + a loud `executionStatus` are hoisted to
+// the TOP of every write response so "nothing was sent" can never be mistaken for "done". Reads never
+// call this. Zayd Khan // cold // www.zayd.wtf
+function writeStatus(result: object, opts: { dryRun: boolean; reason?: string }) {
+  const executionStatus = opts.dryRun
+    ? `⚠️ DRY RUN — NOT EXECUTED. Nothing was sent to Robinhood; no order was placed, changed, or cancelled.${opts.reason ? ` Reason: ${opts.reason}` : ""} To execute for real: pass liveWrite:true AND set ROBINHOOD_ALLOW_LIVE_WRITE=1 in the server's environment (both gates, every call).`
+    : `✅ LIVE — SENT to Robinhood. A 2xx alone is not proof: confirm the order in order history (evidence.confirmed).`;
+  return jsonResponse({ executed: !opts.dryRun, executionStatus, ...result });
 }
 
 function toolAnnotations(readOnly: boolean, risk: RiskLevel) {
@@ -663,7 +676,10 @@ server.registerTool(
       dryRun: effectiveDryRun
     });
     const result = await executeBrokerageRequest(plan, { body, dryRun: effectiveDryRun, fullBody });
-    return jsonResponse(gate.forcedDryRun ? { ...result, liveWriteBlocked: gate.reason } : result);
+    const m = method?.toUpperCase();
+    const isWrite = riskIsWrite(route.risk) || (m !== undefined && m !== "GET" && m !== "HEAD");
+    if (isWrite) return writeStatus(result as object, { dryRun: effectiveDryRun, reason: gate.forcedDryRun ? gate.reason : undefined });
+    return jsonResponse(result);
   }
 );
 
@@ -778,7 +794,10 @@ server.registerTool(
       dryRun: effectiveDryRun
     });
     const result = await executeCryptoRequest(plan, { body, dryRun: effectiveDryRun, fullBody });
-    return jsonResponse(gate.forcedDryRun ? { ...result, liveWriteBlocked: gate.reason } : result);
+    const m = method?.toUpperCase();
+    const isWrite = riskIsWrite(route.risk) || (m !== undefined && m !== "GET" && m !== "HEAD");
+    if (isWrite) return writeStatus(result as object, { dryRun: effectiveDryRun, reason: gate.forcedDryRun ? gate.reason : undefined });
+    return jsonResponse(result);
   }
 );
 
@@ -920,7 +939,7 @@ server.registerTool(
         liveWrite: resolveLiveFlag(liveWrite, live), force: Boolean(force)
       });
       const { result: _raw, ...summary } = r;
-      return jsonResponse(summary);
+      return writeStatus(summary, { dryRun: summary.dryRun });
     } catch (e: any) {
       return jsonResponse({ error: e.message });
     }
@@ -950,7 +969,7 @@ server.registerTool(
         liveWrite: resolveLiveFlag(liveWrite, live), force: Boolean(force)
       });
       const { result: _raw, ...summary } = r;
-      return jsonResponse(summary);
+      return writeStatus(summary, { dryRun: summary.dryRun });
     } catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );
@@ -974,7 +993,7 @@ server.registerTool(
     try {
       // Shared engine (cancelOrder in lib.ts) — same path as the CLI `cancel` command and `panic`.
       const r = await cancelOrder({ idOrUrl: order_id, kind, liveWrite: resolveLiveFlag(liveWrite, live) });
-      return jsonResponse(r);
+      return writeStatus(r, { dryRun: r.dryRun, reason: (r as any).gateReason });
     } catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );
@@ -1010,8 +1029,10 @@ server.registerTool(
     annotations: toolAnnotations(false, "destructive")
   },
   async ({ account_number, liveWrite, live }) => {
-    try { return jsonResponse(await panicCancelAll({ accountNumber: account_number, liveWrite: resolveLiveFlag(liveWrite, live) })); }
-    catch (e: any) { return jsonResponse({ error: e.message }); }
+    try {
+      const r = await panicCancelAll({ accountNumber: account_number, liveWrite: resolveLiveFlag(liveWrite, live) });
+      return writeStatus(r, { dryRun: r.dryRun });
+    } catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );
 
@@ -1211,7 +1232,7 @@ server.registerTool(
       url = "https://api.robinhood.com/accounts/{account_number}/sweep_enrollment_state/"; method = "POST"; body = { sweep_enrollment_action: "unenroll" };
     }
     const r = await gatedBrokerageWrite({ url, method, params, body, dryRun, liveWrite });
-    return jsonResponse(r.dryRun && r.reason ? { ...r, liveWriteBlocked: r.reason } : r);
+    return writeStatus(r, { dryRun: r.dryRun, reason: r.reason });
   }
 );
 
@@ -1248,7 +1269,7 @@ server.registerTool(
       if (!inst) throw new Error(`No instrument for ${symbol}.`);
       const body = { account_number, amount: { amount: Number(amount).toFixed(2), currency_code: "USD" }, frequency: frequency ?? "weekly", investment_asset: { asset_id: inst.id, asset_symbol: inst.symbol, asset_type: "equity" }, source_of_funds: "buying_power", start_date: start_date ?? new Date(Date.now() + 86400000).toISOString().slice(0, 10), ref_id: randomUUID() };
       const r = await gatedBrokerageWrite({ url: LIST, method: "POST", body, dryRun, liveWrite });
-      return jsonResponse(r.dryRun && r.reason ? { ...r, liveWriteBlocked: r.reason } : r);
+      return writeStatus(r, { dryRun: r.dryRun, reason: r.reason });
     }
     if (!id) throw new Error(`${action} needs a schedule id.`);
     let body: unknown;
@@ -1260,7 +1281,7 @@ server.registerTool(
       body = b;
     } else { body = { state: "deleted" }; } // end
     const r = await gatedBrokerageWrite({ url: ITEM, method: "PATCH", params: { "0": id }, body, dryRun, liveWrite });
-    return jsonResponse(r.dryRun && r.reason ? { ...r, liveWriteBlocked: r.reason } : r);
+    return writeStatus(r, { dryRun: r.dryRun, reason: r.reason });
   }
 );
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -43,6 +43,8 @@ import {
   getMarginHealth,
   tryBrokerageGetJson,
   gatedBrokerageWrite,
+  watchlistMutateItems,
+  createWatchlist,
   placeEquityOrder,
   getOrderStatus,
   extractOrderId,
@@ -1333,6 +1335,78 @@ server.registerTool(
     annotations: toolAnnotations(true, "read")
   },
   async () => jsonResponse(await brokerageGetJson("https://api.robinhood.com/discovery/lists/?owner_type=custom", {}, { owner_type: "custom" }))
+);
+
+server.registerTool(
+  "robinhood_watchlist_add",
+  {
+    title: "Robinhood Watchlist — Add",
+    description: "Add tickers to a custom watchlist (resolved by name or id). Watchlists are user-level, not account-scoped. Reads resolve the list + each symbol's instrument UUID; the write is dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      list: z.string(),
+      symbols: z.array(z.string()).min(1),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ list, symbols, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await watchlistMutateItems({ list, symbols, operation: "create", dryRun, liveWrite });
+    return writeStatus(
+      { list: out.list, operation: "add", items: out.items, status: out.result.status, body: out.result.body },
+      { dryRun: out.result.dryRun, reason: out.result.reason }
+    );
+  }
+);
+
+server.registerTool(
+  "robinhood_watchlist_remove",
+  {
+    title: "Robinhood Watchlist — Remove",
+    description: "Remove tickers from a custom watchlist (resolved by name or id). Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      list: z.string(),
+      symbols: z.array(z.string()).min(1),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ list, symbols, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await watchlistMutateItems({ list, symbols, operation: "delete", dryRun, liveWrite });
+    return writeStatus(
+      { list: out.list, operation: "remove", items: out.items, status: out.result.status, body: out.result.body },
+      { dryRun: out.result.dryRun, reason: out.result.reason }
+    );
+  }
+);
+
+server.registerTool(
+  "robinhood_watchlist_create",
+  {
+    title: "Robinhood Watchlist — Create",
+    description: "Create a new custom watchlist (display_name, optional icon emoji). Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      name: z.string(),
+      emoji: z.string().optional(),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ name, emoji, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await createWatchlist({ displayName: name, iconEmoji: emoji, dryRun, liveWrite });
+    return writeStatus(
+      { displayName: name, status: out.result.status, body: out.result.body },
+      { dryRun: out.result.dryRun, reason: out.result.reason }
+    );
+  }
 );
 
 server.registerTool(

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -45,6 +45,8 @@ import {
   gatedBrokerageWrite,
   watchlistMutateItems,
   createWatchlist,
+  getWatchlistItems,
+  buyWatchlistBasket,
   placeEquityOrder,
   getOrderStatus,
   extractOrderId,
@@ -648,12 +650,13 @@ server.registerTool(
   "robinhood_brokerage_execute",
   {
     title: "Robinhood Brokerage Execute",
-    description: "Execute a Robinhood brokerage/account request using caller-owned auth env. Reads run live; writes are dry-run by default and require liveWrite=true (canonical; `live` accepted as alias) plus ROBINHOOD_ALLOW_LIVE_WRITE=1. Pass dryRun=true to force a non-sending plan. After any live write, append a trading-log.md entry (intent + strategy thread); brokerage order history is the only proof an order happened (order-evidence rule).",
+    description: "Execute a Robinhood brokerage/account request using caller-owned auth env. Reads run live; writes are dry-run by default and require liveWrite=true (canonical; `live` accepted as alias) plus ROBINHOOD_ALLOW_LIVE_WRITE=1. Pass dryRun=true to force a non-sending plan. Pass queryParams:[\"key=value\"] to append URL query params AFTER route matching (e.g. queryParams:[\"list_id=<id>\",\"owner_type=custom\"] for discovery/lists/items/) — the route map matches on the path, so this is how you read query-param endpoints without a one-off script. After any live write, append a trading-log.md entry (intent + strategy thread); brokerage order history is the only proof an order happened (order-evidence rule).",
     annotations: toolAnnotations(false, "write-or-sensitive"),
     inputSchema: z.object({
       query: z.string(),
       method: z.string().optional(),
       params: z.array(z.string()).default([]),
+      queryParams: z.array(z.string()).default([]),
       body: z.unknown().optional(),
       dryRun: z.boolean().default(false),
       liveWrite: z.boolean().optional(),
@@ -661,7 +664,7 @@ server.registerTool(
       fullBody: z.boolean().default(false)
     })
   },
-  async ({ query, method, params, body, dryRun, liveWrite: liveWriteParam, live, fullBody }) => {
+  async ({ query, method, params, queryParams, body, dryRun, liveWrite: liveWriteParam, live, fullBody }) => {
     const liveWrite = resolveLiveFlag(liveWriteParam, live);
     const matches = filterBrokerageRoutes(loadBrokerageRoutes(), { query });
     const route = selectRouteByQueryAndMethod(matches, query, method);
@@ -674,6 +677,7 @@ server.registerTool(
       route,
       method,
       params: parseParamAssignments(params),
+      query: parseParamAssignments(queryParams),
       body,
       dryRun: effectiveDryRun
     });
@@ -1410,6 +1414,45 @@ server.registerTool(
 );
 
 server.registerTool(
+  "robinhood_watchlist_items",
+  {
+    title: "Robinhood Watchlist — Items",
+    description: "Read a custom watchlist's tickers (resolved by name or id) live — each item's symbol, price, object_type, and an equity-buyable flag (active + US-tradable instrument). The READ half of operating on a watchlist; pair with robinhood_watchlist_buy. Live read; no gate.",
+    inputSchema: z.object({ list: z.string() }),
+    annotations: toolAnnotations(true, "read")
+  },
+  async ({ list }) => {
+    const { list: wl, items } = await getWatchlistItems(list);
+    return jsonResponse({ list: wl, count: items.length, tradable: items.filter((i) => i.tradable).length, items });
+  }
+);
+
+server.registerTool(
+  "robinhood_watchlist_buy",
+  {
+    title: "Robinhood Watchlist — Basket Buy",
+    description: "Buy $<amount> of EACH equity-buyable ticker in a custom watchlist (BP-aware basket; the EXECUTION half of operating on a watchlist). Loops the SAME shared placeEquityOrder engine per ticker — OTC/fractional guard, pending dedup, ref_id idempotency, the after-hours fractional pre-flight guard, trade-log + order-history evidence — and reads the account's buying power so it only attempts what fits ($amount each), skipping the rest with reasons rather than hammering doomed orders. Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    annotations: toolAnnotations(false, "write-mutate"),
+    inputSchema: z.object({
+      list: z.string(),
+      account_number: z.string(),
+      amount: z.number().positive().default(1),
+      limit: z.number().int().positive().optional(),
+      delayMs: z.number().int().nonnegative().optional(),
+      force: z.boolean().default(false),
+      dryRun: z.boolean().default(false),
+      liveWrite: z.boolean().optional(),
+      live: z.boolean().optional()
+    })
+  },
+  async ({ list, account_number, amount, limit, delayMs, force, dryRun, liveWrite: liveWriteParam, live }) => {
+    const liveWrite = resolveLiveFlag(liveWriteParam, live);
+    const out = await buyWatchlistBasket({ list, amount, accountNumber: account_number, limit, delayMs, force, dryRun, liveWrite });
+    return writeStatus(out, { dryRun: out.dryRun });
+  }
+);
+
+server.registerTool(
   "robinhood_options_enumerate",
   {
     title: "Robinhood Options Enumerate",
@@ -1603,6 +1646,20 @@ server.registerTool(
 );
 
 // Zayd Khan // cold // www.zayd.wtf
+
+// Live-write discoverability (the silent-dry-run trap): writes need ROBINHOOD_ALLOW_LIVE_WRITE=1 in THIS
+// server's environment (the second gate). If it's unset, every write tool dry-runs no matter what the
+// caller passes — and that used to fail silently (a re-registered MCP without the env looked healthy but
+// could never trade). Announce it loudly at startup so the gap is visible, not discovered mid-trade.
+if (process.env.ROBINHOOD_ALLOW_LIVE_WRITE !== "1") {
+  process.stderr.write(
+    "⚠️  robinhood-cli MCP: LIVE WRITES DISABLED — ROBINHOOD_ALLOW_LIVE_WRITE is not \"1\" in this server's " +
+    "environment, so EVERY write tool will dry-run regardless of liveWrite:true (the env is the second gate). " +
+    "Reads work normally. To enable real orders, re-register with the env gate and reload, e.g.:\n" +
+    "    claude mcp add robinhood-cli -s user -e ROBINHOOD_ALLOW_LIVE_WRITE=1 -- node <repo>/mcp/dist/server.js\n" +
+    "  then /reload-mcp (or restart the client).\n"
+  );
+}
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/scripts/equity-buy.mjs
+++ b/scripts/equity-buy.mjs
@@ -11,10 +11,10 @@
 //
 // Usage:
 //   node scripts/equity-buy.mjs --preflight
-//   node scripts/equity-buy.mjs --account 222222222 --symbol ARKG --dollars 5 [--live]
-//   node scripts/equity-buy.mjs --accounts 111111111,222222222,333333333 --symbol ARKG --dollars 5 [--live]
-//   node scripts/equity-buy.mjs --account 222222222 --all-positions --dollars 3 [--live]
-//   node scripts/equity-buy.mjs --account 222222222 --symbol RNECY --shares 1 [--live]   (OTC -> auto limit)
+//   node scripts/equity-buy.mjs --account <ACCOUNT_NUMBER> --symbol ARKG --dollars 5 [--live]
+//   node scripts/equity-buy.mjs --accounts <ACCOUNT_NUMBER>,<ACCOUNT_NUMBER>,<ACCOUNT_NUMBER> --symbol ARKG --dollars 5 [--live]
+//   node scripts/equity-buy.mjs --account <ACCOUNT_NUMBER> --all-positions --dollars 3 [--live]
+//   node scripts/equity-buy.mjs --account <ACCOUNT_NUMBER> --symbol RNECY --shares 1 [--live]   (OTC -> auto limit)
 //
 // Auth: ROBINHOOD_BROKERAGE_TOKEN (and optional ROBINHOOD_COOKIE / ROBINHOOD_CSRF)
 // from the repo .env. Versions/UA overridable via env (see WEB_HEADERS).

--- a/scripts/validate-strategies.mjs
+++ b/scripts/validate-strategies.mjs
@@ -3,7 +3,7 @@
 // options/orders/ endpoint: place a far-from-/valid limit (GTC) → confirm 201 + echoed legs →
 // cancel immediately. Market closed + instant cancel = nothing fills. Proves the order bodies for
 // a wide strategy set across multiple expirations. Read/preview spirit; everything is cancelled.
-//   node scripts/validate-strategies.mjs [SYMBOL=AAPL] [ACCOUNT=333333333]
+//   node scripts/validate-strategies.mjs [SYMBOL=AAPL] [ACCOUNT=<ACCOUNT_NUMBER>]
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
 const REPO = join(dirname(fileURLToPath(import.meta.url)), "..");
 (function(){const p=join(REPO,".env");if(!existsSync(p))return;for(const l of readFileSync(p,"utf8").split("\n")){const t=l.trim();if(!t||t.startsWith("#"))continue;const e=t.indexOf("=");if(e<0)continue;const k=t.slice(0,e).trim();let v=t.slice(e+1).trim();if((v.startsWith('"')&&v.endsWith('"'))||(v.startsWith("'")&&v.endsWith("'")))v=v.slice(1,-1);if(k&&process.env[k]===undefined)process.env[k]=v;}})();
 const H=()=>({accept:"application/json","content-type":"application/json","user-agent":process.env.ROBINHOOD_USER_AGENT??"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",origin:"https://robinhood.com",referer:"https://robinhood.com/","x-robinhood-api-version":"1.431.4","x-robinhood-web-app-version":process.env.ROBINHOOD_WEB_APP_VERSION??"2026.24.3589+55c48b8f7a1c","x-hyper-ex":"enabled",authorization:"Bearer "+process.env.ROBINHOOD_BROKERAGE_TOKEN});
-const SYM=(process.argv[2]||"AAPL").toUpperCase(); const ACCT=process.argv[3]||"333333333";
+const SYM=(process.argv[2]||"AAPL").toUpperCase(); const ACCT=process.argv[3]||"";
 const api=async(u,o={})=>{const r=await fetch(u,o);const t=await r.text();let b=null;try{b=t?JSON.parse(t):null}catch{b=t}return{status:r.status,body:b}};
 const oUrl=id=>`https://api.robinhood.com/options/instruments/${id}/`;
 const log=(...a)=>process.stderr.write(a.join(" ")+"\n");


### PR DESCRIPTION
## What

Adds the **read + execute halves of "operate on a custom watchlist"**, with full CLI ↔ MCP parity:

| Surface | CLI | MCP |
|---|---|---|
| Read a list's tickers (symbol, price, equity-buyable flag) | `watchlist items <list>` | `robinhood_watchlist_items` |
| Buy `$X` of **each** tradable item (BP-aware basket) | `watchlist buy <list> --account <n> --amount <$>` | `robinhood_watchlist_buy` |

Both are thin wrappers over new shared-engine fns in `cli/src/lib.ts` (`getWatchlistItems`, `buyWatchlistBasket`) — so the basket buy inherits the existing `placeEquityOrder` safeties (OTC/fractional guard, pending-dedup, `ref_id` idempotency, trade-log + order-history evidence) and the write gate, with **zero logic duplicated** across the two front doors (the alignment invariant).

`watchlist buy` is **buying-power-aware**: it reads the account's BP and only attempts what fits at `$amount` each, placing the affordable prefix and reporting the rest as `skipped` rather than hammering doomed orders.

## Holes this also closes

- **Query-param escape hatch.** `brokerage execute` (CLI `--query-param`) and `robinhood_brokerage_execute` (MCP `queryParams`) now thread arbitrary `?key=value` params through `planBrokerageRequest` (parity with `planCryptoRequest`). Reading e.g. `discovery/lists/items/?list_id=…&owner_type=custom` no longer requires a one-off script — verified `200 OK`.
- **After-hours fractional pre-flight guard.** A fractional dollar-market order placed outside regular hours returns HTTP `500` from Robinhood (it does **not** queue) — verified live. `placeEquityOrder` now pre-empts that doomed send with a clear, actionable result instead of eating a raw 500; `force` bypasses it for capture/research.

## Verification

- `watchlist items` — live read of a 12-ticker list, all resolved with price + tradability.
- `watchlist buy --dry-run` — surfaced **both** new safeties at once: BP-aware sizing (skipped the 12th when the basket exceeded BP) **and** the after-hours guard (blocked all when market closed).
- `watchlist buy --dry-run --force` — printed the sized order plans ($1 ea, fractional rounding).
- `brokerage execute … --query-param list_id=… --query-param owner_type=custom` → `200 OK`, returned all items.
- `pnpm build` (cli + mcp) clean; **`pnpm test` → 228 passed** (incl. the `mcp-tool-count` guard bumped to 55 for the 2 new tools, and the after-hours-guard test).

## Notes

- **Based on `feat/watchlist-writes` (#3)** — depends on `resolveWatchlist` / `DISCOVERY_LISTS_ITEMS_URL` from that branch. Stacked PR; merge #3 first.
- **Gate model is out of scope here** — this PR keeps the existing gate untouched; the live-write gate change is **#4**.
- No account numbers, balances, or tokens in the diff.
