### PR TITLE
docs: preserve the 2026-06-13 roadmap expansion (ideas.md + tasks.md)

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -24,3 +24,69 @@ Consolidated 2026-06-11. Grind line by line; promote winners into tasks.md.
 - MLX finetunes for finance + this tool (per the README Soon(tm) note)
 - Dividend-account designation flow once account-rename surface is mapped (empty account -> income machine)
 - MCP resources (in addition to tools) for knowledge modules, so clients that render resources get the library natively
+
+## ====== 2026-06-13 expansion pass ======
+New idea batch. Same doctrine: dollars not percents, descriptive not prescriptive on risk.
+Anything that needs a route we haven't captured is flagged "(needs surface mapping)".
+
+### Beginner empowerment / education
+- `coach explain <position|order>` — plain-English breakdown of any held position/order with the dollar math shown: what it is, what you paid, what you'd make/lose, the one risk to watch. The flagship "I'm new, what am I even holding" command.
+- `define <greek|term>` — micro-glossary at the prompt: "what is theta on THIS position" answers in dollars/day for the actual contract, not a textbook abstraction. Pulls from knowledge/greeks.md + live marketdata.
+- `learn` / guided first trade — a stepped, dry-run-only walkthrough that builds one real order with the user, narrating each field (side, effect, limit, TIF) and never lifting the gates. Graduation = they understand the confirmation contract.
+- `sandbox` / paper mode — a persistent local dry-run ledger: place make-believe orders against live quotes, track fake P&L in dollars over time, no account ever touched. Learning reps without risk.
+- `riskcheck` (beginner framing) — before a beginner's order, surface the three plain-English questions (max loss in dollars, can you be assigned, what happens at expiration) as friction, answered for the specific contract.
+- `glossary` resource — ship knowledge/ definitions as an MCP resource + a `glossary` command so a cold user can browse terms without leaving the tool.
+- "explain my fill" — after any fill, a one-paragraph plain-English recap of what just happened and what changed in the account (ties into the existing post-send evidence).
+
+### Pro / aggressive workflows
+- `ticket` — fast multi-leg ticket builder: compose a 2-4 leg spread by strikes in one line, auto-enumerate UUIDs, dry-run quote + payoff, ready to gate-send. The pro's speed path over hand-built bodies.
+- `scan spreads <SYM>` — vertical/credit-spread scanner across a chain: rank candidate short/long strike pairs by credit-per-width, breakeven, and net Greeks in dollars. (needs no new surface; loops existing chain reads.)
+- `ivrank <SYM>` — IV rank / IV percentile read for sizing premium-selling (high IV = richer credit). (needs surface mapping — historical IV series endpoint not yet captured; interim: compute from option chain IVs vs a stored rolling window.)
+- `termstructure <SYM>` — front-vs-back-month IV term structure for calendars/diagonals: where's the kink. (needs surface mapping for historical IV; current-snapshot version works off live chains.)
+- `pinradar` — near-expiry pin/assignment radar: for every short leg within N days, distance to strike in dollars, ITM/OTM flag, ex-div-before-expiry warning, "this will likely assign" call. Aggressive-trader's expiry-day cockpit.
+- `0dte` guardrail mode — a 0DTE-aware wrapper: enforces a same-day-close reminder, flags gamma/theta cliff in dollars, and refuses to silently roll a 0DTE into overnight risk without an explicit ack.
+- `ladder` — build/quote a strike or expiry ladder (e.g. a CSP ladder across 3 strikes) in one command, each rung dry-run-quoted; pairs with the order-presets idea.
+- `delta target` — "get me ~30-delta" resolver: name a target delta, it finds the nearest strike on the chain and dry-runs it. The way pros actually pick strikes.
+
+### Risk & safety
+- `risk` — one-shot portfolio risk scan (already in pool; promote): portfolio max loss in dollars, total assignment exposure, undercovered short calls, margin-call distance, expiry cluster.
+- `exposure` — concentration by underlying/sector + portfolio-wide net Greeks in dollars (already in pool; promote).
+- `margin distance` — for margin accounts, dollars-to-maintenance-call and the price move that triggers it, per account.
+- Notional guardrails — per-order and per-session dollar caps with an explicit `--override`; also a per-underlying concentration cap warning. (Already a task; idea-side note: scale the cap suggestion to buying power.)
+- Scaled "are you sure" friction — confirmation friction proportional to trade dollar size: a $20 order one-taps, a $5,000 order forces a re-typed confirmation of the resolved account+symbol+side+qty+price.
+- `circuit breaker` — a session kill-switch: if realized day loss crosses a user-set dollar threshold, refuse further opens (reads/closes still allowed) until explicitly reset.
+- Naked-exposure double-gate — any order classified naked/undefined-risk gets an extra, separate ack beyond the two write gates, echoing "this is undefined risk."
+
+### Income & tax
+- `income` — combined income view: dividends + option premium collected, by day/wk/mo/qtr/yr, in dollars (already in pool; promote, now spanning both engines).
+- `harvest` — tax-loss-harvest candidate finder mapped to LIVE lots: rank unrealized losers by harvestable dollars, flag the 61-day wash window both directions, suggest correlated-not-identical replacements. Wires knowledge/tax-loss-harvesting.md to real positions.
+- `washradar` — standalone wash-sale radar: scan recent fills + open lots for any buy within 30 days of a realized loss (or pending sell that would trip it), in dollars disallowed.
+- `holding-period` flags — §1256 and LEAPS holding-period surfacing: which lots are near the 1-year short→long-term line or a tax-year boundary, and the deferral that changes the bracket. (Edge-case-only, per doctrine.)
+- `taxplan` — year-end tax planning mode: realized gains/losses YTD in dollars, harvestable losses available, §1256 60/40 positions, suggested December actions (gated, dry-run).
+- Premium-income sustainability note — on weekly-payer / covered-call income, annotate ROC vs real yield and NAV-erosion risk in dollars (extends dividend-investing.md framing).
+
+### Research & memory
+- `brief signals <SYM|portfolio>` — signal digest for held/hotlist names: RH midlands news + ratings + crowd tags, summarized, tagged by the sourcing ladder (pulse vs confirmer). Confirmer-layer, clearly labeled.
+- `calendar` — upcoming events for HELD names: expirations, ex-div dates (CC assignment risk), earnings (already in pool; promote, now driving the morning brief).
+- `thesis track` — ball-knowledge-driven thesis tracker: for each thesis entry tied to a ticker, show the live position/P&L in dollars and whether the thesis is playing out, append-only notes.
+- `hotlist alert` — when a hotlist name moves past a user-set dollar/level trigger or has an event today, surface it in the brief/recap. (Alert delivery local; price triggers via existing quotes.)
+- Auto-journal nudge — after a live fill, prompt a `review note` at the moment of the trade (already in pool; promote, tie to evidence step).
+- `review tape <SYM>` — "study the tape" enhancement: join round-trips + film-study notes + the original ball-knowledge thesis into one retro per name, P&L in dollars, what-I-said-vs-what-happened.
+- `digest` of institutional outlook — periodic pull of the regime/CMA layer (docs/institutional-outlook), framed as info-not-mandate, mapped onto held sectors.
+
+### Automation & scheduled modes
+- `brief` / morning brief — portfolio day-delta, pending rolls, today's calendar events (ex-div/earnings/expiry), hotlist movers, all in dollars (already in pool; promote as the anchor scheduled mode).
+- `recap` / end-of-day — what filled, realized + unrealized day P&L in dollars by underlying, what expires tomorrow, journaling nudge for any new fills.
+- Pending-roll Monday reminder — for kosher rolls staged Friday (close now / open next business day), a Monday-morning "open the second leg, recheck settled cash + fresh bid/ask" prompt. Closes the T+1 loop in roll-ledger.
+- Recurring-buy intelligence — analyze recurring schedules vs buying power and dollar pace; flag schedules that will drain the account, suggest sizing. Extends the existing recurring engine read.
+- `watch <SYM> <trigger>` — watch-and-alert: poll a quote/level and notify on a dollar/percent move or an option mark crossing. (needs surface mapping for native RH alerts; interim: local polling loop.)
+- `order watch` — place → poll → report fill/reject (already a task; idea-side: extend to multi-leg fills).
+- Scheduled health scan — daily `risk`/`exposure` snapshot appended to a local log so drift is visible over time (margin distance, concentration, expiry clusters).
+
+### Platform / reach
+- Strategy bots on the hardened api-map — supervised, gated automation primitives (already in pool; idea-side: ship the `circuit breaker` + notional caps as the safety substrate bots build on).
+- Multi-account orchestration — `--all-accounts` aware variants of risk/exposure/income/brief that roll up across every owned account in dollars, with per-account breakdown. (Wheel/positions already cross-account; generalize.)
+- Export / reporting — `export` to CSV/JSON for positions, fills, income, realized P&L (tax-ready); a printable monthly statement. (Already a carried task; broaden to income + tax outputs.)
+- Dividend-account designation flow — once account-rename surface is mapped, designate an empty account as the income machine (already in pool; depends on the CDP account-management capture task).
+- MCP resources for the knowledge library — expose knowledge/*.md as MCP resources so resource-rendering clients get the library natively, plus the glossary (already in pool; pair with `glossary`).
+- Trade-card / success-graphic generator — HTML render of a completed play (entry/exit, dollar P&L, payoff diagram, thread context) as a shareable card (already in pool; idea-side: drive it from the review/round-trip join so it's evidence-backed).

--- a/tasks.md
+++ b/tasks.md
@@ -38,3 +38,56 @@ Consolidated 2026-06-11. ONE list to grind line by line. Supersedes local/tasks.
 - [ ] Export command (T9) / IPO surface (T11) / CLI-MCP parity audit (T12) / global CLAUDE.md Twitter line (T14) — carried from local
 - [ ] local/ restructure decision: keep local/ strictly personal (thesis, private captures); project work lives here
 - [ ] GitHub SEO remainder (topics, social preview)
+
+## Backlog additions (2026-06-13 pass)
+Scoped from the 2026-06-13 ideas.md expansion. Unchecked, additive; existing tasks untouched.
+
+### Beginner empowerment
+- [ ] `coach explain <position|order>` command (cli/src/index.ts + new lib/coach.ts) — plain-English position/order breakdown with dollar math; pulls live positions + marketdata + knowledge/greeks.md; read-only. MCP twin `robinhood_coach`.
+- [ ] `define <greek|term>` command — per-position dollar-denominated Greek/term explainer off live marketdata + knowledge/greeks.md; no new surface.
+- [ ] `learn` guided first-trade walkthrough (cli/src/index.ts) — stepped dry-run-only order builder, narrates each field, gates stay on; reuses placeEquityOrder/options dry-run path.
+- [ ] `sandbox` paper-trade mode — local JSON ledger of make-believe orders vs live quotes, fake P&L in dollars; never touches account. New lib/sandbox.ts + sandbox-ledger.json (gitignored).
+- [ ] Ship knowledge/ glossary as `glossary` command + MCP resource (mcp/src/server.ts resources) — depends on MCP-resources task below.
+
+### Pro / aggressive
+- [ ] `ticket` multi-leg fast builder (cli/src/index.ts + lib reusing strategy-quote) — one-line strikes → auto-enumerate UUIDs → dry-run quote + payoff → gate-ready body. No new surface.
+- [ ] `scan spreads <SYM>` vertical scanner — rank strike pairs by credit-per-width/breakeven/net-Greeks in dollars; loops existing options chain reads. No new surface.
+- [ ] `pinradar` near-expiry assignment radar (cli + MCP) — short legs within N days: distance-to-strike in dollars, ITM/OTM, ex-div-before-expiry flag. Uses options positions + marketdata. No new surface.
+- [ ] `delta target` strike resolver — name target delta → nearest chain strike → dry-run. No new surface.
+- [ ] `ladder` strike/expiry ladder builder + quoter — one command, each rung dry-run-quoted. Builds on `ticket`.
+- [ ] `ivrank <SYM>` / `termstructure <SYM>` — needs CDP/probe capture of a historical IV series endpoint (surface mapping); ship snapshot-only version (current-chain IVs) first.
+- [ ] `0dte` guardrail wrapper — same-day-close reminder + gamma/theta-cliff dollar flag + refuse silent overnight roll. Layer over options order path in lib.
+
+### Risk & safety
+- [ ] `risk` portfolio risk scan (cli/src/index.ts + lib/risk.ts; MCP `robinhood_risk`) — portfolio max loss, assignment exposure, undercovered shorts, margin-call distance, expiry clusters, all in dollars. Composes positions + options + marketdata + buying-power.
+- [ ] `exposure` concentration + portfolio net Greeks in dollars (cli + MCP) — by underlying/sector; reuses risk.ts joins.
+- [ ] Notional guardrails in the shared order engine (placeEquityOrder + options order path in cli/src/lib.ts) — per-order & per-session $ caps + `--override`; scale suggestion to buying power. (Overlaps existing "Notional guardrails" Now item — fold together.)
+- [ ] Scaled confirmation friction — re-typed account+symbol+side+qty+price confirmation above a $ threshold; in the confirmation-contract path (lib + MCP gate).
+- [ ] `circuit breaker` session kill-switch — refuse opens after a user-set realized-day-loss $ threshold; reads/closes allowed; state in a local session file. Hooks the order engine.
+
+### Income & tax
+- [ ] `income` combined dividends + premium-collected view (cli + MCP `robinhood_income`) — by day/wk/mo/qtr/yr in dollars; joins dividends engine + options fills (premium = sell-to-open credits).
+- [ ] `harvest` TLH candidate finder mapped to live lots (cli + MCP) — rank unrealized losers by harvestable $, flag 61-day wash window, suggest correlated replacements; wires knowledge/tax-loss-harvesting.md. Needs per-lot cost basis read (verify positions/lots route; may need surface mapping).
+- [ ] `washradar` wash-sale scan — buys within 30d of a realized loss (or pending sell that trips it), $ disallowed; off history + open lots.
+- [ ] `taxplan` year-end mode — realized YTD gain/loss, harvestable losses, §1256 positions, suggested December actions (dry-run). Depends on `harvest` + documents/tax engine.
+
+### Research & memory
+- [ ] `calendar` held-name events command (cli + MCP) — expirations + ex-div + earnings for held names; drives the morning brief. Uses options positions + marketdata/earnings/ + corp-actions reads.
+- [ ] `brief signals` digest — RH midlands news/ratings/tags for held+hotlist, labeled by sourcing ladder; confirmer-layer. Reads only.
+- [ ] `thesis track` — ball-knowledge ticker theses joined to live position/P&L in dollars; append-only notes. Reads ball-knowledge.md + positions.
+- [ ] `review tape <SYM>` — join round-trips + trade-notes + ball-knowledge thesis into one per-name retro in dollars. Extends existing `review`.
+- [ ] Auto-journal nudge after live fills — prompt `review note` at the evidence step (post-send path in lib + MCP). (Already in ideas; small wiring task.)
+
+### Automation & scheduled
+- [ ] `brief` morning command (cli + MCP `robinhood_brief`) — day-delta + pending rolls + today's calendar + hotlist movers in dollars. Composes portfolio + roll-ledger + `calendar` + hotlist.
+- [ ] `recap` end-of-day command — fills, day P&L by underlying in dollars, tomorrow's expirations, journaling nudge. Composes history + portfolio + `calendar`.
+- [ ] Pending-roll Monday reminder — surface staged kosher rolls from roll-ledger needing the second (open) leg; recheck settled cash + fresh bid/ask. Extends roll-ledger; ties to scheduled-tasks if available.
+- [ ] Recurring-buy intelligence — flag recurring schedules that outpace buying power; sizing suggestion in dollars. Extends `recurring` read.
+- [ ] `watch <SYM> <trigger>` — local polling watch-and-alert on $/level/option-mark crossings; native RH alerts need surface mapping (CDP capture of bonfire alert endpoints) for the non-polling version.
+- [ ] Scheduled health-scan log — daily `risk`/`exposure` snapshot appended to a local log for drift tracking. Depends on `risk`/`exposure`.
+
+### Platform / reach
+- [ ] Multi-account roll-ups — `--all-accounts` variants of risk/exposure/income/brief with per-account dollar breakdown. Generalizes existing cross-account positions/wheel.
+- [ ] Export/reporting expansion (`export` command) — CSV/JSON for positions, fills, income, realized P&L (tax-ready) + printable monthly statement. Builds on documents engine. (Overlaps carried T9 export task — fold.)
+- [ ] MCP resources for knowledge library (mcp/src/server.ts) — expose knowledge/*.md (+ glossary) as MCP resources alongside the existing robinhood_knowledge tool.
+- [ ] Trade-card / success-graphic generator — evidence-backed HTML render of a completed round-trip (entry/exit, $ P&L, payoff diagram, thread). Driven off `review` round-trip join.


### PR DESCRIPTION
Lands the additive roadmap from the parked `feat/dollar-based-amount-parity` stash onto main **before** any branch/stash cleanup, so it isn't lost. ~30 planned commands across beginner-empowerment, pro/aggressive workflows, risk & safety, income & tax, research & memory, automation, and platform/reach. Purely additive (0 deletions); no code touched.