### PR TITLE
fix(risk): max-loss for long options was 100× overstated and double-counted

### DIFF
--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -6163,11 +6163,16 @@ export async function computeRisk(opts: any = {}, deps: any = {}) {
                     }
                     maxLoss = null;
                 }
-                else if (maxLoss !== null) {
-                    const debitPaid = n(p.avgOpenPrice) * p.qty * 100;
-                    if (Number.isFinite(debitPaid))
-                        maxLoss += debitPaid;
-                }
+            }
+            // Max loss for a purely-long position = total debit paid, computed ONCE from the
+            // position-level cost basis. average_open_price is ALREADY per-contract dollars
+            // (premium × 100; see optionReturnPct), so it is multiplied by the contract count
+            // ONLY — never by another 100 — and only after the leg loop, so a multi-leg long
+            // (e.g. a long straddle) is not counted once per leg. Any short leg already set
+            // maxLoss = null (spread defined-risk is intentionally left unmodeled here).
+            if (maxLoss !== null) {
+                const debit = n(p.avgOpenPrice) * p.qty;
+                maxLoss = Number.isFinite(debit) ? debit : null;
             }
             positions.push({ kind: "option", symbol: p.symbol, description: `${p.symbol} ${p.strategy ?? ""}`.trim(), side: p.strategy?.startsWith("short") ? "short" : "long", quantity: p.qty, marketValueUsd: round2(totalPosMktVal), maxLossUsd: maxLoss !== null ? round2(maxLoss) : null, itmExpirationRisk: itmRisk, undercoveredShortLegs: undercovered, account: a.acct });
             symbolValues.set(p.symbol, (symbolValues.get(p.symbol) ?? 0) + (Number.isFinite(totalPosMktVal) ? Math.abs(totalPosMktVal) : 0));

--- a/cli/test/financial-tools.test.ts
+++ b/cli/test/financial-tools.test.ts
@@ -298,7 +298,7 @@ const riskFix = () => buildFixture({
       },
       {
         symbol: "BBB", strategy: "long put", quantity: "2",
-        average_open_price: "1.50",
+        average_open_price: "150.00", // per-contract dollars (premium $1.50/sh × 100)
         legs: [{
           option_id: "optB1", position_type: "long", option_type: "put",
           strike_price: "30.0000", expiration_date: "2026-08-21",
@@ -336,6 +336,37 @@ describe("computeRisk — portfolio risk scanner", () => {
     const optPut = r.positions.find((p) => p.kind === "option" && p.symbol === "BBB")!;
     expect(optPut.marketValueUsd).toBe(200);
     expect(optPut.side).toBe("long");
+    // Max loss = total debit = $150/contract × 2 = $300. average_open_price is per-contract
+    // dollars, so it is multiplied by the contract count ONLY. Regression guard for the
+    // 100× bug: this must be $300, NOT $30,000 (avgOpen × qty × 100).
+    expect(optPut.maxLossUsd).toBe(300);
+  });
+
+  it("multi-leg long (long straddle) counts the debit ONCE, not per leg", async () => {
+    const fix = buildFixture({
+      accounts: { results: [{ type: "rhs", account_number: "111111111", account_name: "Main" }] },
+      positions: { "111111111": [] },
+      optionAggregates: { "111111111": [
+        {
+          symbol: "CCC", strategy: "long straddle", quantity: "1",
+          average_open_price: "400.00", // net per-contract debit (premium $4.00/sh × 100)
+          legs: [
+            { option_id: "ccc_c", position_type: "long", option_type: "call", strike_price: "100.0000", expiration_date: "2026-09-18", ratio_quantity: "1" },
+            { option_id: "ccc_p", position_type: "long", option_type: "put",  strike_price: "100.0000", expiration_date: "2026-09-18", ratio_quantity: "1" }
+          ]
+        }
+      ]},
+      portfolios: { "111111111": { equity: "5000.00" } },
+      optionMarks: {
+        "ccc_c": { instrument_id: "ccc_c", adjusted_mark_price: "2.50", mark_price: "2.50" },
+        "ccc_p": { instrument_id: "ccc_p", adjusted_mark_price: "1.80", mark_price: "1.80" }
+      }
+    });
+    const r = await computeRisk({}, fix);
+    const pos = r.positions.find((p) => p.kind === "option" && p.symbol === "CCC")!;
+    // Debit = $400/contract × 1 = $400, counted ONCE across BOTH long legs.
+    // Regression guard for the per-leg double-count: must be $400, not $800.
+    expect(pos.maxLossUsd).toBe(400);
   });
 
   it("detects ITM expiration risk for short options", async () => {


### PR DESCRIPTION
## What
`computeRisk` reported long-option **max loss 100× too high**, and **double-counted** multi-leg long positions.

PR #10 merged the feat branch at `5c38a1e` — *before* this fix landed on the branch (a timing race) — so this bug is currently **live in `main`**. This PR re-lands the fix against current main.

## Root cause
`average_open_price` from `aggregate_positions` is **already per-contract dollars** (premium × 100). Proof in-repo: the options-positions view divides it by 100 for a per-share entry, and `optionReturnPct` treats it as per-contract. `computeRisk` multiplied it by **another 100** (`avgOpenPrice × qty × 100`), and accumulated the debit **once per long leg** inside the leg loop.

- 1-contract long call @ $1.50 → reported max loss **$15,000** (true: **$150**)
- long straddle → additionally double-counted

## Fix
Compute the position debit **once**, after the leg loop, as `average_open_price × contract_count` (no extra ×100). Any short leg still forces `maxLoss = null` (defined-risk spreads remain intentionally unmodeled).

## Tests
Corrected the `riskFix` fixture's `average_open_price` to a realistic per-contract value and added regression assertions: long-option max loss = **$300 (not $30,000)**, multi-leg-long single-count = **$400 (not $800)**. **310 tests pass**, build + typecheck clean.