### PR TITLE
docs: finish the single-switch migration (knowledge/ + recipes + current docs)

### DIFF
--- a/api-map/recipes.json
+++ b/api-map/recipes.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Intent → the ONE command to run. Surfaced by `recipes` (CLI) + `robinhood_recipes` (MCP). Each recipe maps a plain-English intent + trigger phrases to the verified first-class CLI command and its MCP-tool equivalent. Keep this in sync when adding commands; it is the agent's intent-routing table. Reads are live/free; writes are double-gated (--live-write + ROBINHOOD_ALLOW_LIVE_WRITE=1).",
+  "_note": "Intent → the ONE command to run. Surfaced by `recipes` (CLI) + `robinhood_recipes` (MCP). Each recipe maps a plain-English intent + trigger phrases to the verified first-class CLI command and its MCP-tool equivalent. Keep this in sync when adding commands; it is the agent's intent-routing table. Reads are live/free; writes are env-gated (set ROBINHOOD_ALLOW_LIVE_WRITE=1; --live-write optional).",
   "_provenance": "Zayd Khan // cold // www.zayd.wtf",
   "recipes": [
     {
@@ -188,7 +188,7 @@
       "command": "watchlist add <list> <SYM...> --live-write",
       "mcpTool": "robinhood_watchlist_add",
       "risk": "write-mutate",
-      "notes": "List resolved by name or id; tickers resolved to instrument UUIDs internally. Double-gated, dry-run by default."
+      "notes": "List resolved by name or id; tickers resolved to instrument UUIDs internally. Env-gated, dry-run by default."
     },
     {
       "id": "watchlist-remove",
@@ -201,7 +201,7 @@
       "command": "watchlist remove <list> <SYM...> --live-write",
       "mcpTool": "robinhood_watchlist_remove",
       "risk": "write-mutate",
-      "notes": "Same endpoint as add (operation=delete). Double-gated."
+      "notes": "Same endpoint as add (operation=delete). Env-gated."
     },
     {
       "id": "watchlist-create",
@@ -214,7 +214,7 @@
       "command": "watchlist create <name> --live-write",
       "mcpTool": "robinhood_watchlist_create",
       "risk": "write-mutate",
-      "notes": "POST discovery/lists/ with display_name (+ optional icon emoji). Double-gated."
+      "notes": "POST discovery/lists/ with display_name (+ optional icon emoji). Env-gated."
     },
     {
       "id": "accounts",
@@ -240,7 +240,7 @@
       "command": "brokerage buy <SYM> --account <N> --dollars <$>   (or --shares <n>) --live-write",
       "mcpTool": "robinhood_brokerage_execute",
       "risk": "write-mutate",
-      "notes": "Double-gated. Ground the ticker with `brokerage search` first; OTC auto-limits at the marketable side (buy=ask, sell=bid; whole shares only, both directions)."
+      "notes": "Env-gated. Ground the ticker with `brokerage search` first; OTC auto-limits at the marketable side (buy=ask, sell=bid; whole shares only, both directions)."
     },
     {
       "id": "options-order-flow",
@@ -269,7 +269,7 @@
       "command": "brokerage execute \"options/orders/\" --method POST --live-write   ·   cancel: \"options/orders/{0}/cancel/\" --param 0=<id>",
       "mcpTool": "robinhood_brokerage_execute",
       "risk": "write-mutate",
-      "notes": "Double-gated. Classify the strategy + bulk-enumerate UUIDs first; keep the {0} placeholder + --param."
+      "notes": "Env-gated. Classify the strategy + bulk-enumerate UUIDs first; keep the {0} placeholder + --param."
     },
     {
       "id": "settings",
@@ -283,7 +283,7 @@
       "command": "settings ... [--live-write]",
       "mcpTool": "robinhood_settings",
       "risk": "write-or-sensitive",
-      "notes": "Reads free; writes double-gated. DRIP write is PATCH corp_actions/drip/account_settings/{account_number}/, NOT drip/enrollment/."
+      "notes": "Reads free; writes env-gated. DRIP write is PATCH corp_actions/drip/account_settings/{account_number}/, NOT drip/enrollment/."
     },
     {
       "id": "recurring",
@@ -356,7 +356,7 @@
       "command": "options strategy-quote cash-secured-short-put --account <N> --symbol <S> --expiration <D> --leg short_put=<K> --pricing-mode safe-sell-probe --json",
       "mcpTool": "robinhood_options_strategy_plan",
       "risk": "sensitive-read",
-      "notes": "Wheel leg 1. Collateral = strike × 100 settled cash per contract. Quote is dry-run; the live send is a separate double-gated step. Pick strikes from `options chain <S>`."
+      "notes": "Wheel leg 1. Collateral = strike × 100 settled cash per contract. Quote is dry-run; the live send is a separate env-gated step. Pick strikes from `options chain <S>`."
     },
     {
       "id": "wheel-covered-call",
@@ -385,7 +385,7 @@
       "command": "buy|sell -s <SYM> -a <N> -m <$> | -q <shares> [-p <limit>] [--live]",
       "mcpTool": "robinhood_buy",
       "risk": "write-mutate",
-      "notes": "Double-gated like every write (--live + ROBINHOOD_ALLOW_LIVE_WRITE=1; dry-run by default). Auto: OTC/fractional guard, pending-order dedup (5-min; --force skips), ref_id idempotency, trade log. Same engine as robinhood_sell. For OTC names needing auto-limit-at-ask use `brokerage buy`."
+      "notes": "Env-gated like every write (set ROBINHOOD_ALLOW_LIVE_WRITE=1; --live optional; dry-run by default). Auto: OTC/fractional guard, pending-order dedup (5-min; --force skips), ref_id idempotency, trade log. Same engine as robinhood_sell. For OTC names needing auto-limit-at-ask use `brokerage buy`."
     },
     {
       "id": "order-status-check",
@@ -426,10 +426,10 @@
         "kill all orders",
         "flatten my orders"
       ],
-      "command": "panic   (dry-run by default — shows the would-cancel list; live needs --live-write + ROBINHOOD_ALLOW_LIVE_WRITE=1)",
+      "command": "panic   (dry-run by default — shows the would-cancel list; live needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (--live-write optional))",
       "mcpTool": "robinhood_panic",
       "risk": "destructive",
-      "notes": "Enumerates orders/ + options/orders/ across ALL owned accounts; each cancel is individually double-gated and evidence-re-read from order history. Zayd Khan // cold // www.zayd.wtf"
+      "notes": "Enumerates orders/ + options/orders/ across ALL owned accounts; each cancel is individually env-gated and evidence-re-read from order history. Zayd Khan // cold // www.zayd.wtf"
     },
     {
       "id": "orders-open",
@@ -476,7 +476,7 @@
       "command": "options close <SYMBOL> [--account N --strike K --expiration D --type call|put]   (emits the dry-run body + the gated send command; never sends)",
       "mcpTool": "robinhood_options_close",
       "risk": "sensitive-read",
-      "notes": "Finds the position across accounts, derives side/effect from its direction — position_effect is ALWAYS close, never infers an open. Multiple matches require disambiguation; the live send stays behind both write gates (double-gated brokerage execute)."
+      "notes": "Finds the position across accounts, derives side/effect from its direction — position_effect is ALWAYS close, never infers an open. Multiple matches require disambiguation; the live send stays behind the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch (env-gated brokerage execute)."
     },
     {
       "id": "trade-review",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -3258,7 +3258,7 @@ program
     const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
     process.stdout.write(`${mode} ${r.type} buy: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}${r.session ? `  [${r.session}]` : ""}\n`);
     if (r.sessionWarning) process.stdout.write(`⚠️  ${r.sessionWarning}\n`);
-    if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
+    if (r.dryRun) process.stdout.write("Add ROBINHOOD_ALLOW_LIVE_WRITE=1 (--live optional) to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });
 
@@ -3296,7 +3296,7 @@ program
     const sizing = r.dollarBased ? `$${r.estimatedTotal.toFixed(2)} (dollar-based ≈ ${r.shares.toFixed(6)} sh)` : `${r.shares.toFixed(6)} sh ≈ $${r.estimatedTotal.toFixed(2)}`;
     process.stdout.write(`${mode} ${r.type} sell: ${r.symbol} ${sizing} @ ~$${r.estimatedPrice.toFixed(2)}  acct=…${String(opts.account).slice(-4)}${r.session ? `  [${r.session}]` : ""}\n`);
     if (r.sessionWarning) process.stdout.write(`⚠️  ${r.sessionWarning}\n`);
-    if (r.dryRun) process.stdout.write("Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
+    if (r.dryRun) process.stdout.write("Add ROBINHOOD_ALLOW_LIVE_WRITE=1 (--live optional) to execute.\n");
     else process.stdout.write(`Status: ${r.httpStatus}  id=${r.orderId ?? "?"}  state=${r.state ?? "?"}\n`);
   });
 
@@ -3322,7 +3322,7 @@ program
     }
     const mode = r.dryRun ? "DRY RUN" : "LIVE";
     process.stdout.write(`${mode} cancel (${r.kind}): ${r.orderId}  status=${r.httpStatus}\n`);
