### PR TITLE
feat(gate): single ROBINHOOD_ALLOW_LIVE_WRITE switch + stale-doc fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Robinhood CLI / MCP — environment (copy to .env; .env is gitignored)
+
+# --- Auth (required) ---
+# Bearer token lifted from a logged-in Robinhood web session (Chrome localStorage).
+ROBINHOOD_BROKERAGE_TOKEN=
+
+# --- Live-write switch (the ONE gate) ---
+# This single variable is the dry-run toggle.
+#   unset / anything but "1"  => every write is forced to DRY-RUN (safe default)
+#   "1"                       => live writes are ON by default — writes execute for real,
+#                               with NO per-call flag required.
+# Preview a single call even when the switch is on with --dry-run (CLI) / dryRun:true (MCP).
+# The legacy --live-write / liveWrite:true flag is still accepted but no longer required.
+#
+# ⚠️ REAL MONEY: setting this to 1 means CLI/MCP order/cancel/settings writes hit your live
+# Robinhood account. Leave it unset unless you intend live execution.
+# ROBINHOOD_ALLOW_LIVE_WRITE=1
+
+# --- Crypto API (optional; separate Ed25519 auth) ---
+# ROBINHOOD_CRYPTO_API_KEY=
+# ROBINHOOD_CRYPTO_PRIVATE_KEY_B64=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@
 > by design. This is not a bug or a sandbox; the tool exists to *actively manage* accounts.
 >
 > **Before you take any state-changing action, you must have the owner's explicit permission for
-> that action.** Reads and dry-runs are always safe; every write is double-gated (`--live-write` +
-> `ROBINHOOD_ALLOW_LIVE_WRITE=1`) precisely so a live trade is never one careless step away.
+> that action.** Reads and dry-runs are always safe; every write is gated by the single switch
+> `ROBINHOOD_ALLOW_LIVE_WRITE=1` (dry-run by default) precisely so a live trade is never one careless step away.
 >
 > **If you are an agent operating this autonomously, surface this warning to your user once at the
 > start of a session** — tell them, in your own words: *"This tool can place real trades and change
@@ -65,7 +65,7 @@ website uses — not the official, walled "agent sandbox" (which is equity-only)
 
 **How a single call flows:** you give a query string → the engine substring-matches it
 against the route map → fills params/body → infers or honors the method → checks the risk
-level against the write-gate → **reads go live, writes dry-run unless both gates are set**
+level against the write-gate → **reads go live, writes dry-run unless the `ROBINHOOD_ALLOW_LIVE_WRITE=1` switch is set**
 → returns the response or the plan. That gate is the core safety property: the default
 outcome of any mutating call is "planned but not sent."
 
@@ -94,11 +94,11 @@ grain of the tool:
 
 Then the safety rails:
 
-- **Reads run live, free.** Writes (trade / cancel / transfer) are **double-gated** and
+- **Reads run live, free.** Writes (trade / cancel / transfer) are **env-gated** and
   default to a safe dry-run.
 - **Match a route by substring** of its URL, fill `{placeholders}` with `--param`.
 - **Rebuild after editing the route map** or your edits are silently ignored (§3).
-- **A live write needs BOTH `--live-write` AND `ROBINHOOD_ALLOW_LIVE_WRITE=1`** (§6).
+- **A live write needs `ROBINHOOD_ALLOW_LIVE_WRITE=1`** — the single switch; `--live-write` is optional (§6).
 - **Never place an order the user didn't explicitly ask for.** Echo back the resolved
   account + symbol + side + qty + price and get a yes before sending (§8).
 - **Order history is the only proof a trade happened** (§20) — not a UI screen, not a lone `201`.
@@ -219,35 +219,34 @@ fills `{placeholders}` from `--param name=value`.
 
 ---
 
-## 6. Writing — the double gate (non-negotiable)
+## 6. Writing — the live-write switch (non-negotiable)
 
 Any route whose risk is `write-safe`, `write-mutate`, `write-or-sensitive`, or
-`destructive` is **forced to a dry-run** unless BOTH gates are set:
+`destructive` is **forced to a dry-run** unless the single live-write switch is set:
 
-1. the `--live-write` flag, **and**
-2. the `ROBINHOOD_ALLOW_LIVE_WRITE=1` environment variable.
+- the `ROBINHOOD_ALLOW_LIVE_WRITE=1` environment variable — that one switch is the gate.
 
-With one or neither, the request is planned but never sent; the result carries a
-`liveWriteBlocked` reason.
+With it unset, the request is planned but never sent; the result carries a
+`liveWriteBlocked` reason. The legacy per-call `--live-write` / `liveWrite:true` flag is
+still accepted but is now **optional** and no longer the gate.
 
 ### Turning dry-run off (going live)
 
-A write is dry-run **by default**. To turn dry-run off and send a real order you must
-flip **both** switches in the same invocation — there is no single "go live" flag:
+A write is dry-run **by default**. To turn dry-run off and send a real order, set the one
+switch — no per-call flag required:
 
 ```bash
-# This is "dry-run OFF": both gates set, order is sent for real.
+# This is "dry-run OFF": the switch is set, order is sent for real (no --live-write needed).
 ROBINHOOD_ALLOW_LIVE_WRITE=1 \
-  node cli/dist/index.js brokerage execute "<write-url>" --method POST --live-write --body-json '{...}'
+  node cli/dist/index.js brokerage execute "<write-url>" --method POST --body-json '{...}'
 ```
 
-- Drop **either** `ROBINHOOD_ALLOW_LIVE_WRITE=1` **or** `--live-write` → dry-run turns
-  back **on** automatically and nothing is sent.
-- Do **not** export `ROBINHOOD_ALLOW_LIVE_WRITE=1` into your shell profile — keep it inline
-  on the one command, so dry-run is always the resting state.
-- MCP equivalent: pass `liveWrite: true` **and** have `ROBINHOOD_ALLOW_LIVE_WRITE=1` in the
-  server's environment. (Note: `dryRun: true` always wins — it forces a plan even with both
-  gates set, a deliberate "I want to preview this exact live call" escape hatch.)
+- Unset `ROBINHOOD_ALLOW_LIVE_WRITE=1` → dry-run turns back **on** automatically and nothing is sent.
+- Prefer keeping `ROBINHOOD_ALLOW_LIVE_WRITE=1` **inline on the one command** rather than exporting it
+  into your shell profile, where it would make every later write live — so dry-run stays the resting state.
+- MCP equivalent: have `ROBINHOOD_ALLOW_LIVE_WRITE=1` in the server's environment — no per-call
+  `liveWrite` required. (Note: `dryRun: true` always wins — it forces a plan even when the switch is on,
+  a deliberate "I want to preview this exact live call" escape hatch.)
 
 Order-placement routes:
 
@@ -313,7 +312,7 @@ buying-power early-stop, JSON receipts).
 # Dry-run (safe, proves the plan + body, sends nothing):
 node cli/dist/index.js brokerage execute "https://api.robinhood.com/orders/" --method POST \
   --body-json '{...web body above...}'
-# Live — requires BOTH gates:
+# Live — requires the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch:
 ROBINHOOD_ALLOW_LIVE_WRITE=1 node cli/dist/index.js brokerage execute \
   "https://api.robinhood.com/orders/" --method POST --live-write --body-json '{...}'
 ```
@@ -364,7 +363,7 @@ node cli/dist/index.js brokerage execute "marketdata/options/?ids={ids}" \
 # "nearest $0.00" = the minimum tick, $0.01 — a resting bid that won't fill.
 ```
 
-**Step 5 — place the order (dry-run shown; flip both gates for live):**
+**Step 5 — place the order (dry-run shown; set the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch for live):**
 ```bash
 REF=$(python3 -c "import uuid;print(uuid.uuid4())")
 node cli/dist/index.js brokerage execute "https://api.robinhood.com/options/orders/" --method POST \
@@ -406,7 +405,7 @@ node cli/dist/index.js api-map options-strategy-plan call-credit-spread \
 ```
 
 The planner emits lookup steps and an `options/orders/` body template only. It never
-sends; live writes still need the normal double gate and exact user approval.
+sends; live writes still need the live-write switch and exact user approval.
 
 Agent decision rule: classify the user's language before building a plan. "Sell a call"
 can mean:
@@ -463,10 +462,10 @@ encode the selected expiration, strike, side, or Builder legs. Resolve those fro
 Watchlists live under `discovery/lists/`. Every read AND the list endpoints need
 `owner_type=custom` as a discriminator. List create/rename/delete are proven live through
 the CLI (create 201, rename 200, delete 204), and **item add/remove are now mapped + tested**
-(verified 2026-06-14) via the first-class `watchlist add`/`remove`/`create` commands (double-gated;
+(verified 2026-06-14) via the first-class `watchlist add`/`remove`/`create` commands (env-gated;
 MCP `robinhood_watchlist_add`/`_remove`/`_create`), plus `watchlist items` (live read of a list's tickers +
 equity-buyable flag) and `watchlist buy` (BP-aware **basket buy**: $<amount> of every equity-buyable ticker,
-looping the shared `placeEquityOrder` engine per ticker; double-gated; MCP `robinhood_watchlist_items`/`_buy`).
+looping the shared `placeEquityOrder` engine per ticker; env-gated; MCP `robinhood_watchlist_items`/`_buy`).
 The raw `brokerage execute` recipes below still work, but prefer the first-class verbs for item edits.
 
 ```bash
@@ -549,13 +548,13 @@ basis (`average_open_price` / `average_buy_price`) vs the live mark/last.
 ### Preferred: the first-class `recurring` command
 
 Recurring buys have a dedicated command so you don't hand-craft URLs or bodies. It shares
-the same engine + double-gate as everything else (reads run live, writes need both gates):
+the same engine + env-gate as everything else (reads run live, writes need the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch):
 
 ```bash
 robinhood-cli recurring list                        # live read: symbol/state/amount/next/id
 robinhood-cli recurring list --state paused --json   # filter + JSON for machine use
 
-# Resume / pause. Without BOTH gates these DRY-RUN (plan only, send nothing):
+# Resume / pause. Without the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch these DRY-RUN (plan only, send nothing):
 ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli recurring resume --all --live-write
 ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli recurring resume --id <SCHEDULE_ID> --live-write
 ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli recurring pause  --all --account <ACCOUNT_NUMBER> --live-write
@@ -572,7 +571,7 @@ robinhood-cli brokerage execute \
   "https://bonfire.robinhood.com/recurring_schedules/" --method GET --full
 
 # RESUME a paused buy (PATCH; verb confirmed via OPTIONS, state field confirmed on the object).
-# Dry-run first (sends nothing), then go live with BOTH gates:
+# Dry-run first (sends nothing), then go live with the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch:
 robinhood-cli brokerage execute \
   "https://bonfire.robinhood.com/recurring_schedules/{0}/" --method PATCH \
   --param 0=<SCHEDULE_ID> --body-json '{"state":"active"}'         # dry-run
@@ -623,7 +622,7 @@ settings/permissions, never print the token value.
 claude mcp add robinhood-cli -s user -- node /absolute/path/to/robinhood-cli/mcp/dist/server.js
 ```
 
-Tools surface as `mcp__robinhood-cli__*` (the full tool roster incl. accounts/positions/portfolio/buy/sell/cancel/order-status/buying-power/wheel/options-holdings/options-inspect/settings/recurring/quote/history/watchlist + the double-gated watchlist_add/remove/create/items/buy writes/options-enumerate parity: route inspection, browser/account
+Tools surface as `mcp__robinhood-cli__*` (the full tool roster incl. accounts/positions/portfolio/buy/sell/cancel/order-status/buying-power/wheel/options-holdings/options-inspect/settings/recurring/quote/history/watchlist + the env-gated watchlist_add/remove/create/items/buy writes/options-enumerate parity: route inspection, browser/account
 context, options strategy workflows/plans, exact-contract link bundles, stock
 profile reads, brokerage plan/execute, and crypto routes/sign/plan/execute). `robinhood_buy`/`robinhood_sell`
 run the same shared engine as the CLI commands — pending-order dedup (5-min window; `force: true` skips),
@@ -649,7 +648,7 @@ This is a hard rule, not a nicety — divergence here has already caused a write
   an ambiguous substring query (>1 distinct route) throws `AmbiguousRouteError` with the candidate list.
   Pass exact URLs for writes.
 - **New capability → wire all three places** (route in api-map, command in CLI, tool in MCP) and keep the
-  double gate intact. Reads live by default; every write dry-run until both gates.
+  env gate intact. Reads live by default; every write dry-run until the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch is set.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ node cli/dist/index.js --help
 | Surface | Current state |
 |---------|---------------|
 | API map | 300+ brokerage/account route entries (incl. instrument search + the `midlands/` sentiment layer) + the official Crypto routes, generated OpenAPI, endpoint Markdown, and curl templates. Every entry carries field-level response provenance (`verified`/`inferred`/`undocumented`, test-enforced). Trust the live count (`brokerage routes --json`), never a hardcoded number. |
-| CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep), `recurring` (list/pause/resume/create/edit/end), and `watchlist` (list/add/remove/create) — all writes double-gated — plus route planning and dry-run order bodies. |
+| CLI | TypeScript command-line tool: live reads (`quote`, `positions`, `portfolio` (one-call day/after-hours P&L in dollars, by underlying), `accounts`, `history`, `order-status` (UUID→ticker resolved), `buying-power`, `options positions/chain/enumerate/inspect/holdings`, `stock profile`, `watchlist`, `recipes` (intent → the one command)), first-class order lifecycle (`buy` / `sell` / `cancel` — OTC-aware, deduped, `ref_id`-idempotent), options strategy quoting + rolling, first-class `settings` (DRIP/expiration/PDT/lending/sweep), `recurring` (list/pause/resume/create/edit/end), and `watchlist` (list/add/remove/create) — all writes env-gated — plus route planning and dry-run order bodies. |
 | MCP | The full agent-tool surface (live truth: `tools/list`) sharing the same engine, auth, route map, and write gates as the CLI — full verb parity. `robinhood_buy`/`robinhood_sell` run the exact same shared order engine as the CLI commands (same dedup, same `ref_id`, same OTC guard), so the two surfaces cannot drift. `robinhood_wheel` reads your actual wheel state (shares + short puts/calls) and returns the next-leg dry-run command. |
 | Memory | `ball-knowledge.md` (market beliefs/themes/sources) + `trading-log.md` (execution + intent history) — the agent's cross-session brain. |
 | Research | A source-quality doctrine (X/Reddit pulse → news/`midlands` confirmer → institutional outlook → academic math, none gospel) + strategy deep-dives (Wheel, rolling, with quant appendices), institutional CMAs, tax-aware notes. |
 | Auth | Browser-session bearer token loaded from local `.env`, with one-shot self-heal on `401` |
-| Safety | Reads run live; every write needs both `--live-write` and `ROBINHOOD_ALLOW_LIVE_WRITE=1`. Pending-duplicate dedup (5-min window) blocks accidental double-sends; `ref_id` idempotency makes 429 retries safe; resolver fails closed/loud; order-evidence rule = order history is the only proof a trade happened. |
+| Safety | Reads run live; every write is dry-run unless `ROBINHOOD_ALLOW_LIVE_WRITE=1` is set — the single master switch (no per-call `--live-write` needed; `--dry-run` still previews even when it's on). Pending-duplicate dedup (5-min window) blocks accidental double-sends; `ref_id` idempotency makes 429 retries safe; resolver fails closed/loud; order-evidence rule = order history is the only proof a trade happened. |
 
 This is a pretty damn American piece of software: local control, account-owner agency, dry-run rights, and a command surface that lets people, scripts, and agents work the same Robinhood account without pretending the browser is the product.
 
@@ -59,14 +59,14 @@ boot (read the operating-intelligence KB → memory → doctrine)
   → research a thesis  (signal sourcing: X/Reddit pulse → news/midlands → institutional outlook → academic math)
   → read the account truthfully  (accounts + portfolio P&L + the buying-power family — overnight/options BP, not the headline)
   → plan the order  (options strategy-quote / roll-plan / contract resolution → exact dry-run body)
-  → gate it  (dry-run by default; live only with BOTH gates + echoed account/side/qty/price)
+  → gate it  (dry-run by default; live only with the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch + echoed account/side/qty/price)
   → execute  (one engine; pending-order dedup, ref_id idempotency, 429-retry, min-tick, collar guards)
   → verify it happened  (order history is the only proof — not the UI, not a 201 alone; `order-status` resolves the ticker)
   → log it  (trading-log.md: what + intent + the strategy thread / "what we're rolling from")
   → update memory  (ball-knowledge.md) → the thread continues next session
 ```
 
