### PR TITLE
fix: YAML colon in skill description + POST route for internal transfers (skill branch → main)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,15 @@
 ---
 name: robinhood-cli
-description: This skill should be used when the user asks to "use Robinhood", "check my Robinhood account", "show my positions", "rank my options", "quote an options spread", "build a dry-run Robinhood order", "manage recurring investments", "check account settings", "map Robinhood endpoints", "use the Robinhood CLI", or "use the Robinhood MCP" — and for finance research/due-diligence: market sentiment and signal sourcing (news vs Twitter/X vs Reddit), or consulting the operator's "ball knowledge" investing-notes ledger. It covers brokerage/crypto reads, positions, orders, watchlists, options chains, recurring buys, account-settings route maps, the source-quality due-diligence doctrine, the Ball Knowledge memory layer, and the full reverse-engineered API map with safety gates.
+description: >
+  This skill should be used when the user asks to "use Robinhood", "check my Robinhood account",
+  "show my positions", "rank my options", "quote an options spread", "build a dry-run Robinhood order",
+  "manage recurring investments", "check account settings", "map Robinhood endpoints",
+  "use the Robinhood CLI", or "use the Robinhood MCP" — and for finance research/due-diligence:
+  market sentiment and signal sourcing (news vs Twitter/X vs Reddit), or consulting the operator's
+  "ball knowledge" investing-notes ledger. It covers brokerage/crypto reads, positions, orders,
+  watchlists, options chains, recurring buys, account-settings route maps, the source-quality
+  due-diligence doctrine, the Ball Knowledge memory layer, and the full reverse-engineered API map
+  with safety gates.
 version: 2.0.0
 author: Zayd (@zaydiscold)
 license: MIT
@@ -1281,14 +1290,14 @@ The full first-class tool roster (live truth: `tools/list`, never a hardcoded co
 ### Registration
 
 ```bash
-hermes mcp add robinhood --command "node" \
-  --args "C:/Users/ZaydK/Desktop/robinhood-cli/mcp/dist/server.js"
-```
+# Hermes (reads + writes gated by ROBINHOOD_ALLOW_LIVE_WRITE=1):
+hermes mcp add robinhood-cli --command node \
+  --env ROBINHOOD_ALLOW_LIVE_WRITE=1 \
+  --args /path/to/robinhood-cli/mcp/dist/server.js
 
-Or for Claude Code / other MCP clients:
-
-```bash
-claude mcp add robinhood-cli -s user -- \
+# Or for Claude Code / other MCP clients:
+claude mcp add robinhood-cli -s user \
+  -e ROBINHOOD_ALLOW_LIVE_WRITE=1 -- \
   node /absolute/path/to/robinhood-cli/mcp/dist/server.js
 ```
 

--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -5930,6 +5930,34 @@
     "fieldsSource": "undocumented"
   },
   {
+    "url": "https://bonfire.robinhood.com/paymenthub/unified_transfers/",
+    "host": "bonfire.robinhood.com",
+    "categories": [
+      "money-movement"
+    ],
+    "risk": "write-mutate",
+    "methods": [
+      "POST"
+    ],
+    "summary": "Create an internal transfer between Robinhood accounts. For retirement accounts set receiving_account_type to 'ira_roth' or 'ira'. Cash accounts only use unleveraged/withdrawable balance (not margin BP). Individual accounts use originating/receiving_account_type 'rhs_account'.",
+    "bodyKeys": [
+      "amount",
+      "currency",
+      "direction",
+      "originating_account_id",
+      "originating_account_type",
+      "receiving_account_id",
+      "receiving_account_type",
+      "transfer_type"
+    ],
+    "source": "cdp-2026-06-18-transfer-flow",
+    "seenOn": [
+      "account-transfers"
+    ],
+    "fields": [],
+    "fieldsSource": "undocumented"
+  },
+  {
     "url": "https://bonfire.robinhood.com/paymenthub/unified_transfers/{uuid}/contribution/",
     "host": "bonfire.robinhood.com",
     "categories": [


### PR DESCRIPTION
Brings the unmerged `fix/skill-yaml-and-transfer-route` work into main (the auth commits it sat on are already in main via PR #11). Net-new: SKILL.md YAML frontmatter block-scalar fix + corrected MCP registration commands, and a POST route for `paymenthub/unified_transfers/` in the route map. SKILL.md registration-block conflict with the merged feat branch resolved by keeping the more complete version (env flag + correct server name + single coherent code block). 310 tests pass; build + typecheck clean.