-    if (r.dryRun) process.stdout.write("Nothing was sent. Add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to execute.\n");
+    if (r.dryRun) process.stdout.write("Nothing was sent. Add ROBINHOOD_ALLOW_LIVE_WRITE=1 (--live optional) to execute.\n");
     if (r.evidence) {
       process.stdout.write(`evidence: confirmed=${r.evidence.confirmed} state=${r.evidence.state ?? "?"}\n`);
       if (r.evidence.warning) process.stdout.write(`⚠️  ${r.evidence.warning}\n`);

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -3379,7 +3379,7 @@ export async function listOpenOrders(
           side: o.side ?? null, state: String(o.state ?? "?"), quantity: qty, price,
           notionalUsd: Number.isFinite(price) && Number.isFinite(qty) ? price * qty : Number.NaN,
           timeInForce: o.time_in_force ?? null, createdAt: o.created_at ?? null, ageHours: ageOf(o.created_at),
-          cancelCommand: `node cli/dist/index.js cancel -i ${o.id} --kind equity   # dry-run; add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to send`
+          cancelCommand: `node cli/dist/index.js cancel -i ${o.id} --kind equity   # dry-run; add ROBINHOOD_ALLOW_LIVE_WRITE=1 (--live optional) to send`
         });
       }
     } catch (e) { warnings.push(`equity open-orders read failed (…${acct.slice(-4)}): ${(e as Error).message.slice(0, 60)}`); }