-The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill entry point — trigger + 80/20 + the operating loop + intent routing) → **`references/`** (the skill's progressive-disclosure layer: `operation-guide`, `command-catalog`, `api-route-map`, `safety-doctrine`, `options-strategy`, `troubleshooting`) → **`knowledge/`** (per-topic reasoning modules) → **`docs/agent-operating-intelligence-2026-06-04.md`** (the boot-smart KB: cardinal rule, account/order/signal decision frameworks, failure→fix tree) → the **memory** files → the **research** docs (`docs/strategy-deep-dive-*`, `institutional-outlook-*`, `tax-aware-options-strategies`, `options-strategies-knowledge-base`). The in-repo **`AGENTS.md`** (developer/maintainer runbook; `CLAUDE.md` is a symlink to it) covers build/test, the shared-engine invariant, and route-map editing. Everything is engine-backed (`cli/src/lib.ts`) and double-gated.
+The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill entry point — trigger + 80/20 + the operating loop + intent routing) → **`references/`** (the skill's progressive-disclosure layer: `operation-guide`, `command-catalog`, `api-route-map`, `safety-doctrine`, `options-strategy`, `troubleshooting`) → **`knowledge/`** (per-topic reasoning modules) → **`docs/agent-operating-intelligence-2026-06-04.md`** (the boot-smart KB: cardinal rule, account/order/signal decision frameworks, failure→fix tree) → the **memory** files → the **research** docs (`docs/strategy-deep-dive-*`, `institutional-outlook-*`, `tax-aware-options-strategies`, `options-strategies-knowledge-base`). The in-repo **`AGENTS.md`** (developer/maintainer runbook; `CLAUDE.md` is a symlink to it) covers build/test, the shared-engine invariant, and route-map editing. Everything is engine-backed (`cli/src/lib.ts`) and env-gated.
 
 ## Coverage
 
@@ -80,10 +80,10 @@ The layers an agent reads to do that: **`SKILL.md`** (the lean, portable skill e
 - **Orders** — equity and options order history, status (single-order lookup with the instrument UUID resolved to a real ticker), placement, and cancellation — with pending-duplicate dedup and `ref_id` idempotency on every send.
 - **Portfolio P&L** — `portfolio` (aliases `pnl`/`snapshot`): one call → per-account day Δ + after-hours Δ + per-account buying power, drivers rolled up by underlying in **dollars** across all accounts, with a reconciliation line.
 - **Recipes** — `recipes "<intent>"`: free-text intent → the one CLI command (and MCP tool) that answers it.
-- **Watchlists** — list, add, remove, create (writes double-gated; the real endpoint is `discovery/lists/items/`, captured + verified live).
+- **Watchlists** — list, add, remove, create (writes env-gated; the real endpoint is `discovery/lists/items/`, captured + verified live).
 - **Margin health** — `margin`: per-account answer to "am I borrowing, how much, at what rate, billed when" — amount borrowed in dollars, interest rate, next billing date, margin available, and buying power with margin; accounts without margin data degrade silently.
-- **Recurring investments** — first-class list, pause, resume, **create, edit, and end** (all double-gated; create/edit body shapes verified live).
-- **Account settings** — first-class `settings` group: DRIP (account-wide + per-stock), trade-on-expiration, PDT protection, stock lending, cash-sweep unenroll — double-gated, several verified live.
+- **Recurring investments** — first-class list, pause, resume, **create, edit, and end** (all env-gated; create/edit body shapes verified live).
+- **Account settings** — first-class `settings` group: DRIP (account-wide + per-stock), trade-on-expiration, PDT protection, stock lending, cash-sweep unenroll — env-gated, several verified live.
 - **Index options** — RH **does** offer cash-settled §1256 index options (SPX/SPXW/XSP/NDX/VIX/RUT), hidden from the search bar but live under `options/chains/?underlying_symbol=` (see `docs/index-options-1256-conclusion-2026-06-04.md`). Futures are read-only (ceres TLS-walled); FX none; commodities via ETF proxies.
 - **Memory + research** — `ball-knowledge.md` / `trading-log.md` (cross-session brain) and the signal-sourcing doctrine + strategy deep-dives + institutional outlook (the research→decision layer).
 - **Film-study mode** — `review`: your filled orders paired into round trips with realized dollar P&L, hold time, win rate, and best/worst trades — plus `review note` to attach the lesson to the trade it came from (`trade-notes.md`). Watch your own tape.
@@ -133,7 +133,7 @@ The one-off features that make this more than an API wrapper:
 
 **A knowledge library for agents.** `knowledge/` holds per-topic operating modules (wheel, rolling, multi-leg, Greeks, tax, tax-loss harvesting, dividend investing, position building, market mechanics, accounts, signals, execution safety) plus `knowledge/playbooks/broker-call.md`: the tested end-to-end "reimagined broker phone call" pipeline, from screenshot to classified strategy to dry-run quote to confirmation contract to gated send to order-history evidence to trading log. SKILL.md routes, knowledge/ teaches, docs/ proves.
 
-**Context:** Robinhood's own agentic-trading beta is equity-only inside a sandboxed, separately funded wallet. This repo runs the full surface (multi-leg options, rolls, settings, all owned accounts) on the account you already have, dry-run by default, double-gated for anything live.
+**Context:** Robinhood's own agentic-trading beta is equity-only inside a sandboxed, separately funded wallet. This repo runs the full surface (multi-leg options, rolls, settings, all owned accounts) on the account you already have, dry-run by default, env-gated for anything live.
 
 ## API Map and Route Coverage
 
@@ -147,7 +147,7 @@ endpoints, we got em all
 
 ### Design note: method-aware route resolution
 
-This CLI selects routes **by URL *and* HTTP method**, so a single endpoint can carry both a safe read and a gated write (e.g. `GET` vs `PATCH` on `recurring_schedules/{id}/`) and each resolves to the correct risk level. That's what lets the same URL expose a free read and a double-gated write without one leaking into the other. A URL-keyed resolver (route looked up by path alone) can't do this safely — a shared GET+write entry would either bypass the write gate or block the read — so it must split writes onto distinct, write-only URLs instead. The method-aware design is why the write surface here can be rich without weakening the safety gate.
+This CLI selects routes **by URL *and* HTTP method**, so a single endpoint can carry both a safe read and a gated write (e.g. `GET` vs `PATCH` on `recurring_schedules/{id}/`) and each resolves to the correct risk level. That's what lets the same URL expose a free read and a env-gated write without one leaking into the other. A URL-keyed resolver (route looked up by path alone) can't do this safely — a shared GET+write entry would either bypass the write gate or block the read — so it must split writes onto distinct, write-only URLs instead. The method-aware design is why the write surface here can be rich without weakening the safety gate.
 
 ## Getting started
 
@@ -207,15 +207,15 @@ robinhood-cli options roll-plan --account <ACCOUNT_NUMBER> --symbol DRAM --type 
 robinhood-cli api-map options-contract-links --account <ACCOUNT_NUMBER> --symbol DRAM --expiration 2026-12-18 --type call --side buy --strike 80 --json
 robinhood-cli stock profile DRAM --account <ACCOUNT_NUMBER> --json
 robinhood-cli watchlist list                          # your custom watchlists + sizes
-robinhood-cli watchlist add "Homie index" NVDA AMAT   # add tickers (double-gated, dry-run by default)
-robinhood-cli watchlist create "Og handle fund"       # make a new list (double-gated)
+robinhood-cli watchlist add "Homie index" NVDA AMAT   # add tickers (env-gated, dry-run by default)
+robinhood-cli watchlist create "Og handle fund"       # make a new list (env-gated)
 robinhood-cli brokerage routes --category orders      # browse mapped routes
 robinhood-cli brokerage plan "https://api.robinhood.com/accounts/{0}/" --param 0=ACCOUNT_ID --json
 ```
 
 ### Command tour — what answers what
 
-One line per question. All reads are live and free; the order/settings commands are dry-run until both write gates are set.
+One line per question. All reads are live and free; the order/settings commands are dry-run until the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch is set.
 
 | Command | The question it answers |
 |---|---|
@@ -234,8 +234,8 @@ One line per question. All reads are live and free; the order/settings commands 
 | `buy` / `sell` / `cancel` / `order-status` | The order lifecycle — dollar or share sizing, dedup + `ref_id` idempotency, real-ticker status |
 | `buying-power [--account N]` | "What can I actually spend?" — the BP family, not the headline number |
 | `recurring list/pause/resume/create/edit/end` | "What's on autopilot, and change it" |
-| `watchlist list/add/remove/create` | "Show my custom lists, and edit them" — add/remove tickers (resolved by name) or make a new list (double-gated) |
-| `settings show/drip/expiration/pdt/lending/sweep` | "Read or toggle account settings" (double-gated) |
+| `watchlist list/add/remove/create` | "Show my custom lists, and edit them" — add/remove tickers (resolved by name) or make a new list (env-gated) |
+| `settings show/drip/expiration/pdt/lending/sweep` | "Read or toggle account settings" (env-gated) |
 | `history --days N` | "What actually executed?" — unified equity + options + crypto + transfers, newest first |
 | `quote <SYM...>` | Live last/bid/ask/day-change for any symbols |
 | `recipes "<intent>"` | "Which command answers this?" — free text in, the one command out |
@@ -248,9 +248,9 @@ One line per question. All reads are live and free; the order/settings commands 
 # Dry-run (default): builds the request, prints the plan, sends nothing
 robinhood-cli brokerage execute "https://api.robinhood.com/orders/" --body-json '{...}'
 
-# Live: BOTH gates required
+# Live: set the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch (the single gate; --live-write is optional)
 ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli brokerage execute \
-  "https://api.robinhood.com/orders/" --body-json '{...}' --live-write
+  "https://api.robinhood.com/orders/" --body-json '{...}'
 
 # First-class commands carry the same gate, e.g. recurring investments:
 ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli recurring resume --all --live-write
@@ -388,7 +388,7 @@ robinhood-cli api-map options-strategy-plan call-credit-spread \
 
 `roll-plan` is the cash-account fallback. It resolves the close leg and open leg separately, quotes each one from bid/ask/mark/Greeks, emits two dry-run single-leg order bodies, and when `--cash-account` is set, marks the replacement leg as not-before the next business day with required fresh checks for settled cash and live quotes.
 
-Planner output is still a write-capable order body, so the live route remains blocked by the normal double gate. Treat aggressive or undefined-risk strategies as exact-approval only.
+Planner output is still a write-capable order body, so the live route remains blocked by the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch. Treat aggressive or undefined-risk strategies as exact-approval only.
 
 The detailed math references live in [`docs/options-greeks-strategy-research-2026-06-02.md`](./docs/options-greeks-strategy-research-2026-06-02.md), [`docs/options-quantitative-playbook-2026-06-03.md`](./docs/options-quantitative-playbook-2026-06-03.md), and [`docs/options-strategy-execution-smoke-2026-06-03.md`](./docs/options-strategy-execution-smoke-2026-06-03.md). They cover net Greek aggregation, Black-Scholes sanity checks, payoff and breakeven formulas, aggressive-vs-non-aggressive variants, the dry-run smoke suite, and the machine-readable `reviewContract` emitted by `options-strategy-plan`. Use them when translating loose requests like "sell a call" or "covered short put" into a precise dry-run order body.
 
@@ -493,8 +493,8 @@ robinhood-cli brokerage routes --query "margin" --json
 Current state:
 
 - Recurring investments are first-class: `recurring list / pause / resume / create / edit / end`
-  (create + edit body shapes verified live; all double-gated).
-- A first-class **`settings`** group ships double-gated writes for the surfaces whose bodies were
+  (create + edit body shapes verified live; all env-gated).
+- A first-class **`settings`** group ships env-gated writes for the surfaces whose bodies were
   captured + verified: **DRIP** (account-wide + per-stock), **trade-on-expiration**, **PDT protection**,
   **stock lending**, and **cash-sweep unenroll**. `settings show` reads them all. (Cash-sweep *enroll*
   needs the agreement-sign flow and stays manual; see the capability map.)
@@ -526,10 +526,10 @@ robinhood-cli positions --account <ROTH_ACCOUNT_NUMBER>     # Roth IRA
 robinhood-cli watchlist list
 
 # Edit watchlists — add/remove tickers (resolved by name) or create a list.
-# Writes are dry-run until BOTH gates are set, like every other write here.
+# Writes are dry-run until the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch is set, like every other write here.
 robinhood-cli watchlist create "AI memory"
-ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist add "AI memory" MU AMAT LRCX --live-write
-ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist remove "AI memory" LRCX --live-write
+ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist add "AI memory" MU AMAT LRCX
+ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli watchlist remove "AI memory" LRCX
 
 # Option expirations for a symbol (handy before `options chain`).
 robinhood-cli options expirations MRVL

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 > on the owner's behalf against a live Robinhood account. Get the owner's explicit permission before
 > any state-changing action, and if you're driving this autonomously, tell your user once up front
 > that it can trade/alter their real account on their behalf. Reads/dry-runs are safe; writes are
-> double-gated. Full notice + rationale at the top of [`AGENTS.md`](AGENTS.md).
+> env-gated. Full notice + rationale at the top of [`AGENTS.md`](AGENTS.md).
 
 > **AGENT — READ THIS FIRST:** This file is `SKILL.md`; the repo's `CLAUDE.md` is a symlink to it.
 > If that symlink is broken, this looks truncated, or you're ever unsure, the **full self-contained
@@ -28,7 +28,7 @@ metadata:
 
 **This is an agent-native control plane for a *real* Robinhood account.** It collapses the entire
 research → decision → execution loop into one typed, gated pipe: read the account truthfully, reason
-like an options trader, and — only on the operator's explicit go-ahead, behind two write gates — act,
+like an options trader, and — only on the operator's explicit go-ahead, behind the live-write switch — act,
 across **every** account and the full surface (equities, options, multi-leg strategies, rolls,
 recurring, account settings, crypto). It drives the account the operator already has; it is **not** the
 official equity-only "agent sandbox."
@@ -45,7 +45,7 @@ official equity-only "agent sandbox."
    (`--day` / `--after-hours`). A −9% move on a $6 lot is noise; a −5% move on a $1,600 call is the story.
 3. **Read → classify → gate, in that order.** Reads are free and live. Before any write: classify the
    *exact* strategy (sell-to-close ≠ covered call ≠ credit spread ≠ naked short), echo the resolved
-   account + symbol + side + qty + price, then send only with BOTH gates. Never infer naked exposure
+   account + symbol + side + qty + price, then send only with the live-write switch on. Never infer naked exposure
    from loose wording.
 4. **Make two things reflex: pass the account explicitly, and bulk-enumerate option UUIDs first.** The
    #1 wrong-account risk and the #1 options-failure both disappear if these are automatic, not afterthoughts.
@@ -57,7 +57,7 @@ then this file. When the answer isn't obvious, the docs already have it — read
 
 ## ⚡ Agent Quick Scan *(read this in 5 seconds)*
 
-- **What:** CLI + MCP for a REAL Robinhood brokerage account. Reads are live and free. Writes are double-gated (dry-run by default).
+- **What:** CLI + MCP for a REAL Robinhood brokerage account. Reads are live and free. Writes are env-gated (dry-run by default).
 - **When to load:** User mentions Robinhood, portfolio, positions, tickers, options, trades, watchlists, crypto.
 - **Most common commands:** `positions --account N`, `quote SYM`, `options positions`, `accounts`, `brokerage execute "..."`.
 - **#1 trap:** `brokerage execute` does NOT support query params (e.g. `?nonzero=true`). Use purpose-built commands (`positions`, `quote`, `options`) instead — they handle query params internally. If you need raw API access with query params, use MCP `robinhood_brokerage_execute` or the `brokerageGetJson` engine function.
@@ -130,7 +130,7 @@ loaded into context. Use it in layers:
    hand-waving.
 4. **Keep the user in control.** Reads and dry-runs can proceed. Live trades,
    transfers, account-setting toggles, cancels, unlinks, or margin/account-type
-   changes require exact user approval plus both write gates.
+   changes require exact user approval plus the ROBINHOOD_ALLOW_LIVE_WRITE=1 write switch.
 
 For this use case, the skill teaches the workflow and guardrails; the MCP tools
 provide execution. Do not overload the prompt with all route docs unless a task
@@ -158,7 +158,7 @@ Do NOT load for: general investing advice (that's not what this tool does), pape
 
 Read this first: it is the menu of supported operations so an agent has full context *before*
 scanning the route map. (Far exceeds what one user would manually do.) Reads are live; every write
-is double-gated (`--live-write` + `ROBINHOOD_ALLOW_LIVE_WRITE=1`).
+is gated by the single switch `ROBINHOOD_ALLOW_LIVE_WRITE=1` (dry-run by default; `--live-write` optional).
 
 **Equity**
 - Buy by dollar-notional (fractional, market) or by shares (`brokerage buy`); OTC names auto-limit
@@ -226,13 +226,13 @@ only via ETF proxies (USO/UVXY/BITO — normal equities, placeable via `brokerag
 strike + bid/ask/last + qty + link) across accounts; `options inspect <uuid>` opens one contract's
 full detail (metadata, Greeks, fill history, rare tax-timing note, buy/sell handoff).
 
-**Watchlists** — read custom lists (`watchlist list`) **and write them, double-gated** (verified 2026-06-14):
+**Watchlists** — read custom lists (`watchlist list`) **and write them, env-gated** (verified 2026-06-14):
 `watchlist add <list> <symbols…>` / `watchlist remove <list> <symbols…>` (batch ops to `discovery/lists/items/`;
 resolve the list by case-insensitive `display_name` or id) and `watchlist create <name> [--emoji]` (POST
 `discovery/lists/`). MCP equivalents: `robinhood_watchlist_add`/`_remove`/`_create`. Read a list's live tickers
 with `watchlist items <list>` (symbol/price/equity-buyable flag), and **basket-buy** every equity-buyable name
 with `watchlist buy <list> --account <N> --amount <$>` — BP-aware, looping the shared `placeEquityOrder` engine
-per ticker (same OTC/dedup/`ref_id`/evidence guards; skips what won't fit; double-gated). Item **reorder** is not yet mapped.
+per ticker (same OTC/dedup/`ref_id`/evidence guards; skips what won't fit; env-gated). Item **reorder** is not yet mapped.
 
 ### Strategy & tax knowledge (background — neutral, NOT risk guidance)
 Reference docs that give the agent broad options/tax background to reason about ANY strategy a user
@@ -281,9 +281,12 @@ Ranked by money-loss. Each is a real way an agent has tripped or would. Follow t
    runs the **read** and returns a LIST — and a careless agent then reports "order placed" when nothing
    was sent. Pass `--method` for every write and confirm the response is a write result (e.g. `201` +
    an order `id`), not a list.
-3. **Never export the live-write gate.** Do NOT put `ROBINHOOD_ALLOW_LIVE_WRITE=1` in your shell
-   profile/`.bashrc`/`.zshrc`. Keep it **inline on the single command**. A persistent env var turns
-   every later `--live-write` into a real send — including "tests." Two gates, per command, every time.
+3. **The live-write switch is the ONE gate — set it deliberately.** `ROBINHOOD_ALLOW_LIVE_WRITE=1` is
+   the single master switch: set it and **every** write executes for real (no per-call `--live-write`
+   needed); unset, every write is dry-run. Turn it on only when you intend live execution, and prefer
+   scoping it to the one command (`ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli …`) over exporting it into
+   your shell profile/`.bashrc`/`.zshrc`, where it would quietly make every later write live — including
+   "tests." Pass `--dry-run` / `dryRun:true` to preview a single call even while the switch is on.
 4. **OTC / non-fractional guard.** Before a dollar order, read `fractional_tradability`. If it's
    `position_closing_only` (OTC, e.g. RNECY) or anything ≠ `tradable`, a "$X of <ticker>" order is
    **impossible** — switch to whole shares + a marketable limit; don't retry the dollar body.
@@ -334,7 +337,7 @@ Ranked by money-loss. Each is a real way an agent has tripped or would. Follow t
    clicked", app state, or agent logs are **not** proof. (Lived this session: a "nothing executed"
    scare resolved by reading the orders list — and the place→cancel tests were confirmed the same way.)
 
-> Golden rule: reads are free and live; **every write is dry-run until you deliberately pass both gates**.
+> Golden rule: reads are free and live; **every write is dry-run unless `ROBINHOOD_ALLOW_LIVE_WRITE=1` is set** (the single switch — no per-call flag required; `--dry-run`/`dryRun:true` still previews even when it's on).
 > When unsure about account, side, position_effect, or amount — stop and confirm. A wrong write is real money.
 
 ---
@@ -396,7 +399,7 @@ Interpretation:
 
 ## CLI Usage — The 80/20
 
-All commands run from repo root. Reads run live and free. Writes are double-gated (dry-run by default unless both `--live-write` AND `ROBINHOOD_ALLOW_LIVE_WRITE=1` are set).
+All commands run from repo root. Reads run live and free. Writes are dry-run by default unless `ROBINHOOD_ALLOW_LIVE_WRITE=1` is set (the single switch; `--live-write` is an optional no-op).
 
 ```bash
 robinhood-cli api-map summary --json
@@ -417,11 +420,11 @@ robinhood-cli options positions --json
 robinhood-cli options chain MRVL --width 6 --json
 robinhood-cli options expirations MRVL --json
 robinhood-cli watchlist list --json
-robinhood-cli watchlist add "My List" NVDA TSLA              # dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1
+robinhood-cli watchlist add "My List" NVDA TSLA              # dry-run by default; set ROBINHOOD_ALLOW_LIVE_WRITE=1 to send (single switch)
 robinhood-cli watchlist remove "My List" TSLA               # dry-run by default
 robinhood-cli watchlist create "Semis" --emoji 🛰️            # dry-run by default
 robinhood-cli watchlist items "Semis" --json                 # live read: tickers + price + equity-buyable flag
-robinhood-cli watchlist buy "Semis" --account <N> --amount 5 # BASKET BUY $5 of each buyable name — dry-run by default; double-gated
+robinhood-cli watchlist buy "Semis" --account <N> --amount 5 # BASKET BUY $5 of each buyable name — dry-run by default; env-gated
 robinhood-cli crypto routes --json
 robinhood-cli crypto sign --api-key "$ROBINHOOD_API_KEY" --private-key-b64 "$ROBINHOOD_PRIVATE_KEY_B64" --path /api/v1/crypto/trading/accounts/ --method GET
 robinhood-cli crypto execute "https://trading.robinhood.com/api/v2/crypto/marketdata/best_bid_ask/" --query-param symbol=BTC-USD --dry-run --json
@@ -436,12 +439,12 @@ Keep this split current when editing the skill:
 | API map | ~300 brokerage/account route entries (live count via `brokerage routes --json`) plus official Crypto API routes | Rebuild after edits; runtime reads `cli/dist/api-map/` |
 | Read commands | `quote`, `positions`, `options positions`, `options expirations`, `options chain`, `watchlist list`, `recurring list`, route-map reads, crypto read plans | Live reads are allowed with caller-owned auth, but redact balances/tokens in shareable output |
 | Options research/planning | 20 strategy workflows; `options-strategy-plan` emits `reviewContract` | Planning only until exact user approval and write gates |
-| Equity/options order writes | Route-map executor against `orders/`, `options/orders/`, and cancel routes | Must use `--method`, exact body, `--live-write`, and `ROBINHOOD_ALLOW_LIVE_WRITE=1`; dry-run first |
+| Equity/options order writes | Route-map executor against `orders/`, `options/orders/`, and cancel routes | Must use `--method` and an exact body; live needs `ROBINHOOD_ALLOW_LIVE_WRITE=1` (the single switch; `--live-write` optional); dry-run first |
 | Recurring investments | First-class `recurring list`, `recurring resume`, `recurring pause`; route map also has GET one schedule and POST create | Resume/pause are the verified first-class writes. Create/edit amount/funding-source are route-map research unless a fresh capture verifies body shape |
-| Watchlist read / edit / basket-buy | `watchlist list`/`items` (read); `watchlist add`/`remove`/`create` + `watchlist buy` (basket) (MCP `robinhood_watchlist_add`/`_remove`/`_create`/`_items`/`_buy`) | Double-gated writes (verified 2026-06-14): add/remove batch `discovery/lists/items/`, create POSTs `discovery/lists/`; `watchlist buy` loops the shared order engine per ticker (BP-aware, OTC/dedup/`ref_id` guards, skips what won't fit); item reorder still route-map research |
+| Watchlist read / edit / basket-buy | `watchlist list`/`items` (read); `watchlist add`/`remove`/`create` + `watchlist buy` (basket) (MCP `robinhood_watchlist_add`/`_remove`/`_create`/`_items`/`_buy`) | Env-gated writes (verified 2026-06-14): add/remove batch `discovery/lists/items/`, create POSTs `discovery/lists/`; `watchlist buy` loops the shared order engine per ticker (BP-aware, OTC/dedup/`ref_id` guards, skips what won't fit); item reorder still route-map research |
 | Money movement / funding | ACH relationships/transfers and cashier/deposit-schedule routes are mapped mostly as read or `write-or-sensitive` | Never mutate funding, ACH links, deposits, withdrawals, or transfers without a fresh route/body capture and explicit approval |
-| DRIP/options/account settings | DRIP GET/PATCH is method-split; account-setting routes are mapped or browser-observed | Treat account-setting writes as dry-run first; plan, obtain exact approval, send only with both gates, then verify reload state |
-| Crypto | Official Crypto API signing/planning/execution commands | Different auth from brokerage; crypto writes/cancels use the same double gate |
+| DRIP/options/account settings | DRIP GET/PATCH is method-split; account-setting routes are mapped or browser-observed | Treat account-setting writes as dry-run first; plan, obtain exact approval, send only with the switch on, then verify reload state |
+| Crypto | Official Crypto API signing/planning/execution commands | Different auth from brokerage; crypto writes/cancels use the same `ROBINHOOD_ALLOW_LIVE_WRITE=1` switch |
 
 Do not overclaim first-class support. If a capability is route-map-only, say so and build a dry-run body from the current route map before considering implementation.
 
@@ -460,10 +463,10 @@ Do not overclaim first-class support. If a capability is route-map-only, say so 
 | Orders (create) | `orders/` | Requires `--method POST` |
 | Options chain | `options/chains/{id}/` | Get expirations + tick rules |
 | Options instruments | `options/instruments/?chain_id={id}&expiration_dates={date}&state=active&type=call` | Find specific strikes |
-| Options orders | `options/orders/` | POST, same double-gate |
+| Options orders | `options/orders/` | POST, same env gate |
 | Stock profile page | `stock profile <symbol> --account <n> --json` | Joins quote, description, fundamentals, shorting/borrow, buying-power, and margin reads |
 | Recurring buys | `recurring` subcommand | `robinhood-cli recurring list` — dedicated command |
-| Recurring pause/resume | `recurring pause|resume` | Verified first-class writes; double-gated |
+| Recurring pause/resume | `recurring pause|resume` | Verified first-class writes; env-gated |
 | Recurring create/edit/funding source | `bonfire.robinhood.com/recurring_schedules/` | Route-map research only until fresh body capture verifies amount/source fields |
 | Funding sources | `cashier.robinhood.com/ach/relationships/`, `payment_instruments/v2/` | Read first; writes are high-risk and not first-class |
 | Account settings capability map | `docs/account-settings-capability-map-2026-06-03.md` | Defines what is first-class, route-map-only, browser-observed, or not yet proven |
@@ -757,7 +760,7 @@ Use this exact planning sequence:
 6. For calendar rolls, pass per-leg expirations: `--param close_call_expiration=<old> --param open_call_expiration=<new>` or use `options roll-plan` for a two-order staged plan.
 7. Use `--pricing-mode safe-sell-probe` only as a dry-run control when proving a sell/credit body is far from the market.
 8. If exact ids are already known, `robinhood-cli api-map options-strategy-plan <id> --param key=value --json` can still emit the raw template body.
-9. Only after the dry-run body is exact should any live route be considered, and only with `--live-write` plus `ROBINHOOD_ALLOW_LIVE_WRITE=1`.
+9. Only after the dry-run body is exact should any live route be considered, and only with `ROBINHOOD_ALLOW_LIVE_WRITE=1` set (the single switch; `--live-write` optional).
 
 Worked dry-run examples:
 
@@ -887,7 +890,7 @@ deep math lives in *Options Greeks and Strategy Math* above.
 | "Change a setting (DRIP, recurring, etc.)" | gated write | `recurring pause|resume`; route-map writes via `brokerage execute --method ... --live-write` |
 
 **Decision rule:** read first, classify the strategy, compute payoff + net Greeks,
-emit blockers, *then* (only on explicit request + both write gates) send. Never
+emit blockers, *then* (only on explicit request + the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch) send. Never
 infer naked/undefined-risk exposure from loose wording — see *Options Strategy
 Classification*.
 
@@ -1002,7 +1005,7 @@ and good-faith violations still do — selling unsettled funds can flag it.
 
 Verified live, not theorized:
 
-- **Both gates fire and mutate:** `--live-write` + `ROBINHOOD_ALLOW_LIVE_WRITE=1`.
+- **The switch fires and mutates:** `ROBINHOOD_ALLOW_LIVE_WRITE=1` (the single switch; `--live-write` optional).
   A recurring `pause`→`resume` round-trip returned `200` both ways and restored
   state; an options order placed (`201`, state `queued`) and cancelled (`200`).
 - **Order lifecycle:** `POST options/orders/` returns the order `id` → confirm it
@@ -1030,7 +1033,7 @@ Verified live, not theorized:
   - `brokerage buy ORCU --account <num> --dollars 5` → fractional dollar-notional (market).
   - `brokerage buy RNECY --account <num> --shares 1` → whole shares; **OTC auto-limits at the
     marketable side — ask on buys, bid on sells** (`sell` is the mirror, same engine).
-  - Dry-run by default; live needs `--live-write` + `ROBINHOOD_ALLOW_LIVE_WRITE=1`.
+  - Dry-run by default; live needs `ROBINHOOD_ALLOW_LIVE_WRITE=1` (the single switch; `--live-write` optional).
 - **OTC / fractional guard.** Before a dollar order the tool reads `fractional_tradability` +
   `otc_market_tier`. OTC names (e.g. RNECY) are `position_closing_only` and **reject market
   orders** — trade them (buy AND sell both supported) as **whole shares via an auto marketable
@@ -1269,7 +1272,7 @@ documented. To extend it safely:
 
 ## MCP Server
 
-The full first-class tool roster (live truth: `tools/list`, never a hardcoded count) surfaced via Hermes MCP (route/strategy planning + generic executors, PLUS first-class parity tools mirroring the CLI verbs: `robinhood_accounts`, `robinhood_positions`, `robinhood_portfolio` (one-call P&L: day Δ + after-hours Δ, drivers by underlying in dollars), `robinhood_buy`/`robinhood_sell` (the SAME shared order engine as the CLI — dedup, `ref_id`, OTC guard), `robinhood_cancel`, `robinhood_order_status` (UUID→ticker resolved), `robinhood_buying_power`, `robinhood_wheel` (evidence-based Wheel stage + next-leg command), `robinhood_options_holdings`, `robinhood_options_inspect`, `robinhood_settings`, `robinhood_recurring`, `robinhood_quote`, `robinhood_history`, `robinhood_watchlist` + the double-gated `robinhood_watchlist_add`/`robinhood_watchlist_remove`/`robinhood_watchlist_create` writes, `robinhood_options_enumerate`). Same engine -> same auth, gate, and method-aware routing as the CLI.
+The full first-class tool roster (live truth: `tools/list`, never a hardcoded count) surfaced via Hermes MCP (route/strategy planning + generic executors, PLUS first-class parity tools mirroring the CLI verbs: `robinhood_accounts`, `robinhood_positions`, `robinhood_portfolio` (one-call P&L: day Δ + after-hours Δ, drivers by underlying in dollars), `robinhood_buy`/`robinhood_sell` (the SAME shared order engine as the CLI — dedup, `ref_id`, OTC guard), `robinhood_cancel`, `robinhood_order_status` (UUID→ticker resolved), `robinhood_buying_power`, `robinhood_wheel` (evidence-based Wheel stage + next-leg command), `robinhood_options_holdings`, `robinhood_options_inspect`, `robinhood_settings`, `robinhood_recurring`, `robinhood_quote`, `robinhood_history`, `robinhood_watchlist` + the env-gated `robinhood_watchlist_add`/`robinhood_watchlist_remove`/`robinhood_watchlist_create` writes, `robinhood_options_enumerate`). Same engine -> same auth, gate, and method-aware routing as the CLI.
 
 > **Count note:** the *source/dist* registers the full roster (live truth: `tools/list`, never a hardcoded count). A *running* MCP process started before the
 > last tool additions will still advertise its old count until reloaded — run `/reload-mcp` (or restart
@@ -1318,30 +1321,30 @@ claude mcp add robinhood-cli -s user -- \
 | `robinhood_positions` | Equity positions for an account (UUIDs resolved to tickers + quotes) |
 | `robinhood_options_holdings` | Every held option contract (UUID + strike + bid/ask/last + qty + link) |
 | `robinhood_options_inspect` | Full detail on one owned contract (metadata, Greeks, fills, buy/sell handoff) |
-| `robinhood_settings` | Read/toggle account settings: DRIP, trade-on-expiration, PDT-protection, lending, sweep (double-gated) |
-| `robinhood_recurring` | List/create/edit/end recurring investment schedules (double-gated writes) |
+| `robinhood_settings` | Read/toggle account settings: DRIP, trade-on-expiration, PDT-protection, lending, sweep (env-gated) |
+| `robinhood_recurring` | List/create/edit/end recurring investment schedules (env-gated writes) |
 | `robinhood_quote` | Live quote(s) for one or more equity/ETF symbols |
 | `robinhood_history` | Unified history (equity + options + crypto orders + transfers), newest first |
 | `robinhood_watchlist` | Read custom watchlists (`owner_type=custom`) |
-| `robinhood_watchlist_add` | Add ticker(s) to a custom watchlist by name/id — batch `discovery/lists/items/` write (double-gated) |
-| `robinhood_watchlist_remove` | Remove ticker(s) from a custom watchlist by name/id (double-gated) |
-| `robinhood_watchlist_create` | Create a new custom watchlist (optional emoji) via `discovery/lists/` (double-gated) |
+| `robinhood_watchlist_add` | Add ticker(s) to a custom watchlist by name/id — batch `discovery/lists/items/` write (env-gated) |
+| `robinhood_watchlist_remove` | Remove ticker(s) from a custom watchlist by name/id (env-gated) |
+| `robinhood_watchlist_create` | Create a new custom watchlist (optional emoji) via `discovery/lists/` (env-gated) |
 | `robinhood_watchlist_items` | Read a custom watchlist's tickers live (symbol, price, equity-buyable flag) — the read half; pair with `robinhood_watchlist_buy` |
-| `robinhood_watchlist_buy` | **Basket buy** — buy $<amount> of EACH equity-buyable ticker in a watchlist (BP-aware; loops the shared order engine per ticker — OTC/dedup/`ref_id`/evidence guards) (double-gated) |
+| `robinhood_watchlist_buy` | **Basket buy** — buy $<amount> of EACH equity-buyable ticker in a watchlist (BP-aware; loops the shared order engine per ticker — OTC/dedup/`ref_id`/evidence guards) (env-gated) |
 | `robinhood_options_enumerate` | Bulk-enumerate every strike's `option_instrument_id` for a chain/expiration |
-| `robinhood_buy` | Equity buy (dollar-notional fractional or shares) — shared engine: OTC guard, pending-order dedup (5-min, `force` skips), `ref_id` idempotency, trade log; double-gated |
+| `robinhood_buy` | Equity buy (dollar-notional fractional or shares) — shared engine: OTC guard, pending-order dedup (5-min, `force` skips), `ref_id` idempotency, trade log; env-gated |
 | `robinhood_sell` | Equity sell — same shared engine + gates as `robinhood_buy` |
-| `robinhood_cancel` | Cancel a pending order by ID or URL (double-gated) |
+| `robinhood_cancel` | Cancel a pending order by ID or URL (env-gated) |
 | `robinhood_order_status` | One order's state/fills/price — instrument UUID resolved to the real ticker |
 | `robinhood_buying_power` | Per-account buying power breakdown + margin health |
 | `robinhood_wheel` | Wheel stage from account evidence (shares + short puts/calls) + the literal next-leg dry-run command; flags undercovered short calls; discussion mode when no position |
 
 ### MCP Safety Gates
 
-Same double-gate as CLI:
+Same single switch as the CLI:
 - **Reads run live** — no gate needed.
-- **Writes are dry-run by default.** To go live: `liveWrite: true` + `ROBINHOOD_ALLOW_LIVE_WRITE=1` in the server's environment.
-- `dryRun: true` always forces a plan, even with both gates set — a deliberate "preview this exact live call" escape hatch.
+- **Writes are dry-run by default.** To go live: set `ROBINHOOD_ALLOW_LIVE_WRITE=1` in the server's environment — the one switch; **no per-call `liveWrite` required** (it's accepted but optional, no longer the gate).
+- `dryRun: true` always forces a plan, even when the switch is on — a deliberate "preview this exact live call" escape hatch.
 
 Reload MCP tools in-session with `/reload-mcp`.
 
@@ -1399,13 +1402,13 @@ Always try Syncthing before fighting with SSH.
 7. **`owner_type=custom` is MANDATORY.** Every watchlist read without it returns 400: `"owner_type of request must be specified"`.
 8. **Rename uses `display_name`, not `name`.** Wrong field → 200 with no change.
 9. **The Options Watchlist cannot be deleted.** Robinhood hard-blocks it server-side (not a CLI bug).
-10. **Item add/remove ARE mapped (verified 2026-06-14); only reorder is not.** `watchlist add`/`remove` (MCP `robinhood_watchlist_add`/`_remove`) POST a list-id-keyed batch body to `discovery/lists/items/` — `{"<list_id>":[{"object_id":"<uuid>","object_type":"instrument","operation":"create"|"delete"}]}` — double-gated like every write. Item **reorder** (weight/sort) is still unmapped.
+10. **Item add/remove ARE mapped (verified 2026-06-14); only reorder is not.** `watchlist add`/`remove` (MCP `robinhood_watchlist_add`/`_remove`) POST a list-id-keyed batch body to `discovery/lists/items/` — `{"<list_id>":[{"object_id":"<uuid>","object_type":"instrument","operation":"create"|"delete"}]}` — env-gated like every write. Item **reorder** (weight/sort) is still unmapped.
 
 ### Writes & Safety
 
-11. **Writes need BOTH gates.** `--live-write` AND `ROBINHOOD_ALLOW_LIVE_WRITE=1`. One alone = dry-run. Never export the env var into your shell profile — keep it inline.
+11. **The live-write switch is the one gate.** `ROBINHOOD_ALLOW_LIVE_WRITE=1` set → writes go live (no per-call `--live-write` needed); unset → dry-run. Prefer scoping it inline (`ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli …`) over exporting it into your shell profile, where every later write would silently go live.
 12. **Method-aware routing fails closed.** A forced `--method POST` (or PATCH/PUT/DELETE) on a URL with no matching write route now returns **no match** (clear error), instead of silently degrading to the GET route — so a forced write can never be mis-resolved into a read at the wrong risk class. (GET/HEAD stay permissive for legacy route entries without method metadata.)
-13. **`dryRun: true` always wins in MCP.** Even with both gates set, it forces a plan. Use it to preview exact live calls.
+13. **`dryRun: true` always wins in MCP.** Even with the switch on, it forces a plan. Use it to preview exact live calls.
 
 ### Cross-Machine
 
@@ -1473,7 +1476,7 @@ node cli/dist/index.js brokerage execute "recurring list" --json
 # Resume all paused (dry-run first)
 node cli/dist/index.js brokerage execute "recurring resume --all" --json
 
-# Live resume — BOTH gates
+# Live resume — switch on
 ROBINHOOD_ALLOW_LIVE_WRITE=1 node cli/dist/index.js brokerage execute \
   "recurring resume --all --live-write" --json
 ```
@@ -1521,8 +1524,8 @@ query params) — use the `positions` command, or just `portfolio`.
 - [ ] MCP server starts: `node mcp/dist/server.js` (or `hermes mcp add` registered)
 - [ ] Route map count: `node cli/dist/index.js brokerage routes --json | python3 -c "import sys,json;print(json.load(sys.stdin)['count'])"` returns the live count (~300+ and growing — do NOT assert a hardcoded number; the count drifts as routes are captured)
 - [ ] Watchlists work: `node cli/dist/index.js brokerage execute "discovery/lists/?owner_type=custom" --json` returns 200
-- [ ] Dry-run gate works: a POST without `--live-write` returns `liveWriteBlocked`
-- [ ] Live write gate works: a POST with `--live-write` but without `ROBINHOOD_ALLOW_LIVE_WRITE=1` returns `liveWriteBlocked`
+- [ ] Dry-run default works: a POST without `ROBINHOOD_ALLOW_LIVE_WRITE=1` returns `liveWriteBlocked` (the single switch unset → forced dry-run)
+- [ ] Live-write switch works: a POST with `ROBINHOOD_ALLOW_LIVE_WRITE=1` set is allowed to send (no per-call `--live-write` needed); `dryRun`/`--dry-run` still previews even when it's on
 
 ---
 
@@ -1530,7 +1533,7 @@ query params) — use the `positions` command, or just `portfolio`.
 
 - Treat `api-map/robinhood-routes.json` as the unified route map: official Robinhood Crypto OpenAPI + community seed + sanitized CDP capture.
 - Treat `api-map/brokerage-routes.json` as the browser-backed brokerage/account subset used by `brokerage execute`.
-- Reads run live and free. Writes default to dry-run unless BOTH gates are set.
+- Reads run live and free. Writes default to dry-run unless `ROBINHOOD_ALLOW_LIVE_WRITE=1` is set.
 - Never trade, transfer, cancel, unlink, or mutate unless the user explicitly asked for that exact live operation. Echo back the resolved account + symbol + side + qty + price and get a yes before sending.
 - If you discover a route not in the map, add it, classify risk conservatively, rebuild, and document the discovery in `docs/undocumented-surface.md`.
 - If you hit a 401: the engine self-heals. If it fails, run `pnpm auth:refresh` manually.

--- a/SKILL.md
+++ b/SKILL.md
@@ -176,7 +176,7 @@ is double-gated (`--live-write` + `ROBINHOOD_ALLOW_LIVE_WRITE=1`).
 - **Sell to open** — short call or short put / naked (`side:sell, position_effect:open`; needs option level + BP).
 - **Buy to close** — cover a short (`side:buy, position_effect:close`).
 
-**Options — multi-leg / strategies** (`options strategy-quote`, `api-map options-strategies`; 18+ workflows)
+**Options — multi-leg / strategies** (`options strategy-quote`, `api-map options-strategies`; 20 workflows)
 - Vertical spreads: call/put **debit** and **credit** spreads.
 - **Covered call (CC)** and **cash-secured put (CSP)** (coverage/collateral checked); covered put.
 - Straddles / strangles (long & short), butterflies, iron condors, calendars / diagonals.
@@ -435,7 +435,7 @@ Keep this split current when editing the skill:
 |---------|---------------|------------|
 | API map | ~300 brokerage/account route entries (live count via `brokerage routes --json`) plus official Crypto API routes | Rebuild after edits; runtime reads `cli/dist/api-map/` |
 | Read commands | `quote`, `positions`, `options positions`, `options expirations`, `options chain`, `watchlist list`, `recurring list`, route-map reads, crypto read plans | Live reads are allowed with caller-owned auth, but redact balances/tokens in shareable output |
-| Options research/planning | 18 strategy workflows; `options-strategy-plan` emits `reviewContract` | Planning only until exact user approval and write gates |
+| Options research/planning | 20 strategy workflows; `options-strategy-plan` emits `reviewContract` | Planning only until exact user approval and write gates |
 | Equity/options order writes | Route-map executor against `orders/`, `options/orders/`, and cancel routes | Must use `--method`, exact body, `--live-write`, and `ROBINHOOD_ALLOW_LIVE_WRITE=1`; dry-run first |
 | Recurring investments | First-class `recurring list`, `recurring resume`, `recurring pause`; route map also has GET one schedule and POST create | Resume/pause are the verified first-class writes. Create/edit amount/funding-source are route-map research unless a fresh capture verifies body shape |
 | Watchlist read / edit / basket-buy | `watchlist list`/`items` (read); `watchlist add`/`remove`/`create` + `watchlist buy` (basket) (MCP `robinhood_watchlist_add`/`_remove`/`_create`/`_items`/`_buy`) | Double-gated writes (verified 2026-06-14): add/remove batch `discovery/lists/items/`, create POSTs `discovery/lists/`; `watchlist buy` loops the shared order engine per ticker (BP-aware, OTC/dedup/`ref_id` guards, skips what won't fit); item reorder still route-map research |
@@ -538,7 +538,7 @@ screen into a tradeable research object:
 1. Resolve symbol -> instrument -> chain id -> expiration -> option instrument ids.
 2. Quote individual legs with `marketdata/options/`; quote multi-leg packages
    with `marketdata/options/strategy/quotes/` when available.
-3. Classify the strategy from the 18-workflow catalog before building an order.
+3. Classify the strategy from the 20-workflow catalog before building an order.
 4. Compute payoff math separately from Greek sensitivity math.
 5. Emit missing fields and blockers before any dry-run body.
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -653,7 +653,7 @@ brokerage
 
 brokerage
   .command("execute")
-  .description("Execute a brokerage/account request. Reads run live; writes are dry-run by default and require --live-write plus ROBINHOOD_ALLOW_LIVE_WRITE=1. Uses ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE.")
+  .description("Execute a brokerage/account request. Reads run live; writes are dry-run by default and require ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional). Uses ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE.")
   .argument("<query>", "exact URL or URL substring")
   .option("--method <method>", "override inferred HTTP method")
   .option("--param <name=value>", "replace a route placeholder; repeatable", (value: string, previous: string[] = []) => [
@@ -666,7 +666,7 @@ brokerage
   ])
   .option("--body-json <json>", "JSON request body")
   .option("--dry-run", "print execution plan without sending")
-  .option("--live-write", "permit a live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--full", "print full response body instead of bounded preview")
   .option("--json", "emit JSON")
   .action(async (query: string, options: { method?: string; param?: string[]; queryParam?: string[]; bodyJson?: string; dryRun?: boolean; liveWrite?: boolean; full?: boolean; json?: boolean }) => {
@@ -713,14 +713,14 @@ brokerage
 const ORDERS_URL = "https://api.robinhood.com/orders/";
 brokerage
   .command("buy <symbol>")
-  .description("Equity buy: --dollars (fractional/market) or --shares (whole; OTC auto-limit). Web order body. Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Equity buy: --dollars (fractional/market) or --shares (whole; OTC auto-limit). Web order body. Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional).")
   .requiredOption("--account <account_number>", "brokerage account number")
   .option("--dollars <amount>", "dollar-notional fractional buy (market, regular hours only)")
   .option("--shares <qty>", "share quantity (whole shares for OTC names)")
   .option("--limit <price>", "explicit limit price; else market with ask collar (OTC forces a limit at the ask)")
   .option("--tif <gfd|gtc>", "time in force", "gfd")
   .option("--dry-run", "print plan/body, send nothing")
-  .option("--live-write", "permit a live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (symbol: string, opts: { account: string; dollars?: string; shares?: string; limit?: string; tif?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (!opts.dollars && !opts.shares) throw new Error("Pass --dollars <amt> or --shares <qty>.");
@@ -878,9 +878,9 @@ function collectId(value: string, previous: string[] = []): string[] {
   return [...previous, value];
 }
 
-// Generic double-gated brokerage write. Pass the EXACT templated URL (with {placeholders}) so the
+// Generic env-gated brokerage write. Pass the EXACT templated URL (with {placeholders}) so the
 // resolver matches one route and the ambiguity guard can't fire. Dry-run by default; a live send
-// needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1. Returns status + the (dry-run or live) body.
+// needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional). Returns status + the (dry-run or live) body.
 // gatedBrokerageWrite is imported from ./lib.js — shared write executor (CLI + MCP).
 
 async function runRecurringSet(
@@ -961,12 +961,12 @@ recurring
 
 recurring
   .command("resume")
-  .description("Resume paused recurring buys. Live write — needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1 (else dry-run).")
+  .description("Resume paused recurring buys. Live write — needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional) (else dry-run).")
   .option("--id <id>", "schedule id to resume; repeatable", collectId, [])
   .option("--all", "resume ALL currently-paused schedules")
   .option("--account <num>", "limit --all to one account number")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (options: { id?: string[]; all?: boolean; account?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) =>
     runRecurringSet("active", options)
@@ -974,12 +974,12 @@ recurring
 
 recurring
   .command("pause")
-  .description("Pause active recurring buys. Live write — needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1 (else dry-run).")
+  .description("Pause active recurring buys. Live write — needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional) (else dry-run).")
   .option("--id <id>", "schedule id to pause; repeatable", collectId, [])
   .option("--all", "pause ALL currently-active schedules")
   .option("--account <num>", "limit --all to one account number")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (options: { id?: string[]; all?: boolean; account?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) =>
     runRecurringSet("paused", options)
@@ -987,14 +987,14 @@ recurring
 
 recurring
   .command("create")
-  .description("Create a recurring investment schedule (PROVEN write). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Create a recurring investment schedule (PROVEN write). Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional).")
   .requiredOption("--account <account_number>", "account number")
   .requiredOption("--symbol <ticker>", "equity ticker to invest in")
   .requiredOption("--amount <usd>", "dollar amount per cycle")
   .option("--frequency <weekly|biweekly|monthly>", "cadence", "weekly")
   .option("--start-date <YYYY-MM-DD>", "first investment date (default: tomorrow)")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account: string; symbol: string; amount: string; frequency?: string; startDate?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (!(Number(opts.amount) > 0)) throw new Error(`--amount must be a positive number (got "${opts.amount}").`);
@@ -1025,7 +1025,7 @@ recurring
   .option("--amount <usd>", "new dollar amount per cycle")
   .option("--frequency <weekly|biweekly|monthly>", "new cadence")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { id: string; amount?: string; frequency?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (!opts.amount && !opts.frequency) throw new Error("Pass --amount and/or --frequency to edit.");
@@ -1042,10 +1042,10 @@ recurring
 
 recurring
   .command("end")
-  .description("End/delete a recurring schedule (PATCH state=deleted). Dry-run by default; live needs both gates.")
+  .description("End/delete a recurring schedule (PATCH state=deleted). Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch).")
   .requiredOption("--id <schedule_id>", "schedule id to end")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { id: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     const r = await gatedBrokerageWrite({ url: RECURRING_ITEM_URL, method: "PATCH", params: { "0": opts.id }, body: { state: "deleted" }, dryRun: opts.dryRun, liveWrite: opts.liveWrite });
@@ -1058,7 +1058,7 @@ recurring
 program.addCommand(recurring);
 
 // --- Account settings: first-class wrappers over the PROVEN settings-write endpoints ---
-// (capability map docs/account-settings-capability-map-2026-06-03.md). Every write double-gated.
+// (capability map docs/account-settings-capability-map-2026-06-03.md). Every write env-gated.
 const DRIP_ACCOUNT_URL = "https://api.robinhood.com/corp_actions/drip/account_settings/{account_number}/";
 const DRIP_INSTRUMENT_URL = "https://api.robinhood.com/corp_actions/drip/instrument_settings/{account_number}/{instrument_id}/";
 const OPTION_SETTINGS_URL = "https://api.robinhood.com/options/option_settings/{account_number}/";
@@ -1066,7 +1066,7 @@ const MARGIN_SETTINGS_URL = "https://api.robinhood.com/settings/margin/{account_
 const SWEEP_STATE_URL = "https://api.robinhood.com/accounts/{account_number}/sweep_enrollment_state/";
 const STOCK_LENDING_URL = "https://bonfire.robinhood.com/slip/{account_number}/status/";
 
-const settings = new Command("settings").description("Read/write account settings: DRIP, trade-on-expiration, PDT protection, cash sweep, stock lending. Writes double-gated.");
+const settings = new Command("settings").description("Read/write account settings: DRIP, trade-on-expiration, PDT protection, cash sweep, stock lending. Writes env-gated.");
 
 settings
   .command("show")
@@ -1102,13 +1102,13 @@ const writeFlag = (action: () => Promise<{ status: number | string; dryRun: bool
 
 settings
   .command("drip")
-  .description("Toggle dividend reinvestment (DRIP). Account-wide, or per-stock with --instrument. Double-gated.")
+  .description("Toggle dividend reinvestment (DRIP). Account-wide, or per-stock with --instrument. Env-gated.")
   .requiredOption("--account <account_number>", "account number")
   .option("--enable", "turn DRIP on")
   .option("--disable", "turn DRIP off")
   .option("--instrument <instrument_id>", "scope to one stock (per-instrument DRIP)")
   .option("--dry-run", "plan only")
-  .option("--live-write", "permit live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account: string; enable?: boolean; disable?: boolean; instrument?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (opts.enable === opts.disable) throw new Error("Pass exactly one of --enable / --disable.");
@@ -1121,12 +1121,12 @@ settings
 
 settings
   .command("expiration")
-  .description("Toggle 'trade on expiration' for options. Double-gated.")
+  .description("Toggle 'trade on expiration' for options. Env-gated.")
   .requiredOption("--account <account_number>", "account number")
   .option("--enable", "enable trading on expiration")
   .option("--disable", "disable trading on expiration")
   .option("--dry-run", "plan only")
-  .option("--live-write", "permit live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account: string; enable?: boolean; disable?: boolean; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (opts.enable === opts.disable) throw new Error("Pass exactly one of --enable / --disable.");
@@ -1136,12 +1136,12 @@ settings
 
 settings
   .command("pdt")
-  .description("Toggle PDT (pattern-day-trade) protection. Double-gated.")
+  .description("Toggle PDT (pattern-day-trade) protection. Env-gated.")
   .requiredOption("--account <account_number>", "account number")
   .option("--on", "enable PDT protection")
   .option("--off", "disable PDT protection")
   .option("--dry-run", "plan only")
-  .option("--live-write", "permit live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account: string; on?: boolean; off?: boolean; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (opts.on === opts.off) throw new Error("Pass exactly one of --on / --off.");
@@ -1151,12 +1151,12 @@ settings
 
 settings
   .command("lending")
-  .description("Toggle stock lending (SLIP). Double-gated.")
+  .description("Toggle stock lending (SLIP). Env-gated.")
   .requiredOption("--account <account_number>", "account number")
   .option("--enable", "enable stock lending")
   .option("--disable", "disable stock lending")
   .option("--dry-run", "plan only")
-  .option("--live-write", "permit live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account: string; enable?: boolean; disable?: boolean; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (opts.enable === opts.disable) throw new Error("Pass exactly one of --enable / --disable.");
@@ -1166,11 +1166,11 @@ settings
 
 settings
   .command("sweep")
-  .description("Cash sweep enrollment. --disable unenrolls (proven). Enroll requires a separate agreement-sign flow — not automated. Double-gated.")
+  .description("Cash sweep enrollment. --disable unenrolls (proven). Enroll requires a separate agreement-sign flow — not automated. Env-gated.")
   .requiredOption("--account <account_number>", "account number")
   .option("--disable", "unenroll from cash sweep")
   .option("--dry-run", "plan only")
-  .option("--live-write", "permit live write")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account: string; disable?: boolean; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (!opts.disable) throw new Error("Only --disable (unenroll) is automated. Enrolling needs the agreement-sign flow (see capability map).");
@@ -1791,7 +1791,7 @@ options
       greeks: { delta: num(mark.delta), gamma: num(mark.gamma), theta: num(mark.theta), vega: num(mark.vega), rho: num(mark.rho) },
       openInterest: num(mark.open_interest), volume: num(mark.volume),
       fills, taxNote, link,
-      handoff: "Sell-to-close: options/orders/ {side:sell, position_effect:close}. Buy-to-open: {side:buy, position_effect:open}. Dry-run via 'options strategy-quote', live needs both write gates."
+      handoff: "Sell-to-close: options/orders/ {side:sell, position_effect:close}. Buy-to-open: {side:buy, position_effect:open}. Dry-run via 'options strategy-quote', live needs the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch."
     };
     if (opts.json) { printJson(out); return; }
     process.stdout.write(`${out.symbol} $${out.strike.toFixed(2)}${String(out.type)[0].toUpperCase()} exp ${out.expiration} (${out.state})\n`);
@@ -3370,13 +3370,13 @@ ordersCmd
 
 program.addCommand(ordersCmd);
 
-// ── panic: enumerate and cancel EVERY open order across all accounts (double-gated per cancel) ──
+// ── panic: enumerate and cancel EVERY open order across all accounts (env-gated per cancel) ──
 // Zayd Khan // cold // www.zayd.wtf
 program
   .command("panic")
-  .description("Cancel-all: list every open/pending equity+options order across ALL accounts and cancel each (each cancel individually double-gated). DRY-RUN by default — shows the would-cancel list and sends NOTHING; live needs --live-write + ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Cancel-all: list every open/pending equity+options order across ALL accounts and cancel each (each cancel individually env-gated). DRY-RUN by default — shows the would-cancel list and sends NOTHING; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional).")
   .option("-a, --account <number>", "Limit to one account")
-  .option("--live-write", "Send the cancels live (still requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (opts: { account?: string; liveWrite?: boolean; json?: boolean }) => {
     const r = await panicCancelAll({ accountNumber: opts.account, liveWrite: Boolean(opts.liveWrite) });
@@ -3499,7 +3499,7 @@ program
     if (pendingRolls.length) process.stdout.write(`\n⏳ ${pendingRolls.length} pending kosher roll(s) — run roll-ledger list\n`);
   });
 
-const watchlist = new Command("watchlist").description("Inspect (read) and edit (add/remove/create, double-gated) your custom watchlists");
+const watchlist = new Command("watchlist").description("Inspect (read) and edit (add/remove/create, env-gated) your custom watchlists");
 
 watchlist
   .command("list")
@@ -3532,9 +3532,9 @@ watchlist
 
 watchlist
   .command("add <list> <symbols...>")
-  .description("Add tickers to a custom watchlist (by name or id). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Add tickers to a custom watchlist (by name or id). Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional).")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (list: string, symbols: string[], opts: { dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     const out = await watchlistMutateItems({ list, symbols, operation: "create", dryRun: opts.dryRun, liveWrite: opts.liveWrite });
@@ -3546,9 +3546,9 @@ watchlist
 
 watchlist
   .command("remove <list> <symbols...>")
-  .description("Remove tickers from a custom watchlist (by name or id). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Remove tickers from a custom watchlist (by name or id). Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional).")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (list: string, symbols: string[], opts: { dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     const out = await watchlistMutateItems({ list, symbols, operation: "delete", dryRun: opts.dryRun, liveWrite: opts.liveWrite });
@@ -3560,10 +3560,10 @@ watchlist
 
 watchlist
   .command("create <name>")
-  .description("Create a new custom watchlist. Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Create a new custom watchlist. Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional).")
   .option("--emoji <emoji>", "icon emoji for the list")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (name: string, opts: { emoji?: string; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     const out = await createWatchlist({ displayName: name, iconEmoji: opts.emoji, dryRun: opts.dryRun, liveWrite: opts.liveWrite });
@@ -3589,14 +3589,14 @@ watchlist
 
 watchlist
   .command("buy <list>")
-  .description("Buy $<amount> of EACH equity-buyable ticker in a custom watchlist (BP-aware basket). Dry-run by default; live needs --live-write AND ROBINHOOD_ALLOW_LIVE_WRITE=1.")
+  .description("Buy $<amount> of EACH equity-buyable ticker in a custom watchlist (BP-aware basket). Dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional).")
   .requiredOption("--account <number>", "account number to buy into")
   .option("--amount <dollars>", "dollars per ticker (Robinhood minimum $1.00)", "1")
   .option("--limit <n>", "cap the number of tickers attempted")
   .option("--delay <ms>", "pace between live sends (429 burst guard)", "2500")
   .option("--force", "skip per-order dedup + the after-hours fractional pre-flight guard")
   .option("--dry-run", "plan only, send nothing")
-  .option("--live-write", "permit the live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional (back-compat); gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
   .action(async (list: string, opts: { account: string; amount?: string; limit?: string; delay?: string; force?: boolean; dryRun?: boolean; liveWrite?: boolean; json?: boolean }) => {
     const out = await buyWatchlistBasket({
@@ -3729,7 +3729,7 @@ crypto
 
 crypto
   .command("execute")
-  .description("Execute an official Robinhood Crypto API request. Reads run live; writes (orders/cancels) are dry-run by default and require --live-write plus ROBINHOOD_ALLOW_LIVE_WRITE=1. Uses ROBINHOOD_CRYPTO_API_KEY and ROBINHOOD_CRYPTO_PRIVATE_KEY_B64.")
+  .description("Execute an official Robinhood Crypto API request. Reads run live; writes (orders/cancels) are dry-run by default and require ROBINHOOD_ALLOW_LIVE_WRITE=1 (single switch; --live-write optional). Uses ROBINHOOD_CRYPTO_API_KEY and ROBINHOOD_CRYPTO_PRIVATE_KEY_B64.")
   .argument("<query>", "exact official Crypto URL or URL substring")
   .option("--method <method>", "override inferred HTTP method")
   .option("--param <name=value>", "replace a route placeholder; repeatable", (value: string, previous: string[] = []) => [
@@ -3743,7 +3743,7 @@ crypto
   .option("--body <body>", "exact request body string")
   .option("--body-json <json>", "JSON request body")
   .option("--dry-run", "print execution plan without sending")
-  .option("--live-write", "permit a live write (also requires ROBINHOOD_ALLOW_LIVE_WRITE=1)")
+  .option("--live-write", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--full", "print full response body instead of bounded preview")
   .option("--json", "emit JSON")
   .action(

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -1088,7 +1088,7 @@ export function buildOptionsContractNavigationPlan(input: OptionsContractNavigat
       id: "handoff-order-endpoint",
       method: "POST",
       url: "https://api.robinhood.com/options/orders/",
-      purpose: "Dry-run handoff only; live send still requires exact approval and the double write gate.",
+      purpose: "Dry-run handoff only; live send still requires exact approval and the ROBINHOOD_ALLOW_LIVE_WRITE=1 write switch.",
       required: true
     }
   ];
@@ -1163,7 +1163,7 @@ export function buildOptionsContractNavigationPlan(input: OptionsContractNavigat
       "Dry-run planner only. This command opens nothing and sends no Robinhood order.",
       "Only account_number on the web options-chain shell is browser-observed. Expiration, strike, side, and type query keys are candidate probe keys, not proven URL state.",
       "For exact contracts, prefer API resolution: chains -> instruments filtered by expiration/type/strike -> marketdata/options -> strategy quote -> dry-run order body.",
-      "Live options orders remain blocked unless exact user approval, --live-write, and ROBINHOOD_ALLOW_LIVE_WRITE=1 are all present.",
+      "Live options orders remain blocked unless exact user approval and ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional) are present.",
       ...riskWarnings("write-mutate")
     ],
     evidence: [
@@ -1353,7 +1353,7 @@ export function buildOptionsQuantReviewContract(workflow: OptionsStrategyWorkflo
     "net Greeks are summed over signed legs with the 100-share multiplier and unit labels",
     "liquidity is reviewed: bid/ask width, volume/open interest if available, and stale quote flags",
     "expiration risks are reviewed: 0DTE/near-expiration, assignment/exercise, and dividend events",
-    "write gates are dry-run unless exact approval, --live-write, and ROBINHOOD_ALLOW_LIVE_WRITE=1 are present"
+    "writes are dry-run unless exact approval and ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional) are present"
   ];
   if (workflow.requiresUnderlying) {
     requiredChecks.push("coverage is verified in the same account before treating the strategy as covered");
@@ -1457,7 +1457,7 @@ export function buildOptionsQuantReviewContract(workflow: OptionsStrategyWorkflo
       "coverage or collateral claim not verified in the same account",
       "strategy quote stale or missing for a multi-leg order",
       "missing limit_price, quantity, time_in_force, or ref_id",
-      "any live write attempted without --live-write and ROBINHOOD_ALLOW_LIVE_WRITE=1"
+      "any live write attempted without ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional)"
     ]
   };
 }
@@ -1767,15 +1767,28 @@ export interface LiveWriteGate {
 }
 
 /**
- * Writes never go live unless the caller both passes --live-write AND sets the
- * ROBINHOOD_ALLOW_LIVE_WRITE=1 environment gate. Reads and explicit --dry-run
- * runs are always allowed. This keeps the CLI from ever placing a real order on
- * its own: a write requires two deliberate, separate opt-ins.
+ * Live-write gate — single master switch.
+ *
+ * Writes go live ONLY when `ROBINHOOD_ALLOW_LIVE_WRITE=1` is present in the
+ * environment. That one switch is the toggle: set it (locally it lives in `.env`
+ * / the MCP server registration) and writes execute by default — no per-call
+ * `--live-write` / `liveWrite:true` flag is required. With the switch unset (the
+ * published / fresh-clone default) every write is forced to dry-run, so the tool
+ * can never place a real order out of the box.
+ *
+ * `--dry-run` / `dryRun:true` always forces a preview, even when the switch is on
+ * — the per-call escape hatch to inspect an exact live call without sending it.
+ *
+ * The legacy `liveWrite` field is still accepted (so existing callers/scripts keep
+ * compiling and reading clearly) but is no longer required and no longer the gate:
+ * the env switch is the single source of truth. Previously this required BOTH the
+ * env var AND a per-call flag; the per-call flag is now optional.
  */
 export function resolveLiveWriteGate(input: {
   risk: RouteRisk;
   dryRun: boolean;
-  liveWrite: boolean;
+  /** Legacy/optional: retained for back-compat. The env switch is the real gate. */
+  liveWrite?: boolean;
   /** HTTP method — when it's a write verb, the gate engages even if `risk` is mis-classified as read. */
   method?: string;
   env?: NodeJS.ProcessEnv;
@@ -1787,31 +1800,21 @@ export function resolveLiveWriteGate(input: {
   const m = input.method?.toUpperCase();
   const methodIsWrite = m !== undefined && m !== "GET" && m !== "HEAD";
   const isWrite = riskIsWrite(input.risk) || methodIsWrite;
+  // Explicit per-call preview, or a plain read: never sends.
   if (input.dryRun || !isWrite) {
     return { allowed: true, forcedDryRun: false };
   }
-  const envAllows = env.ROBINHOOD_ALLOW_LIVE_WRITE === "1";
-  if (input.liveWrite && envAllows) {
+  // Single master switch: ROBINHOOD_ALLOW_LIVE_WRITE=1 turns live writes ON by default,
+  // with no per-call flag required. Pass --dry-run / dryRun:true to preview instead.
+  if (env.ROBINHOOD_ALLOW_LIVE_WRITE === "1") {
     return { allowed: true, forcedDryRun: false };
   }
-  if (!input.liveWrite && !envAllows) {
-    return {
-      allowed: false,
-      forcedDryRun: true,
-      reason: "Live write blocked: pass --live-write and set ROBINHOOD_ALLOW_LIVE_WRITE=1 to send. Forced to dry-run."
-    };
-  }
-  if (!input.liveWrite) {
-    return {
-      allowed: false,
-      forcedDryRun: true,
-      reason: "Live write blocked: ROBINHOOD_ALLOW_LIVE_WRITE=1 is set but --live-write was not passed. Forced to dry-run."
-    };
-  }
+  // Switch off → writes are forced to dry-run (the safe default for the published tool).
   return {
     allowed: false,
     forcedDryRun: true,
-    reason: "Live write blocked: --live-write was passed but ROBINHOOD_ALLOW_LIVE_WRITE=1 is not set. Forced to dry-run."
+    reason:
+      "Live writes are OFF — forced to dry-run. Turn them on by setting ROBINHOOD_ALLOW_LIVE_WRITE=1 in the environment (locally it lives in .env / the MCP registration). Pass --dry-run / dryRun:true to preview a single call even when live writes are on."
   };
 }
 
@@ -1825,13 +1828,13 @@ export function riskWriteWarning(risk: RouteRisk, url: string): string | undefin
 export function riskWarnings(risk: RouteRisk): string[] {
   switch (risk) {
     case "destructive":
-      return ["Destructive route. Dry-run by default; a live write needs --live-write plus ROBINHOOD_ALLOW_LIVE_WRITE=1."];
+      return ["Destructive route. Dry-run by default; a live write needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional)."];
     case "write-mutate":
-      return ["Write route. Dry-run by default; a live write needs --live-write plus ROBINHOOD_ALLOW_LIVE_WRITE=1."];
+      return ["Write route. Dry-run by default; a live write needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional)."];
     case "write-safe":
-      return ["Non-account-state write route such as telemetry or acknowledgement. Dry-run by default; a live write needs --live-write plus ROBINHOOD_ALLOW_LIVE_WRITE=1."];
+      return ["Non-account-state write route such as telemetry or acknowledgement. Dry-run by default; a live write needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional)."];
     case "write-or-sensitive":
-      return ["Potential write or highly sensitive route. Dry-run by default; a live write needs --live-write plus ROBINHOOD_ALLOW_LIVE_WRITE=1."];
+      return ["Potential write or highly sensitive route. Dry-run by default; a live write needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional)."];
     case "sensitive-read":
       return ["Sensitive read route. Redact account identifiers, positions, documents, and tax data in shared artifacts."];
     default:
@@ -2425,10 +2428,10 @@ export async function readOptionsOrderFlow(
 }
 
 /**
- * Generic double-gated brokerage write, shared by the CLI and the MCP server. Pass the EXACT templated
+ * Generic env-gated brokerage write, shared by the CLI and the MCP server. Pass the EXACT templated
  * URL (with {placeholders}) so the resolver matches one route and the ambiguity guard can't fire. The
  * gate engages on write verbs even if a route's risk is mis-classified (verb floor). Dry-run by default;
- * a live send needs liveWrite:true AND ROBINHOOD_ALLOW_LIVE_WRITE=1. Hoisted here so the write path
+ * a live send needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; liveWrite:true optional). Hoisted here so the write path
  * (the dangerous one to duplicate) is single-source across both surfaces.
  */
 export async function gatedBrokerageWrite(opts: {
@@ -2497,7 +2500,7 @@ export async function logTrade(entry: Record<string, unknown>) {
 //   delete a list    : DELETE discovery/lists/{id}/    (204)
 // object_id is the instrument UUID (resolved from a ticker via instruments/?symbol=), never the symbol.
 // operation: "create" = add, "delete" = remove. Both ride the same items endpoint. As with every write
-// here, these go through gatedBrokerageWrite — dry-run unless BOTH gates (liveWrite + env) are set.
+// here, these go through gatedBrokerageWrite — dry-run unless the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch is set (liveWrite optional).
 
 export const DISCOVERY_LISTS_URL = "https://api.robinhood.com/discovery/lists/";
 export const DISCOVERY_LISTS_ITEMS_URL = "https://api.robinhood.com/discovery/lists/items/";
@@ -2559,7 +2562,7 @@ export interface WatchlistMutateDeps {
 
 /**
  * Add or remove tickers in a custom watchlist. Resolves the list (by name/id) and each ticker (to an
- * instrument UUID), builds the list-keyed batch body, and sends it through the double-gated write path.
+ * instrument UUID), builds the list-keyed batch body, and sends it through the env-gated write path.
  */
 export async function watchlistMutateItems(input: WatchlistMutateInput, deps: WatchlistMutateDeps = {}) {
   const getJson = deps.getJson ?? brokerageGetJson;
@@ -2590,7 +2593,7 @@ export async function watchlistMutateItems(input: WatchlistMutateInput, deps: Wa
   return { list: wl, operation: input.operation, items: resolved, body, result };
 }
 
-/** Create a new custom watchlist (POST discovery/lists/). Double-gated. */
+/** Create a new custom watchlist (POST discovery/lists/). Env-gated. */
 export async function createWatchlist(
   input: { displayName: string; iconEmoji?: string; dryRun?: boolean; liveWrite?: boolean },
   deps: { write?: typeof gatedBrokerageWrite } = {}
@@ -2609,7 +2612,7 @@ export async function createWatchlist(
   return { displayName: input.displayName, body, result };
 }
 
-/** Delete a custom watchlist by id (DELETE discovery/lists/{id}/). Double-gated; irreversible. */
+/** Delete a custom watchlist by id (DELETE discovery/lists/{id}/). Env-gated; irreversible. */
 export async function deleteWatchlist(
   input: { id: string; dryRun?: boolean; liveWrite?: boolean },
   deps: { write?: typeof gatedBrokerageWrite } = {}
@@ -2896,7 +2899,7 @@ export interface EquityOrderInput {
   shares?: number;
   /** Limit price; omit for a market order. */
   limitPrice?: number;
-  /** Live send — still requires ROBINHOOD_ALLOW_LIVE_WRITE=1 (second gate, enforced downstream). */
+  /** Optional (back-compat) — the gate is ROBINHOOD_ALLOW_LIVE_WRITE=1, enforced downstream. */
   liveWrite?: boolean;
   /** Skip the pending-duplicate check. */
   force?: boolean;
@@ -2951,7 +2954,7 @@ export interface EquityOrderResult {
  *   4. pending-duplicate check (live sends only; 5-min window; force skips)
  *   5. ref_id idempotency (safe to retry the SAME ref_id on 429 — nothing was placed)
  *   6. trading-log append on live sends
- * Dry-run unless liveWrite — and even then the engine's double gate still applies.
+ * Dry-run unless the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch is set — the engine's env gate still applies.
  */
 export async function placeEquityOrder(input: EquityOrderInput, deps: EquityOrderDeps = {}): Promise<EquityOrderResult> {
   const getJson = deps.getJson ?? brokerageGetJson;
@@ -3260,8 +3263,8 @@ export interface CancelOrderResult {
 
 /**
  * Shared cancel path for equity AND options orders — single source for the CLI `cancel` command,
- * the MCP `robinhood_cancel` tool, and `panicCancelAll`. Double-gated via gatedBrokerageWrite
- * (dry-run by default; live needs liveWrite + ROBINHOOD_ALLOW_LIVE_WRITE=1). After a live 2xx it
+ * the MCP `robinhood_cancel` tool, and `panicCancelAll`. Env-gated via gatedBrokerageWrite
+ * (dry-run by default; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 — the single switch; liveWrite optional). After a live 2xx it
  * re-reads the order and reports evidence; a cancel whose re-read is not cancelled/pending gets a
  * warning (it may have filled before the cancel landed).
  */
@@ -3444,9 +3447,9 @@ export interface PanicResult {
 
 /**
  * PANIC: enumerate every open/pending order across ALL owned accounts and cancel each one —
- * every cancel individually double-gated through gatedBrokerageWrite (logContext "panic
+ * every cancel individually env-gated through gatedBrokerageWrite (logContext "panic
  * cancel-all"). Dry-run by default: shows the full would-cancel list and sends NOTHING; a live
- * run needs liveWrite + ROBINHOOD_ALLOW_LIVE_WRITE=1 and re-reads each order for evidence.
+ * run needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; liveWrite optional) and re-reads each order for evidence.
  * One failed cancel never stops the sweep.
  */
 export async function panicCancelAll(
@@ -3472,14 +3475,14 @@ export async function panicCancelAll(
       rows.push({ ...o, cancel: { httpStatus: r.httpStatus, dryRun: r.dryRun, state: r.state, evidence: r.evidence, gateReason: r.gateReason } });
     } catch (error) {
       failed++;
-      rows.push({ ...o, cancel: { httpStatus: "error", dryRun: !liveWrite, state: null, error: (error as Error).message } });
+      rows.push({ ...o, cancel: { httpStatus: "error", dryRun: process.env.ROBINHOOD_ALLOW_LIVE_WRITE !== "1", state: null, error: (error as Error).message } });
     }
   }
-  const dryRun = rows.length > 0 ? rows.every((r) => r.cancel.dryRun) : !(liveWrite && process.env.ROBINHOOD_ALLOW_LIVE_WRITE === "1");
+  const dryRun = rows.length > 0 ? rows.every((r) => r.cancel.dryRun) : process.env.ROBINHOOD_ALLOW_LIVE_WRITE !== "1";
   const summary = rows.length === 0
     ? `No open/pending orders found across ${open.accountsScanned.length} account(s) — nothing to cancel.`
     : dryRun
-      ? `DRY RUN: ${rows.length} open order(s) WOULD be cancelled — nothing was sent. Re-run with --live-write (liveWrite:true) AND ROBINHOOD_ALLOW_LIVE_WRITE=1 to cancel for real.`
+      ? `DRY RUN: ${rows.length} open order(s) WOULD be cancelled — nothing was sent. Re-run with ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; --live-write optional) to cancel for real.`
       : `${rows.length} open order(s) found: ${cancelled} cancelled, ${failed} failed (evidence re-read per cancel; order history is the source of truth).`;
   return { dryRun, accountsScanned: open.accountsScanned, found: rows.length, cancelled, failed, orders: rows, warnings: open.warnings, summary };
 }
@@ -3694,7 +3697,7 @@ export async function runPretradeChecks(
   checks.push({
     id: "marketability",
     status: "MANUAL",
-    detail: `manual step (POST, gated): options/orders/marketability/ is a POST — pretrade never sends it. To probe marketability yourself, dry-run first: node cli/dist/index.js brokerage execute "https://bonfire.robinhood.com/options/orders/marketability/" --method POST --body-json '<order body>' --dry-run --json   (a live probe needs --live-write + ROBINHOOD_ALLOW_LIVE_WRITE=1).`
+    detail: `manual step (POST, gated): options/orders/marketability/ is a POST — pretrade never sends it. To probe marketability yourself, dry-run first: node cli/dist/index.js brokerage execute "https://bonfire.robinhood.com/options/orders/marketability/" --method POST --body-json '<order body>' --dry-run --json   (a live probe needs ROBINHOOD_ALLOW_LIVE_WRITE=1 — the single switch; --live-write optional).`
   });
 
   // (f) OTC / fractional guard for the equity symbol
@@ -3724,7 +3727,7 @@ export async function runPretradeChecks(
     clear,
     summary: clear ? "CLEAR TO BUILD ORDER" : `BLOCKED: ${blocks.map((b) => `${b.id} — ${b.detail}`).join(" | ")}`,
     resolved,
-    note: "READ-ONLY preflight: nothing was sent. CLEAR means no hard blocker was found with the inputs given — it is NOT order approval; build the dry-run body next, then send only with both write gates."
+    note: "READ-ONLY preflight: nothing was sent. CLEAR means no hard blocker was found with the inputs given — it is NOT order approval; build the dry-run body next, then send only with the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch."
   };
 }
 
@@ -3916,7 +3919,7 @@ export interface WheelStateInput {
 export interface WheelNextLeg {
   action: string;
   rationale: string;
-  /** The literal dry-run command to run next (never sends; live needs both write gates). */
+  /** The literal dry-run command to run next (never sends; live needs the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch). */
   command: string | null;
 }
 
@@ -4149,7 +4152,7 @@ export async function computeWheelState(
     states,
     notes,
     reference: WHEEL_DOC,
-    disclaimer: "Descriptive, not prescriptive — evidence + the conventional next leg. Live sends always need both write gates."
+    disclaimer: "Descriptive, not prescriptive — evidence + the conventional next leg. Live sends always need the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch."
   };
 }
 

--- a/cli/test/lib.test.ts
+++ b/cli/test/lib.test.ts
@@ -541,34 +541,30 @@ describe("Robinhood API map", () => {
     );
   });
 
-  it("never sends a live write without both --live-write and the env gate", () => {
+  it("single switch: ROBINHOOD_ALLOW_LIVE_WRITE=1 is the sole live-write gate", () => {
     // Read routes always run live.
-    expect(resolveLiveWriteGate({ risk: "read", dryRun: false, liveWrite: false, env: {} })).toEqual({
+    expect(resolveLiveWriteGate({ risk: "read", dryRun: false, env: {} })).toEqual({
       allowed: true,
       forcedDryRun: false
     });
 
-    // Write with neither opt-in is forced to dry-run.
-    const neither = resolveLiveWriteGate({ risk: "write-mutate", dryRun: false, liveWrite: false, env: {} });
-    expect(neither.allowed).toBe(false);
-    expect(neither.forcedDryRun).toBe(true);
+    // Write with the switch OFF is forced to dry-run (the safe published default).
+    const off = resolveLiveWriteGate({ risk: "write-mutate", dryRun: false, env: {} });
+    expect(off.allowed).toBe(false);
+    expect(off.forcedDryRun).toBe(true);
 
-    // Flag alone is not enough.
+    // The legacy --live-write / liveWrite flag is no longer the gate: switch OFF stays dry-run
+    // even when it's passed.
     expect(
       resolveLiveWriteGate({ risk: "write-mutate", dryRun: false, liveWrite: true, env: {} }).forcedDryRun
     ).toBe(true);
 
-    // Env alone is not enough.
+    // Switch ON → live write allowed with NO per-call flag (the single-switch model that unblocks MCP).
     expect(
-      resolveLiveWriteGate({
-        risk: "write-mutate",
-        dryRun: false,
-        liveWrite: false,
-        env: { ROBINHOOD_ALLOW_LIVE_WRITE: "1" }
-      }).forcedDryRun
-    ).toBe(true);
+      resolveLiveWriteGate({ risk: "write-mutate", dryRun: false, env: { ROBINHOOD_ALLOW_LIVE_WRITE: "1" } })
+    ).toEqual({ allowed: true, forcedDryRun: false });
 
-    // Both opt-ins permit the live write.
+    // Switch ON + the legacy flag is identical — the flag is an accepted no-op.
     expect(
       resolveLiveWriteGate({
         risk: "destructive",
@@ -576,6 +572,11 @@ describe("Robinhood API map", () => {
         liveWrite: true,
         env: { ROBINHOOD_ALLOW_LIVE_WRITE: "1" }
       })
+    ).toEqual({ allowed: true, forcedDryRun: false });
+
+    // dryRun:true always previews — never blocked, never auto-sent — even with the switch ON.
+    expect(
+      resolveLiveWriteGate({ risk: "write-mutate", dryRun: true, env: { ROBINHOOD_ALLOW_LIVE_WRITE: "1" } })
     ).toEqual({ allowed: true, forcedDryRun: false });
   });
 
@@ -586,8 +587,8 @@ describe("Robinhood API map", () => {
     expect(gated.forcedDryRun).toBe(true);
     // GET on a read route still runs live.
     expect(resolveLiveWriteGate({ risk: "read", method: "GET", dryRun: false, liveWrite: false, env: {} }).allowed).toBe(true);
-    // Write verb + both gates → live allowed.
-    expect(resolveLiveWriteGate({ risk: "read", method: "POST", dryRun: false, liveWrite: true, env: { ROBINHOOD_ALLOW_LIVE_WRITE: "1" } }).allowed).toBe(true);
+    // Write verb + the switch on → live allowed (no per-call flag required).
+    expect(resolveLiveWriteGate({ risk: "read", method: "POST", dryRun: false, env: { ROBINHOOD_ALLOW_LIVE_WRITE: "1" } }).allowed).toBe(true);
   });
 
   it("MAP INTEGRITY: every write-only route carries a write-class risk", () => {

--- a/docs/agent-operating-intelligence-2026-06-04.md
+++ b/docs/agent-operating-intelligence-2026-06-04.md
@@ -269,7 +269,7 @@ State this honestly; never overclaim a capability that isn't there, and never
 | Asset class | Status | What's true |
 |---|---|---|
 | **Equity / ETP** | **Placeable** | Dollar-notional (fractional, market) or whole shares; OTC auto-limits at the ask (whole only). Full lifecycle via `brokerage buy` / `orders/`. |
-| **Single-leg + multi-leg options** | **Placeable** | The four primitives + 18+ strategy workflows; lifecycle verified (201→cancel 200). UUIDs are random v4 — **bulk-enumerate every time** (`options enumerate`); never compute/guess/cache a per-contract id. |
+| **Single-leg + multi-leg options** | **Placeable** | The four primitives + 20 strategy workflows; lifecycle verified (201→cancel 200). UUIDs are random v4 — **bulk-enumerate every time** (`options enumerate`); never compute/guess/cache a per-contract id. |
 | **Index options (SPX/SPXW/XSP/NDX/VIX/RUT)** | **Present & chain-readable; opening needs an entitlement tier** | True cash-settled §1256 products — hidden from search & `instruments/?symbol=`, live under `options/chains/?underlying_symbol=`. `can_open_position:true` on reads, but actually opening may need index-options approval. Picking SPX over SPY is a *live* choice that buys §1256 60/40 + European-style box financing. |
 | **Crypto** | **Placeable (separate auth)** | Official signed Crypto Trading API — Ed25519 key signing, NOT the brokerage bearer. Same double-gate. |
 | **Futures (CME /ES, /MGC, /6E, …)** | **Read/enumerate only** | Real contracts quote via `midlands/lists/items/?list_id=…` (embedded bid/ask/last/margin). `brokerage search` *drops* the futures objects — use the lists endpoint. **Not placeable:** `ceres.robinhood.com` refuses TLS to all non-app clients, and this login has no onboarded futures account. |

--- a/docs/release-notes-2026-06-11.md
+++ b/docs/release-notes-2026-06-11.md
@@ -89,7 +89,7 @@ both surfaces, so the CLI and MCP can never disagree about how a real-money orde
 - New `docs/error-code-reference-2026-06-11.md` — the error taxonomy (kind → trigger → fix),
   matching the `classifyRobinhoodError` implementation one-for-one.
 - README rewritten to match the current surface (engine parity, `portfolio`, `recipes`, order
-  lifecycle, 37 MCP tools); repo title/description shortened to "Robinhood API + MCP + CLI".
+  lifecycle, the full MCP tool surface — count per live `tools/list`, never hardcoded); repo title/description shortened to "Robinhood API + MCP + CLI".
 
 ## Safety rails session 2 — evidence in code, panic, pretrade, options close, orders open
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -77,7 +77,7 @@ const server = new McpServer(
   {
     // Boot pointer for MCP-only agents (no repo checkout needed) — Zayd Khan // cold // www.zayd.wtf
     instructions:
-      "Control plane for a REAL Robinhood account: reads run live; writes are dry-run unless liveWrite=true AND ROBINHOOD_ALLOW_LIVE_WRITE=1. At session start on any trading topic, pull the operator knowledge library via robinhood_knowledge (action=index, then read the module that matches the task) and check robinhood_roll_ledger (action=list) for pending cash-account kosher rolls whose open leg may be due — they are two-day trades and sessions die between the legs. After any live write append a trading-log.md entry; brokerage order history is the ONLY proof an order happened."
+      "Control plane for a REAL Robinhood account: reads run live; writes are dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 is set in the server env — a single master switch (no per-call liveWrite needed; pass dryRun:true to preview even when it's on). At session start on any trading topic, pull the operator knowledge library via robinhood_knowledge (action=index, then read the module that matches the task) and check robinhood_roll_ledger (action=list) for pending cash-account kosher rolls whose open leg may be due — they are two-day trades and sessions die between the legs. After any live write append a trading-log.md entry; brokerage order history is the ONLY proof an order happened."
   }
 );
 
@@ -94,7 +94,7 @@ function jsonResponse(value: unknown) {
 // call this. Zayd Khan // cold // www.zayd.wtf
 function writeStatus(result: object, opts: { dryRun: boolean; reason?: string }) {
   const executionStatus = opts.dryRun
-    ? `⚠️ DRY RUN — NOT EXECUTED. Nothing was sent to Robinhood; no order was placed, changed, or cancelled.${opts.reason ? ` Reason: ${opts.reason}` : ""} To execute for real: pass liveWrite:true AND set ROBINHOOD_ALLOW_LIVE_WRITE=1 in the server's environment (both gates, every call).`
+    ? `⚠️ DRY RUN — NOT EXECUTED. Nothing was sent to Robinhood; no order was placed, changed, or cancelled.${opts.reason ? ` Reason: ${opts.reason}` : ""} To execute for real: set ROBINHOOD_ALLOW_LIVE_WRITE=1 in the server's environment — the single master switch; no per-call liveWrite needed. (dryRun:true still previews any one call even when the switch is on.)`
     : `✅ LIVE — SENT to Robinhood. A 2xx alone is not proof: confirm the order in order history (evidence.confirmed).`;
   return jsonResponse({ executed: !opts.dryRun, executionStatus, ...result });
 }
@@ -112,8 +112,8 @@ function toolAnnotations(readOnly: boolean, risk: RiskLevel) {
 
 // Live-flag alias resolution (param-consistency pass 2026-06-11): the parity tools historically
 // took `live` while the executor tools took `liveWrite`. Every write tool now accepts BOTH —
-// `liveWrite` is canonical, `live` is the accepted alias — so neither spelling silently no-ops a
-// caller's intent (either way the env gate ROBINHOOD_ALLOW_LIVE_WRITE=1 is still required).
+// `liveWrite` is canonical, `live` is the accepted alias — both are now OPTIONAL no-ops kept for
+// back-compat: the env switch ROBINHOOD_ALLOW_LIVE_WRITE=1 is the SOLE live-write gate.
 // Zayd Khan // cold // www.zayd.wtf
 function resolveLiveFlag(liveWrite?: boolean, live?: boolean): boolean {
   return Boolean(liveWrite ?? live);
@@ -650,7 +650,7 @@ server.registerTool(
   "robinhood_brokerage_execute",
   {
     title: "Robinhood Brokerage Execute",
-    description: "Execute a Robinhood brokerage/account request using caller-owned auth env. Reads run live; writes are dry-run by default and require liveWrite=true (canonical; `live` accepted as alias) plus ROBINHOOD_ALLOW_LIVE_WRITE=1. Pass dryRun=true to force a non-sending plan. Pass queryParams:[\"key=value\"] to append URL query params AFTER route matching (e.g. queryParams:[\"list_id=<id>\",\"owner_type=custom\"] for discovery/lists/items/) — the route map matches on the path, so this is how you read query-param endpoints without a one-off script. After any live write, append a trading-log.md entry (intent + strategy thread); brokerage order history is the only proof an order happened (order-evidence rule).",
+    description: "Execute a Robinhood brokerage/account request using caller-owned auth env. Reads run live; writes are dry-run by default and require ROBINHOOD_ALLOW_LIVE_WRITE=1 set in the server env (liveWrite optional). Pass dryRun=true to force a non-sending plan. Pass queryParams:[\"key=value\"] to append URL query params AFTER route matching (e.g. queryParams:[\"list_id=<id>\",\"owner_type=custom\"] for discovery/lists/items/) — the route map matches on the path, so this is how you read query-param endpoints without a one-off script. After any live write, append a trading-log.md entry (intent + strategy thread); brokerage order history is the only proof an order happened (order-evidence rule).",
     annotations: toolAnnotations(false, "write-or-sensitive"),
     inputSchema: z.object({
       query: z.string(),
@@ -768,7 +768,7 @@ server.registerTool(
   "robinhood_crypto_execute",
   {
     title: "Robinhood Crypto Execute",
-    description: "Execute an official Robinhood Crypto API request using caller-owned API key env. Reads run live; writes (orders/cancels) are dry-run by default and require liveWrite=true (canonical; `live` accepted as alias) plus ROBINHOOD_ALLOW_LIVE_WRITE=1. Pass dryRun=true to force a non-sending plan.",
+    description: "Execute an official Robinhood Crypto API request using caller-owned API key env. Reads run live; writes (orders/cancels) are dry-run by default and require ROBINHOOD_ALLOW_LIVE_WRITE=1 set in the server env (liveWrite optional). Pass dryRun=true to force a non-sending plan.",
     annotations: toolAnnotations(false, "write-mutate"),
     inputSchema: z.object({
       query: z.string(),
@@ -924,7 +924,7 @@ server.registerTool(
   {
     title: "Robinhood Buy Order",
     description:
-      "Place an equity buy order. Market buys are fractional, limit orders are whole shares. Dry-run by default; set liveWrite=true (canonical; `live` accepted as alias) and ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute. Auto-resolves symbol, fetches live quote, sizes shares from dollar amount, blocks OTC/non-fractional dollar orders, dedups against pending same-side orders (5-min window; force=true skips), sends a ref_id for broker-level idempotency, logs live sends to the trading log, and re-reads the order from order history after a live send (`evidence.confirmed`) — same shared engine as the CLI `buy` command.",
+      "Place an equity buy order. Market buys are fractional, limit orders are whole shares. Dry-run by default; set ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute (single env switch; liveWrite optional). Auto-resolves symbol, fetches live quote, sizes shares from dollar amount, blocks OTC/non-fractional dollar orders, dedups against pending same-side orders (5-min window; force=true skips), sends a ref_id for broker-level idempotency, logs live sends to the trading log, and re-reads the order from order history after a live send (`evidence.confirmed`) — same shared engine as the CLI `buy` command.",
     inputSchema: z.object({
       symbol: z.string(),
       account_number: z.string(),
@@ -957,7 +957,7 @@ server.registerTool(
   "robinhood_sell",
   {
     title: "Robinhood Sell Order",
-    description: "Place an equity sell order. Market sells are fractional. Dry-run by default; set liveWrite=true (canonical; `live` accepted as alias) and ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute. Dedups against pending same-side orders (5-min window; force=true skips), sends a ref_id for broker-level idempotency, logs live sends to the trading log, and re-reads the order from order history after a live send (`evidence.confirmed`) — same shared engine as the CLI `sell` command.",
+    description: "Place an equity sell order. Market sells are fractional. Dry-run by default; set ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute (single env switch; liveWrite optional). Dedups against pending same-side orders (5-min window; force=true skips), sends a ref_id for broker-level idempotency, logs live sends to the trading log, and re-reads the order from order history after a live send (`evidence.confirmed`) — same shared engine as the CLI `sell` command.",
     inputSchema: z.object({
       symbol: z.string(), account_number: z.string(),
       amount: z.number().positive().optional(), shares: z.number().positive().optional(),
@@ -986,7 +986,7 @@ server.registerTool(
   "robinhood_cancel",
   {
     title: "Robinhood Cancel Order",
-    description: "Cancel a pending order by ID (kind=equity|options). Dry-run by default; liveWrite=true (canonical; `live` accepted as alias) + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute. Live cancels re-read the order from order history and return `evidence` (confirmed/state) — order history is the only proof the cancel took.",
+    description: "Cancel a pending order by ID (kind=equity|options). Dry-run by default; ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute (single env switch; liveWrite optional). Live cancels re-read the order from order history and return `evidence` (confirmed/state) — order history is the only proof the cancel took.",
     inputSchema: z.object({
       order_id: z.string(),
       kind: z.enum(["equity", "options"]).default("equity"),
@@ -1020,13 +1020,13 @@ server.registerTool(
   }
 );
 
-// ── robinhood_panic: enumerate + cancel EVERY open order (each cancel double-gated) ──
+// ── robinhood_panic: enumerate + cancel EVERY open order (each cancel env-gated) ──
 // Zayd Khan // cold // www.zayd.wtf
 server.registerTool(
   "robinhood_panic",
   {
     title: "Robinhood Panic Cancel-All",
-    description: "PANIC: enumerate every open/pending equity + options order across ALL owned accounts (or one) and cancel each — every cancel individually double-gated (logContext 'panic cancel-all'). DRY-RUN by default: returns the full would-cancel list and sends NOTHING. A live sweep needs liveWrite=true (canonical; `live` accepted as alias) AND ROBINHOOD_ALLOW_LIVE_WRITE=1, and re-reads each order from order history for evidence. Summary reports found/cancelled/failed.",
+    description: "PANIC: enumerate every open/pending equity + options order across ALL owned accounts (or one) and cancel each — every cancel individually env-gated (logContext 'panic cancel-all'). DRY-RUN by default: returns the full would-cancel list and sends NOTHING. A live sweep needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional), and re-reads each order from order history for evidence. Summary reports found/cancelled/failed.",
     inputSchema: z.object({
       account_number: z.string().optional(),
       liveWrite: z.boolean().optional(),
@@ -1197,7 +1197,7 @@ server.registerTool(
   "robinhood_settings",
   {
     title: "Robinhood Account Settings",
-    description: "Read or toggle account settings (double-gated). action=show reads all; drip/expiration/pdt/lending/sweep toggle the corresponding setting. Writes are dry-run unless liveWrite=true (canonical; `live` accepted as alias) AND ROBINHOOD_ALLOW_LIVE_WRITE=1. Cash-sweep only supports disable (enroll needs the agreement-sign flow). After any live write, append a trading-log.md entry (intent + thread); order history is the only proof a change took effect (order-evidence rule).",
+    description: "Read or toggle account settings (env-gated). action=show reads all; drip/expiration/pdt/lending/sweep toggle the corresponding setting. Writes are dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional). Cash-sweep only supports disable (enroll needs the agreement-sign flow). After any live write, append a trading-log.md entry (intent + thread); order history is the only proof a change took effect (order-evidence rule).",
     inputSchema: z.object({
       account_number: z.string(),
       action: z.enum(["show", "drip", "expiration", "pdt", "lending", "sweep"]),
@@ -1246,7 +1246,7 @@ server.registerTool(
   "robinhood_recurring",
   {
     title: "Robinhood Recurring Schedules",
-    description: "List or mutate recurring investment schedules (double-gated writes). action=list reads all; create/edit/end mutate. Writes dry-run unless liveWrite=true (canonical; `live` accepted as alias) AND ROBINHOOD_ALLOW_LIVE_WRITE=1. After any live write, append a trading-log.md entry (intent + thread); order history is the only proof a change took effect (order-evidence rule).",
+    description: "List or mutate recurring investment schedules (env-gated writes). action=list reads all; create/edit/end mutate. Writes dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional). After any live write, append a trading-log.md entry (intent + thread); order history is the only proof a change took effect (order-evidence rule).",
     inputSchema: z.object({
       action: z.enum(["list", "create", "edit", "end"]),
       id: z.string().optional(),
@@ -1345,7 +1345,7 @@ server.registerTool(
   "robinhood_watchlist_add",
   {
     title: "Robinhood Watchlist — Add",
-    description: "Add tickers to a custom watchlist (resolved by name or id). Watchlists are user-level, not account-scoped. Reads resolve the list + each symbol's instrument UUID; the write is dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    description: "Add tickers to a custom watchlist (resolved by name or id). Watchlists are user-level, not account-scoped. Reads resolve the list + each symbol's instrument UUID; the write is dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional).",
     annotations: toolAnnotations(false, "write-mutate"),
     inputSchema: z.object({
       list: z.string(),
@@ -1369,7 +1369,7 @@ server.registerTool(
   "robinhood_watchlist_remove",
   {
     title: "Robinhood Watchlist — Remove",
-    description: "Remove tickers from a custom watchlist (resolved by name or id). Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    description: "Remove tickers from a custom watchlist (resolved by name or id). Dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional).",
     annotations: toolAnnotations(false, "write-mutate"),
     inputSchema: z.object({
       list: z.string(),
@@ -1393,7 +1393,7 @@ server.registerTool(
   "robinhood_watchlist_create",
   {
     title: "Robinhood Watchlist — Create",
-    description: "Create a new custom watchlist (display_name, optional icon emoji). Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    description: "Create a new custom watchlist (display_name, optional icon emoji). Dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional).",
     annotations: toolAnnotations(false, "write-mutate"),
     inputSchema: z.object({
       name: z.string(),
@@ -1431,7 +1431,7 @@ server.registerTool(
   "robinhood_watchlist_buy",
   {
     title: "Robinhood Watchlist — Basket Buy",
-    description: "Buy $<amount> of EACH equity-buyable ticker in a custom watchlist (BP-aware basket; the EXECUTION half of operating on a watchlist). Loops the SAME shared placeEquityOrder engine per ticker — OTC/fractional guard, pending dedup, ref_id idempotency, the after-hours fractional pre-flight guard, trade-log + order-history evidence — and reads the account's buying power so it only attempts what fits ($amount each), skipping the rest with reasons rather than hammering doomed orders. Dry-run unless liveWrite=true (canonical; `live` accepted) AND ROBINHOOD_ALLOW_LIVE_WRITE=1.",
+    description: "Buy $<amount> of EACH equity-buyable ticker in a custom watchlist (BP-aware basket; the EXECUTION half of operating on a watchlist). Loops the SAME shared placeEquityOrder engine per ticker — OTC/fractional guard, pending dedup, ref_id idempotency, the after-hours fractional pre-flight guard, trade-log + order-history evidence — and reads the account's buying power so it only attempts what fits ($amount each), skipping the rest with reasons rather than hammering doomed orders. Dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 (single env switch; liveWrite optional).",
     annotations: toolAnnotations(false, "write-mutate"),
     inputSchema: z.object({
       list: z.string(),
@@ -1648,13 +1648,13 @@ server.registerTool(
 // Zayd Khan // cold // www.zayd.wtf
 
 // Live-write discoverability (the silent-dry-run trap): writes need ROBINHOOD_ALLOW_LIVE_WRITE=1 in THIS
-// server's environment (the second gate). If it's unset, every write tool dry-runs no matter what the
+// server's environment (the single master switch). If it's unset, every write tool dry-runs no matter what the
 // caller passes — and that used to fail silently (a re-registered MCP without the env looked healthy but
 // could never trade). Announce it loudly at startup so the gap is visible, not discovered mid-trade.
 if (process.env.ROBINHOOD_ALLOW_LIVE_WRITE !== "1") {
   process.stderr.write(
     "⚠️  robinhood-cli MCP: LIVE WRITES DISABLED — ROBINHOOD_ALLOW_LIVE_WRITE is not \"1\" in this server's " +
-    "environment, so EVERY write tool will dry-run regardless of liveWrite:true (the env is the second gate). " +
+    "environment, so EVERY write tool will dry-run regardless of liveWrite:true (the env switch is the single gate). " +
     "Reads work normally. To enable real orders, re-register with the env gate and reload, e.g.:\n" +
     "    claude mcp add robinhood-cli -s user -e ROBINHOOD_ALLOW_LIVE_WRITE=1 -- node <repo>/mcp/dist/server.js\n" +
     "  then /reload-mcp (or restart the client).\n"


### PR DESCRIPTION
Two parts, both verified:

**1. Doc fixes** — strategy-workflow count 18→20 (catalog has 20, jq-verified); de-hardcode the last `37 MCP tools` literal (defer to `tools/list`).

**2. Single-switch live-write gate** — collapse the two-gate model to one env master switch so the MCP isn't blocked by a per-call flag. `ROBINHOOD_ALLOW_LIVE_WRITE=1` is now the sole gate; `--live-write`/`liveWrite` accepted but optional. `--dry-run`/`dryRun` still previews. Inverts the safety docs (caution preserved, re-pointed at the new model), rewrites the gate test, fixes a panic-path double-gate remnant, adds `.env.example`. 228 tests pass; live-verified end-to-end (OFF→dry-run, ON+no-flag→sends, ON+--dry-run→preview).