### PR TITLE
reconcile: land the last dangling session feature (sentinel) into main

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -17,6 +17,7 @@ import {
   computeExposure,
   computeIncome,
   computeRisk,
+  computeSentinel,
   computeWhatIf,
   computeNews,
   computeRatings,
@@ -3682,6 +3683,26 @@ program
       process.stdout.write("No short options approaching expiration in this window.\n");
     }
     if (r.warnings.length) process.stdout.write(`${r.warnings.map((w: string) => "⚠️  " + w).join("\n")}\n`);
+  });
+
+program
+  .command("sentinel")
+  .description("Daily risk + event guardian: portfolio risk scan + options event calendar (assignment, exercise, expiration). Zero CDP — safe for scheduled daily runs.")
+  .option("--account <number>", "scope to one account (default: all owned)")
+  .option("--days <n>", "event lookahead in days (default: 7)", "7")
+  .option("--json", "emit JSON")
+  .action(async (opts: { account?: string; days?: string; json?: boolean }) => {
+    const r = await computeSentinel({ accountNumber: opts.account, eventLookaheadDays: Number(opts.days ?? "7") });
+    if (opts.json) { printJson(r); return; }
+    process.stdout.write(`Sentinel — ${r.accountsScanned.length} account(s) — as of ${r.generatedAt}\n`);
+    if (r.events.count > 0) {
+      process.stdout.write(`\n${r.events.count} option events on record:\n`);
+      for (const e of r.events.events.slice(0, 10)) {
+        process.stdout.write(`  ${e.date}  ${e.type}  ${e.symbol} ${e.direction} qty=${e.quantity} cash=$${e.cash.toFixed(2)}  ${e.state}\n`);
+      }
+      if (r.events.events.length > 10) process.stdout.write(`  ... and ${r.events.events.length - 10} more\n`);
+    }
+    if (r.warnings.length) process.stdout.write(`\n${r.warnings.map((w: string) => "⚠️  " + w).join("\n")}\n`);
   });
 
 const watchlist = new Command("watchlist").description("Inspect (read) and edit (add/remove/create, env-gated) your custom watchlists");

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -6874,4 +6874,50 @@ export async function computeOptionsEvents(
   return { count: events.length, events };
 }
 
-    // Zayd Khan // cold // www.zayd.wtf
+/**
+ * Sentinel — daily risk + event guardian. Composes computeRisk (positions, concentration,
+ * margin, Greeks exposure) + computeOptionsEvents (assignment, exercise, expiration).
+ * Zero CDP. Designed for scheduled daily scans.
+ */
+export async function computeSentinel(
+  opts: { accountNumber?: string; eventLookaheadDays?: number } = {},
+  deps: { getJson?: typeof brokerageGetJson; getAll?: typeof brokerageGetAllResults } = {}
+): Promise<{
+  generatedAt: string;
+  accountsScanned: string[];
+  risk: Awaited<ReturnType<typeof computeRisk>>;
+  events: Awaited<ReturnType<typeof computeOptionsEvents>>;
+  warnings: string[];
+}> {
+  const warnings: string[] = [];
+  const risk = await computeRisk({ accountNumber: opts.accountNumber }, deps as any);
+  const events = await computeOptionsEvents(
+    { accountNumber: opts.accountNumber, limit: 50 },
+    { getJson: deps.getJson }
+  );
+  // Collect risk warnings
+  if (risk.warnings?.length) warnings.push(...risk.warnings);
+  // Flag near-term expirations and assignments
+  const lookaheadDays = opts.eventLookaheadDays ?? 7;
+  const cutoff = new Date(Date.now() + lookaheadDays * 86400000).toISOString().slice(0, 10);
+  const upcoming = events.events.filter((e) => e.date <= cutoff);
+  if (upcoming.length > 0) {
+    const assignmentEvents = upcoming.filter((e) => e.type === "assignment");
+    const expirationEvents = upcoming.filter((e) => e.type === "expiration");
+    if (assignmentEvents.length > 0) {
+      warnings.push(`${assignmentEvents.length} assignment event(s) in the next ${lookaheadDays} days — review short positions.`);
+    }
+    if (expirationEvents.length > 0) {
+      warnings.push(`${expirationEvents.length} expiration(s) in the next ${lookaheadDays} days.`);
+    }
+  }
+  return {
+    generatedAt: new Date().toISOString(),
+    accountsScanned: risk.accountsScanned ?? [],
+    risk,
+    events,
+    warnings
+  };
+}
+
+// Zayd Khan // cold // www.zayd.wtf