@@ -3396,7 +3396,7 @@ export async function listOpenOrders(
           side: o.direction ?? null, state: String(o.state ?? "?"), quantity: qty, price,
           notionalUsd: Number.isFinite(price) && Number.isFinite(qty) ? price * qty * 100 : Number.NaN,
           timeInForce: o.time_in_force ?? null, createdAt: o.created_at ?? null, ageHours: ageOf(o.created_at),
-          cancelCommand: `node cli/dist/index.js cancel -i ${o.id} --kind options   # dry-run; add --live + ROBINHOOD_ALLOW_LIVE_WRITE=1 to send`
+          cancelCommand: `node cli/dist/index.js cancel -i ${o.id} --kind options   # dry-run; add ROBINHOOD_ALLOW_LIVE_WRITE=1 (--live optional) to send`
         });
       }
     } catch (e) { warnings.push(`options open-orders read failed (…${acct.slice(-4)}): ${(e as Error).message.slice(0, 60)}`); }

--- a/docs/account-settings-capability-map-2026-06-03.md
+++ b/docs/account-settings-capability-map-2026-06-03.md
@@ -10,7 +10,7 @@ research. No live account-setting mutation is recorded here.
   funding, recurring investments, DRIP, high-yield cash/sweeps, stock lending,
   options, futures, event contracts, account type, and margin.
 - Mixed read/write routes were split by method in `api-map/brokerage-routes.json`
-  so reads stay live and writes stay double-gated.
+  so reads stay live and writes stay env-gated.
 - The MCP server exposes the same route map through
   `robinhood_brokerage_routes`, `robinhood_brokerage_plan`, and
   `robinhood_brokerage_execute`.
@@ -25,15 +25,15 @@ research. No live account-setting mutation is recorded here.
 |---------|-----------------|-------------------|-----------------|
 | Account enumeration | Live read, first-class route-map use | `bonfire.robinhood.com/transfer/accounts/`, `accounts/?default_to_all_accounts=true` | Read-only |
 | Deposit / withdraw / funding sources | Live reads mapped; transfer/link writes are route-map dry-runs only | `ach/relationships/`, `ach/transfers/`, `cashier.robinhood.com/ach/relationships/`, `cashier.robinhood.com/ach/deposit_schedules/`, `payment_instruments/v2/`, `paymenthub/unified_transfers/` | Never mutate without fresh body capture and exact user approval |
-| Recurring investments | First-class list/pause/resume; **create + edit PROVEN** (agentic via CLI, 2026-06-03) | create: `POST bonfire…/recurring_schedules/` body `{account_number,amount{amount,currency_code},frequency,investment_asset{asset_id,asset_symbol,asset_type},source_of_funds:"buying_power",start_date,ref_id}`; **edit: `PATCH bonfire…/recurring_schedules/{id}/` body `{"amount":{...}}` (and frequency/etc.) → 200**; `recurring list/pause/resume` | All double-gated. Create makes a real schedule; edit mutates a live one. Delete body still to capture |
-| Dividend reinvestment | **Read + write PROVEN** (browser-captured 2026-06-03) | account-wide: `corp_actions/drip/account_settings/{account}/` (GET + PATCH); per-stock: `corp_actions/drip/instrument_settings/{account}/` (GET list) and `.../{account}/{instrument_id}/` (PATCH) | `PATCH {"drip_enabled":bool}` double-gated; verify with GET. NOTE: the old `corp_actions/drip/enrollment/{num}/` is GET-only (405 on writes) — wrong endpoint; the two above are the real ones |
+| Recurring investments | First-class list/pause/resume; **create + edit PROVEN** (agentic via CLI, 2026-06-03) | create: `POST bonfire…/recurring_schedules/` body `{account_number,amount{amount,currency_code},frequency,investment_asset{asset_id,asset_symbol,asset_type},source_of_funds:"buying_power",start_date,ref_id}`; **edit: `PATCH bonfire…/recurring_schedules/{id}/` body `{"amount":{...}}` (and frequency/etc.) → 200**; `recurring list/pause/resume` | All env-gated. Create makes a real schedule; edit mutates a live one. Delete body still to capture |
+| Dividend reinvestment | **Read + write PROVEN** (browser-captured 2026-06-03) | account-wide: `corp_actions/drip/account_settings/{account}/` (GET + PATCH); per-stock: `corp_actions/drip/instrument_settings/{account}/` (GET list) and `.../{account}/{instrument_id}/` (PATCH) | `PATCH {"drip_enabled":bool}` env-gated; verify with GET. NOTE: the old `corp_actions/drip/enrollment/{num}/` is GET-only (405 on writes) — wrong endpoint; the two above are the real ones |
 | High-yield cash / sweep | Live reads mapped; enable/disable route not proven | `accounts/sweeps/`, `accounts/sweeps/interest/`, `accounts/sweeps/timeline_summary/`, `gold/sweep_flow_splash/` | Do not claim toggle support until a fresh browser capture provides the mutation route/body |
 | Stock lending | Payment/status reads mapped; enable/disable route not proven | `accounts/stock_loan_payments/`; browser page `/account/stock-lending` has mixed account query behavior | Do not toggle until capture proves the write route/body |
 | Options trading settings | Trading/position/order surfaces mapped; settings toggles are browser-observed only | `options/chains/`, `options/orders/`, `options/positions/`, `options/aggregate_positions/`, browser `/account/settings/investing?account_number=...` | Option orders use the hardened order gate; options-level/remove-options toggles need fresh capture |
 | Futures trading | Eligibility/account/order reads mapped | `ceres/v1/futures_account_eligibility/{num}`, `ceres/v1/accounts`, `ceres/v1/accounts/{id}/orders`, `ceres/v1/user_settings` | Enable/disable route not first-class in this map |
 | Event contracts | Event-related reads mapped | `options/events/`, `instruments/{uuid}/qa/event-info/`, `instruments/{uuid}/qa/events-section/` | Trading enable/disable route not proven |
 | Account type / margin | Margin and eligibility reads mapped; switching cash/margin is not first-class | `margin/{num}/upgrade_restrictions`, `bonfire.robinhood.com/margin/{id}/settings/`, `eligibility`, `investing_info/`, `buying_power_hub_view` | Do not switch account type or margin settings without a fresh mutation capture and explicit approval |
-| Agentic account config | Read and dry-run PATCH route mapped | `robinhood/agentic/` split into `GET` and `PATCH` routes | Double-gated account-setting write |
+| Agentic account config | Read and dry-run PATCH route mapped | `robinhood/agentic/` split into `GET` and `PATCH` routes | Env-gated account-setting write |
 
 ## CLI Recipes
 
@@ -87,7 +87,7 @@ The dry-run examples above send nothing unless both live-write gates are present
 
 Captured live via an in-page fetch/XHR interceptor (`Page.addScriptToEvaluateOnNewDocument`,
 persisted to `sessionStorage`) while toggling settings across the cash, Roth, and 9mo accounts.
-All are writes (double-gated); the account is in the path, so `?account_number=` / `{account}`
+All are writes (env-gated); the account is in the path, so `?account_number=` / `{account}`
 selects which account they hit.
 
 | Setting | Method + route | Body |

--- a/docs/agent-operating-intelligence-2026-06-04.md
+++ b/docs/agent-operating-intelligence-2026-06-04.md
@@ -46,7 +46,7 @@ mid-batch.
    (what + intent + thread; status `executed` only if order history confirms — order-evidence rule).
 
 If all seven pass, you're cleared for reads and dry-runs. Live writes still require
-explicit user approval + both gates, every single command.
+explicit user approval + the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch, every single command.
 
 ---
 