--- a/cli/test/mcp-tool-count.test.ts
+++ b/cli/test/mcp-tool-count.test.ts
@@ -10,7 +10,7 @@ import { dirname, resolve } from "node:path";
 // expected count here — do NOT re-introduce a hardcoded count into the docs.
 // It is deterministic and offline: it parses mcp/src/server.ts source, no server boot, no network.
 
-const EXPECTED_TOOL_COUNT = 71;
+const EXPECTED_TOOL_COUNT = 72;
 const FAIL_MSG =
   "tool count changed — bump EXPECTED_TOOL_COUNT here (the only sanctioned hardcode). Docs express the count via `tools/list`, never a literal — do NOT add a number back to them.";
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -9,6 +9,7 @@ import {
   buildOptionsContractNavigationPlan,
   buildOptionsStrategyOrderPlan,
   computeAutopilot,
+  computeSentinel,
   computeCalendar,
   computeExposure,
   computeIncome,
@@ -1797,6 +1798,25 @@ server.registerTool(
   },
   async ({ account_number, days }) => {
     try { return jsonResponse(await computeAutopilot({ accountNumber: account_number, days })); }
+    catch (e: any) { return jsonResponse({ error: e.message }); }
+  }
+);
+
+// ── robinhood_sentinel: daily risk + event guardian ──
+server.registerTool(
+  "robinhood_sentinel",
+  {
+    title: "Robinhood Sentinel — Daily Risk + Event Guardian",
+    description:
+      "Daily risk + event guardian: composes computeRisk (portfolio risk scan — positions, concentration, margin, Greeks exposure) + computeOptionsEvents (assignment, exercise, expiration history). Zero CDP — safe for scheduled daily scans. Returns a consolidated report with risk scan, upcoming events, and warnings. Live read; no gate.",
+    inputSchema: z.object({
+      account_number: z.string().optional(),
+      event_lookahead_days: z.number().int().min(1).max(30).default(7)
+    }),
+    annotations: toolAnnotations(true, "sensitive-read")
+  },
+  async ({ account_number, event_lookahead_days }) => {
+    try { return jsonResponse(await computeSentinel({ accountNumber: account_number, eventLookaheadDays: event_lookahead_days })); }
     catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );


### PR DESCRIPTION
## What

Reconciliation of the messy multi-agent session. After fetching, **all** prior session work was verified already in `main` (PRs #16/#17 landed the reconcile + audit nice-to-haves ~minutes earlier). Branch-by-branch check against `origin/main`:

| Branch | Unmerged forward work |
|---|---|
| `fix/skill-yaml-and-transfer-route` | none (fully in main) |
| `fix/stale-token-env-reread` | none (fully in main) |
| `reconcile/session-to-main` | none (merge commit only) |
| `feat/financial-tools-and-hardening` | `85339e5` signals — **equivalent already in main** (signal-reads.test.ts byte-identical); `b4e6173` **sentinel — the only true gap** |

This PR lands that one gap: **`computeSentinel`** — daily risk + event guardian, composing the existing `computeRisk` (portfolio risk scan) + `computeOptionsEvents` (assignment/exercise/expiration). Zero CDP, sensitive-read, no write gate — safe for scheduled daily runs.

- CLI: `sentinel --account X --days 7`
- MCP: `robinhood_sentinel` tool
- Tool count 71 → 72

## Forward-only, no regression

Cherry-picked the feature onto current `main` rather than merging the stale branch (which lacks main's 21 audit/hardening commits — a merge would risk reverting them).

Dropped one piece of the original commit: it re-added `resolveChainIdForAccount` to `lib.ts` ("lost in a reclone" on its older base), but `main` already has a working copy in `index.ts` and nothing consumes a `lib` export of it. Landing it would have introduced a **divergent duplicate of an account-resolver on a real-money path** — dropped.

## Verification
- typecheck + build (CLI + MCP): clean
- full suite: **347 passing** (19 files), identical to baseline → dedup lost nothing
- lint: 0 errors
- tool-count guard: 72 asserted == 72 registered; `robinhood_sentinel` present; CLI `sentinel --help` wired