@@ -271,7 +271,7 @@ State this honestly; never overclaim a capability that isn't there, and never
 | **Equity / ETP** | **Placeable** | Dollar-notional (fractional, market) or whole shares; OTC auto-limits at the ask (whole only). Full lifecycle via `brokerage buy` / `orders/`. |
 | **Single-leg + multi-leg options** | **Placeable** | The four primitives + 20 strategy workflows; lifecycle verified (201→cancel 200). UUIDs are random v4 — **bulk-enumerate every time** (`options enumerate`); never compute/guess/cache a per-contract id. |
 | **Index options (SPX/SPXW/XSP/NDX/VIX/RUT)** | **Present & chain-readable; opening needs an entitlement tier** | True cash-settled §1256 products — hidden from search & `instruments/?symbol=`, live under `options/chains/?underlying_symbol=`. `can_open_position:true` on reads, but actually opening may need index-options approval. Picking SPX over SPY is a *live* choice that buys §1256 60/40 + European-style box financing. |
-| **Crypto** | **Placeable (separate auth)** | Official signed Crypto Trading API — Ed25519 key signing, NOT the brokerage bearer. Same double-gate. |
+| **Crypto** | **Placeable (separate auth)** | Official signed Crypto Trading API — Ed25519 key signing, NOT the brokerage bearer. Same env gate. |
 | **Futures (CME /ES, /MGC, /6E, …)** | **Read/enumerate only** | Real contracts quote via `midlands/lists/items/?list_id=…` (embedded bid/ask/last/margin). `brokerage search` *drops* the futures objects — use the lists endpoint. **Not placeable:** `ceres.robinhood.com` refuses TLS to all non-app clients, and this login has no onboarded futures account. |
 | **Spot FX** | **Absent** | No spot-FX product at all (`currency_pairs` always `[]`; `/forex/` 404). Currency exposure = currency *futures* (read-only) or crypto pairs (separate API). DXY not tradable. |
 | **Commodities** | **ETF proxies only (placeable); real futures read-only** | USO/UVXY/VXX/BITO etc. are normal equities, placeable via the equity engine. The underlying commodity futures (/CL, /GC, /SI) quote but route through ceres → not placeable. |
@@ -306,7 +306,7 @@ educational, not tax advice.
 
 ## 7. The safety model in one screen (so you act, not just read)
 
-- **Double gate, per command, every time:** a write sends only with **both**
+- **Single-switch gate, per command, every time:** a write sends only with **both**
   `--live-write` AND `ROBINHOOD_ALLOW_LIVE_WRITE=1` (MCP: `liveWrite:true` + the env
   var in the server's environment). With one or neither it's a dry-run.
 - **Never export the env var** into your shell profile. Inline, single command, every
@@ -375,7 +375,7 @@ Ranked by leverage (hardening first, then growth). Each is concrete enough to st
 7. **Own-the-market wedge — keep CLI/MCP/api-map aligned and lean into the niche.**
    RH's own "Agentic Trading" (launched 2026-05-27) is equities-only and sandboxed;
    this tool's wedge is **options + crypto + every owned account + an auditable
-   double-gate**. PDT is lifted on RH — the $25k day-trade cap is gone (FINRA eliminated
+   env gate**. PDT is lifted on RH — the $25k day-trade cap is gone (FINRA eliminated
    it 2026-06-04, RH implemented), so margin accounts day-trade freely.
    The durable advantage is breadth + auditability, so the maintenance invariant (no
    duplicated logic, gate intact across all three surfaces) is also the product moat —

--- a/docs/error-code-reference-2026-06-11.md
+++ b/docs/error-code-reference-2026-06-11.md
@@ -26,7 +26,7 @@ a debugging session.
 | Error | What it means | Fix |
 |-------|----------------|-----|
 | `DEDUP: N pending <side> order(s) … already exist` | A same-side order on this instrument+account is pending and < 5 min old — you (or an agent retry) are about to double-fire | If intentional, pass `--force` (CLI) / `force: true` (MCP). Stale (>5 min) pendings never trigger this. |
-| `liveWriteBlocked` | A write ran without BOTH gates (`--live-write` / `liveWrite: true` **and** `ROBINHOOD_ALLOW_LIVE_WRITE=1`) | Set both — deliberately, inline, never exported in your shell profile |
+| `liveWriteBlocked` | A write ran without the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch (`--live-write` / `liveWrite: true` **and** `ROBINHOOD_ALLOW_LIVE_WRITE=1`) | Set both — deliberately, inline, never exported in your shell profile |
 | `No <METHOD> route for <url> — … fails closed` | A forced write (POST/PATCH/PUT/DELETE) matched no write route — the resolver refuses to degrade it into a read | Check the route map; rebuild (`pnpm build`) after map edits — the runtime reads `cli/dist/api-map/` |
 | `<SYM>: fractional_tradability=… — cannot place a dollar/fractional order` | OTC/non-fractional name; a "$X of SYM" order is impossible | Switch to whole shares + a marketable limit |
 | `Invalid or missing quote for <SYM>` | The quote came back dead (`last_trade_price` 0/absent) — sizing math would divide by zero | Check the symbol/halt status; retry when a live quote exists |

--- a/docs/futures-fx-commodities-surface-2026-06-04.md
+++ b/docs/futures-fx-commodities-surface-2026-06-04.md
@@ -219,7 +219,7 @@ above (read-only).
 ## What's confirmed placeable vs read-only vs unsupported
 
 - **Placeable now (existing engine):** equity/ETP commodity & volatility proxies
-  (USO, UVXY, VXX, BITO, …) via `brokerage buy` / `orders/`. Double-gated as usual.
+  (USO, UVXY, VXX, BITO, …) via `brokerage buy` / `orders/`. Env-gated as usual.
 - **Read-only (reachable api host):** real futures contracts incl. commodity & FX
   futures — symbols, names, margin requirement, bid/ask/last/prev-close — via
   `GET api.robinhood.com/midlands/lists/items/?list_id=<id>`.

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -111,7 +111,7 @@ entries are unrelated read routes).
 4. **Response shape.** Items POST echoes the request body (200). Create returns the full list object (id, display_name, owner UUID, allowed_object_types, item_count). Lists are **user-level, not account-scoped** — no `account_number` anywhere.
 5. **Rate-limit behavior.** None observed across the capture + verification writes.
 6. **Risk classification.** `discovery/lists/items/` POST = `write-mutate` (reversible add/remove);
-   `discovery/lists/` POST + `discovery/lists/{id}/` PATCH/DELETE = `destructive`. All double-gated; safe
+   `discovery/lists/` POST + `discovery/lists/{id}/` PATCH/DELETE = `destructive`. All env-gated; safe
    for `brokerage execute` only behind both write gates. Wired as first-class `watchlist add/remove/create`.
 
 When a new undocumented route is discovered, record:

--- a/docs/write-operations.md
+++ b/docs/write-operations.md
@@ -7,8 +7,8 @@ This is a personal `zaydiscold` repo. It is read/write capable.
 - `brokerage execute` sends live HTTP requests when `ROBINHOOD_BROKERAGE_TOKEN` or `ROBINHOOD_COOKIE` is present.
 - `crypto execute` sends live HTTP requests to Robinhood's official Crypto Trading API when `ROBINHOOD_CRYPTO_API_KEY` and `ROBINHOOD_CRYPTO_PRIVATE_KEY_B64` are present.
 - `--dry-run` is opt-in and returns the execution plan without sending.
-- **Writes are double-gated.** Any route whose risk is `write-safe`, `write-mutate`,
-  `write-or-sensitive`, or `destructive` is forced to a dry-run UNLESS both gates are set:
+- **Writes are env-gated.** Any route whose risk is `write-safe`, `write-mutate`,
+  `write-or-sensitive`, or `destructive` is forced to a dry-run UNLESS the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch are set:
   the `--live-write` flag AND the `ROBINHOOD_ALLOW_LIVE_WRITE=1` environment variable.
   With only one (or neither), `resolveLiveWriteGate` returns `forcedDryRun: true` and the
   request is planned but never sent (the result carries a `liveWriteBlocked` reason).
@@ -34,7 +34,7 @@ robinhood-cli brokerage execute "https://api.robinhood.com/accounts/" --json
 robinhood-cli brokerage execute "https://api.robinhood.com/orders/" --method POST \
   --body-json '{"account":"...","instrument":"...","symbol":"F","type":"limit","time_in_force":"gfd","trigger":"immediate","price":"9.00","quantity":"1","side":"buy"}'
 
-# Write, BOTH gates ON → sends live:
+# Write, the ROBINHOOD_ALLOW_LIVE_WRITE=1 switch ON → sends live:
 ROBINHOOD_ALLOW_LIVE_WRITE=1 robinhood-cli brokerage execute "https://api.robinhood.com/orders/" \
   --method POST --live-write --body-json '{...}'
 

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -41,7 +41,7 @@ you *why it's true*; AGENTS.md tells you *everything else*.
   dollar-denominated.
 - **Descriptive, not prescriptive on risk.** Modules surface mechanics, numbers, and flags; the
   operator chooses risk and sizing.
-- **Reads are free; writes are double-gated.** Nothing in this library overrides the dry-run
+- **Reads are free; writes are env-gated.** Nothing in this library overrides the dry-run
   default, the confirmation contract, or the order-evidence rule.
 - **Link, don't duplicate.** When a module and a deep doc disagree, the dated doc + live API are
   the tiebreakers — and the discrepancy should be reported, not papered over.

--- a/knowledge/dividend-investing.md
+++ b/knowledge/dividend-investing.md
@@ -67,7 +67,7 @@ attention. Two operational facts agents must carry:
 
 - **A DRIP reinvest is a purchase** — it can wash a tax-loss harvest on the same name
   (`knowledge/tax-loss-harvesting.md`). Robinhood DRIP toggles **account-wide or per-stock**,
-  and both are first-class double-gated writes here.
+  and both are first-class env-gated writes here.
 - DRIP into a falling payer is automated averaging-down — fine if intended, surface it if not.
 
 ## Weekly-payer covered-call ETFs (QDTE-style) — distribution ≠ dividend
@@ -107,7 +107,7 @@ node cli/dist/index.js dividends --account <N>      # one account               
 node cli/dist/index.js stock profile <SYM> --json   # P/E, market cap, fundamentals for payout-ratio context
 node cli/dist/index.js history --days 90 --account <N> --json   # fill dates → qualified-holding check
 
-# DRIP control (double-gated writes; explicit approval + both gates):
+# DRIP control (env-gated writes; explicit approval + the live-write switch on):
 node cli/dist/index.js settings show --account <N>
 node cli/dist/index.js settings drip --account <N> --enable                    # account-wide
 node cli/dist/index.js settings drip --account <N> --disable --instrument <ID> # per-stock
@@ -120,7 +120,7 @@ declared ex-date) — buy must land **before** the ex-date; (4) "is this yield s
 ratio + FCF + history via `stock profile` and outside research (`knowledge/signals.md`); for a
 QDTE-style payer, pull the fund's 19a-1 before calling its distribution "yield"; (5) "is this
 dividend qualified for me?" → fill timestamps from `history` vs the 121-day window;
-(6) DRIP changes → echo account + scope, both gates, verify with `settings show` re-read.
+(6) DRIP changes → echo account + scope, the live-write switch on, verify with `settings show` re-read.
 
 ## Deep dives
 

--- a/knowledge/execution-safety.md
+++ b/knowledge/execution-safety.md
@@ -2,20 +2,22 @@
 
 > **When to load this:** before ANY write (order, cancel, settings change, recurring toggle) and
 > whenever an error comes back from a write path. Reads are free and live; **every write is a
-> dry-run until both gates are deliberately passed.** This is the checklist version of SKILL.md's
-> failure modes — when in doubt, stop and confirm.
+> dry-run unless the `ROBINHOOD_ALLOW_LIVE_WRITE=1` switch is set.** This is the checklist version of
+> SKILL.md's failure modes — when in doubt, stop and confirm.
 
-## The two gates (non-negotiable)
+## The live-write switch (non-negotiable)
 
-- A write sends only with **both** `--live-write` AND `ROBINHOOD_ALLOW_LIVE_WRITE=1`
-  (MCP: `liveWrite: true` + the env var in the server's environment). One alone = dry-run.
-- **Never export the env var** into a shell profile. Inline, on the single command, every time:
+- A write sends only when `ROBINHOOD_ALLOW_LIVE_WRITE=1` is set in the environment — the single master
+  switch (MCP: the env var in the server's environment). No per-call `--live-write`/`liveWrite` is
+  required; the flag is accepted but optional and no longer the gate. Switch unset = every write is dry-run.
+- **Set it deliberately.** Prefer inline on the single command over exporting it into a shell profile,
+  where every later write would silently go live:
 
 ```bash
-ROBINHOOD_ALLOW_LIVE_WRITE=1 node cli/dist/index.js <command> ... --live-write
+ROBINHOOD_ALLOW_LIVE_WRITE=1 node cli/dist/index.js <command> ...
 ```
 
-- MCP `dryRun: true` always wins, even with both gates — the deliberate "preview this exact live
+- MCP `dryRun: true` always wins, even when the switch is on — the deliberate "preview this exact live
   call" escape hatch.
 
 ## The account-echo contract (before ANY send)
@@ -84,7 +86,7 @@ stop and ask. Never default into naked/undefined-risk exposure.
 
 ## Golden rule
 
-> Reads are free and live; every write is dry-run until you deliberately pass both gates. When
+> Reads are free and live; every write is dry-run unless ROBINHOOD_ALLOW_LIVE_WRITE=1 is set. When
 > unsure about account, side, position_effect, or amount — stop and confirm. A wrong write is
 > real money.
 

--- a/knowledge/playbooks/broker-call.md
+++ b/knowledge/playbooks/broker-call.md
@@ -108,7 +108,7 @@ qty <n> | limit $<x.xx> <debit|credit> | est. $<dollars> | TIF <gfd|gtc> | ref_i
 Reply "yes" to send exactly this.
 ```
 
-## Step 7 — Gated send (both gates, inline env var)
+## Step 7 — Gated send (the live-write switch on, inline env var)
 
 ```bash
 REF=$(python3 -c "import uuid;print(uuid.uuid4())")

--- a/knowledge/position-building.md
+++ b/knowledge/position-building.md
@@ -99,7 +99,7 @@ node cli/dist/index.js wheel <SYM> --account <N>            # stage + the litera
 # 3a. Accumulation path — gap math, then the schedule
 node cli/dist/index.js quote <SYM> --json                   # gap $ = (100 − shares) × last
 node cli/dist/index.js buy -s <SYM> -a <N> -m <USD>         # fractional tranche (dry-run default)
-node cli/dist/index.js recurring create --account <N> --symbol <SYM> --amount <USD> --frequency weekly  # autopilot (double-gated)
+node cli/dist/index.js recurring create --account <N> --symbol <SYM> --amount <USD> --frequency weekly  # autopilot (env-gated)
 
 # 3b. CSP-acquisition path — enumerate, then dry-run quote
 node cli/dist/index.js options expirations <SYM> --json
@@ -121,7 +121,7 @@ wheel/CC question, hand off to `wheel`; (3) if cash ≥ strike×100 → CSP acqu
 quote it at the strike the user would pay; (4) if neither, price the PMCC floor (LEAPS ask ×
 100) against buying power and the account's entitlement; (5) otherwise accumulation — emit the
 gap in dollars, the cycles-to-goal at the proposed cadence, and the `recurring create` dry-run;
-(6) any send: both gates, echo contract, order-history evidence, log the THREAD ("building to
+(6) any send: the live-write switch on, echo contract, order-history evidence, log the THREAD ("building to
 100 sh for CC; leg 0: accumulation") in `trading-log.md` so the next session knows the campaign.
 
 ## Deep dives

--- a/knowledge/tax-loss-harvesting.md
+++ b/knowledge/tax-loss-harvesting.md
@@ -115,7 +115,7 @@ grep -i "<SYM>" trading-log.md                                  # agent-side int
 node cli/dist/index.js recurring list --json                    # live schedule on the symbol? → pause first
 node cli/dist/index.js settings show --account <N>              # DRIP on? → per-instrument disable below
 
-# 4. Neutralize the automatic re-buyers (double-gated writes; get explicit approval)
+# 4. Neutralize the automatic re-buyers (env-gated writes; get explicit approval)
 node cli/dist/index.js recurring pause --id <SCHEDULE_ID> --live-write      # + ROBINHOOD_ALLOW_LIVE_WRITE=1
 node cli/dist/index.js settings drip --account <N> --disable --instrument <INSTRUMENT_ID> --live-write
 
@@ -128,7 +128,7 @@ node cli/dist/index.js buy  -s <CORRELATED_SYM> -a <N> -m <USD>  # replacement e
 candidates by **realized-loss dollars**, not percent — a −40% on a $50 lot is $20 of loss, a −8%
 on a $20,000 lot is $1,600; (3) for each candidate, clear the 30-day lookback AND kill the
 automatic re-buyers; (4) pick the replacement (correlated-not-identical, or sit in cash 31 days);
-(5) dry-run, echo account + symbol + side + qty, send only with both gates, verify in order
+(5) dry-run, echo account + symbol + side + qty, send only with the live-write switch on, verify in order
 history, log to `trading-log.md` with INTENT "tax-loss harvest, $X loss realized, replacement
 <SYM>, re-entry window opens <DATE+31>". Set the re-entry date in the log — future-you needs it.
 


### PR DESCRIPTION
Long-tail follow-up to PR #7. Sweeps every *currently-authoritative* surface that still taught the double-gate — knowledge/ modules (incl. the execution-safety doctrine), recipes.json, CLI/engine output strings, and operating/reference docs — to the single ROBINHOOD_ALLOW_LIVE_WRITE=1 switch. Dated changelogs + claims-audit-2026-06-11 left as historical records. 228 tests pass.