### PR TITLE
feat(performance): portfolio equity-curve command (+ MCP-modernization research note)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ grain of the tool:
 
 - **Prefer the first-class command over raw `brokerage execute`.** `portfolio`, `positions`, `quote`,
   `options chain/positions/enumerate/holdings/inspect`, `accounts`, `history`, `watchlist`, `recurring`,
-  `settings`, `stock profile`, `pretrade`, `income`, `risk`, `whatif`, `calendar`, `exposure`, `autopilot`,
+  `settings`, `stock profile`, `pretrade`, `income`, `performance`, `risk`, `whatif`, `calendar`, `exposure`, `autopilot`,
   `search` do the multi-step join + query params for you. `brokerage execute` is the
   fallback for an unwrapped route — and it **can't take `?query=` params** (top time-waster).
 - **Money questions → DOLLARS, weighted by size, one command:** `portfolio` (`--day` / `--after-hours`).

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,6 +109,7 @@ then this file. When the answer isn't obvious, the docs already have it — read
 | "Quote a spread" / "Price an iron condor" | [Options CLI Playbook](#options-cliapi-playbook) |
 | "Review my trades / film study" | `review` — round trips with realized P&L, win rate, best/worst trades (filter by days/symbol/account) |
 | "How much income am I making?" | `income` — combined dividends + option premium by month, in dollars (TTM total, monthly avg, projected annual run-rate) |
+| "How am I doing over time / my returns / equity curve?" | `performance` (alias `perf`) — account value + return across day/week/month/3month/ytd/year/all; per-account (portfolio-wide summed client-side) |
 | "What's my risk exposure?" | `risk` — max loss per position, ITM assignment exposure, undercovered short legs, margin-call distance, concentration warnings |
 | "What if spot drops 10% / IV spikes?" | `whatif` — Greeks-based scenario calc: spot ±X%, IV ±N pts, T−n days → P&L per position in dollars |
 | "What's coming up on my holdings?" | `calendar` — upcoming option expirations, ex-div dates, earnings for held names with assignment-risk flags |
@@ -1360,6 +1361,7 @@ claude mcp add robinhood-cli -s user \
 | `robinhood_accounts` | List every account (full graph via `transfer/accounts/`) with type/capabilities |
 | `robinhood_positions` | Equity positions for an account (UUIDs resolved to tickers + quotes) |
 | `robinhood_portfolio` | One-call portfolio P&L: per-account day Δ + after-hours Δ, drivers by underlying in **dollars**, all accounts |
+| `robinhood_performance` | Portfolio historical performance (the equity curve over time): value + return across day/week/month/3month/ytd/year/all spans, per account |
 | `robinhood_options_holdings` | Every held option contract (UUID + strike + bid/ask/last + qty + link) |
 | `robinhood_options_inspect` | Full detail on one owned contract (metadata, Greeks, fills, buy/sell handoff) |
 | `robinhood_options_chain` | Live options chain around the money for a symbol (width, expiration, type filters) |

--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -6085,7 +6085,7 @@
     "fieldsShape": "object"
   },
   {
-    "url": "https://bonfire.robinhood.com/portfolio/performance/{id}",
+    "url": "https://bonfire.robinhood.com/portfolio/performance/{id}/",
     "host": "bonfire.robinhood.com",
     "categories": [
       "unknown"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
   computeCalendar,
   computeExposure,
   computeIncome,
+  computePerformance,
   computeRisk,
   computeSentinel,
   computeWhatIf,
@@ -3434,6 +3435,37 @@ program
     }
     if (r.warnings.length) process.stdout.write(`${r.warnings.map((w: string) => "⚠️  " + w).join("\n")}\n`);
     if (r.notes?.length) process.stdout.write(`\n📝 ${r.notes.join("\n")}\n`);
+  });
+
+// ── performance: portfolio equity curve over time ──
+program
+  .command("performance")
+  .alias("perf")
+  .description("Portfolio historical performance (the equity curve): account value + return across day/week/month/3month/ytd/year/all. Reads the desktop app's own chart route (per-account; portfolio-wide is summed client-side). Live read.")
+  .option("--account <number>", "scope to one account (default: all owned)")
+  .option("--span <span>", "day|week|month|3month|ytd|year|all (default: day)", "day")
+  .option("--no-all-hours", "exclude pre/post-market points")
+  .option("--points <n>", "max curve points to print per account (default: 8)")
+  .option("--json", "emit JSON")
+  .action(async (opts: { account?: string; span?: string; allHours?: boolean; points?: string; json?: boolean }) => {
+    const r = await computePerformance({ accountNumber: opts.account, span: opts.span, includeAllHours: opts.allHours !== false });
+    if (opts.json) { printJson({ generatedAt: new Date().toISOString(), ...r }); return; }
+    process.stdout.write(`Portfolio Performance — ${r.accounts.length} account(s) — span: ${r.span}\n`);
+    process.stdout.write(`as of ${new Date().toISOString()}\n\n`);
+    const maxPts = Math.max(1, Number(opts.points ?? "8"));
+    for (const a of r.accounts) {
+      const s = a.summary;
+      const ret = s.periodReturnUsd !== null ? `${usd(s.periodReturnUsd)} (${s.periodReturnPct?.toFixed(2)}%)` : "—";
+      process.stdout.write(`${a.account}${a.nickname ? " " + a.nickname : ""}: ${s.currentValueUsd !== null ? usd(s.currentValueUsd) : "—"} · ${r.span} return ${ret} · ${s.pointCount} pts\n`);
+      const pts = a.points;
+      if (pts.length) {
+        const step = Math.max(1, Math.floor(pts.length / maxPts));
+        const sample = pts.filter((_: any, i: number) => i % step === 0 || i === pts.length - 1);
+        printTable(sample.map((p: any) => ({ at: p.at ?? "", value: usd(p.valueUsd), return: p.returnPct != null ? `${p.returnPct.toFixed(2)}%` : "", session: p.session ?? "" })), ["at", "value", "return", "session"]);
+      }
+      process.stdout.write("\n");
+    }
+    if (r.warnings.length) process.stdout.write(`${r.warnings.map((w: string) => "⚠️  " + w).join("\n")}\n`);
   });
 
 // ── risk: portfolio risk scanner ──

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -6184,6 +6184,111 @@ export async function computeIncome(opts: any = {}, deps: any = {}) {
         notes
     };
 }
+// Friendly span aliases → the API's `display_span` values. The endpoint self-documents these in
+// spans.available_spans[]; we accept both the API value and common shorthands.
+const PERFORMANCE_SPANS: Record<string, string> = {
+    day: "day", "1d": "day", today: "day",
+    week: "week", "1w": "week",
+    month: "month", "1m": "month",
+    "3month": "3month", "3m": "3month", quarter: "3month",
+    ytd: "ytd",
+    year: "year", "1y": "year",
+    all: "all", max: "all",
+};
+// RH chart dollar values arrive as formatted strings ("$1,234.56", "-$12.30", "($12.30)").
+function parseMoneyUsd(v: unknown): number {
+    if (typeof v === "number") return v;
+    const s = String(v ?? "").trim();
+    if (!s) return Number.NaN;
+    const negative = s.startsWith("-") || s.startsWith("(");
+    const magnitude = Number(s.replace(/[^0-9.]/g, ""));
+    if (!Number.isFinite(magnitude)) return Number.NaN;
+    return negative ? -magnitude : magnitude;
+}
+/**
+ * Portfolio historical performance — the equity curve over time (the data behind a `performance`
+ * command: account value across day/week/month/3month/ytd/year/all). Reads the desktop web app's
+ * own chart route, bonfire.robinhood.com/portfolio/performance/{account}/?display_span=… — which is
+ * reachable on the regular host. (The classic `portfolios/historicals/` route 404s and the `phoenix`
+ * host is TLS-walled; this is the route the modern app actually uses — live-verified 2026-06-19.)
+ *
+ * Per-account only: RH exposes no all-accounts performance route, so a portfolio-wide curve must be
+ * summed client-side. Each account degrades independently (a failed read → a warning, not a throw).
+ *
+ * Reliable fields: the curve lives in lines[identifier="returns"].segments[].points[], where each
+ * point's dollar value is cursor_data.primary_value.value and its return fraction is `y` (both
+ * populated on 100% of points). The high-precision price_chart_data block is inconsistent
+ * (null on year/all spans) — do NOT depend on it. `x` is a 0..1 layout fraction, not a timestamp;
+ * the timestamp is cursor_data.label.value.
+ */
+export async function computePerformance(opts: any = {}, deps: any = {}) {
+    const getJson = deps.getJson ?? brokerageGetJson;
+    const n = (v: unknown) => Number(v);
+    const warnings: string[] = [];
+    const spanInput = String(opts.span ?? "day").toLowerCase();
+    const span = PERFORMANCE_SPANS[spanInput] ?? "day";
+    if (!PERFORMANCE_SPANS[spanInput]) {
+        warnings.push(`Unknown span "${opts.span}" — defaulting to "day". Valid: day/week/month/3month/ytd/year/all.`);
+    }
+    const includeAllHours = opts.includeAllHours !== false; // default true
+    const accts = await listOwnedTradingAccounts(getJson, opts.accountNumber);
+    const accounts = [];
+    for (const { acct, label } of accts) {
+        try {
+            const body = await getJson(
+                "https://bonfire.robinhood.com/portfolio/performance/{id}/",
+                { id: acct },
+                { display_span: span, include_all_hours: String(includeAllHours), chart_type: "historical_portfolio" }
+            );
+            const lines = Array.isArray(body?.lines) ? body.lines : [];
+            const returnsLine = lines.find((l: any) => l?.identifier === "returns") ?? lines[0] ?? {};
+            const points = [];
+            for (const seg of returnsLine.segments ?? []) {
+                for (const p of seg.points ?? []) {
+                    const cd = p?.cursor_data ?? {};
+                    points.push({
+                        at: cd.label?.value ?? null,
+                        valueUsd: round2(parseMoneyUsd(cd.primary_value?.value)),
+                        returnPct: round2(n(p?.y) * 100),
+                        returnLabel: cd.secondary_value?.main?.value ?? null,
+                        session: cd.secondary_value?.description?.value ?? null,
+                    });
+                }
+            }
+            const first = points[0] ?? null;
+            const last = points[points.length - 1] ?? null;
+            const baselineUsd = round2(parseMoneyUsd(body?.performance_baseline?.amount));
+            const currentValueUsd = last ? last.valueUsd : Number.NaN;
+            const periodReturnUsd = Number.isFinite(currentValueUsd) && Number.isFinite(baselineUsd)
+                ? round2(currentValueUsd - baselineUsd) : null;
+            accounts.push({
+                accountNumber: acct,
+                account: "…" + acct.slice(-4),
+                nickname: label,
+                span,
+                summary: {
+                    currentValueUsd: Number.isFinite(currentValueUsd) ? currentValueUsd : null,
+                    baselineUsd: Number.isFinite(baselineUsd) ? baselineUsd : null,
+                    periodReturnUsd,
+                    periodReturnPct: last ? last.returnPct : null,
+                    pointCount: points.length,
+                    first,
+                    last,
+                },
+                points,
+            });
+        }
+        catch (e: any) {
+            warnings.push(`performance read failed (…${acct.slice(-4)}): ${(e as Error).message.slice(0, 80)}`);
+        }
+    }
+    return {
+        span,
+        accountsScanned: accts.map((a: any) => "…" + a.acct.slice(-4)),
+        accounts,
+        warnings,
+    };
+}
 /**
  * Portfolio risk scanner: max loss across open positions, assignment exposure (ITM shorts),
  * undercovered short legs, margin-call distance, and concentration warnings (>20% in one symbol).

--- a/cli/test/mcp-tool-count.test.ts
+++ b/cli/test/mcp-tool-count.test.ts
@@ -10,7 +10,7 @@ import { dirname, resolve } from "node:path";
 // expected count here — do NOT re-introduce a hardcoded count into the docs.
 // It is deterministic and offline: it parses mcp/src/server.ts source, no server boot, no network.
 
-const EXPECTED_TOOL_COUNT = 72;
+const EXPECTED_TOOL_COUNT = 73;
 const FAIL_MSG =
   "tool count changed — bump EXPECTED_TOOL_COUNT here (the only sanctioned hardcode). Docs express the count via `tools/list`, never a literal — do NOT add a number back to them.";
 

--- a/cli/test/performance.test.ts
+++ b/cli/test/performance.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { computePerformance } from "../src/lib.js";
+
+// computePerformance calls getJson(url, params, query); brokerageGetJson fills {id} from params,
+// so the injected fake keys off params.id (the url stays the {id} template). The accounts graph
+// comes from transfer/accounts/.
+function fakeGetJson(perfBody: any, accounts = [{ type: "rhs", account_number: "111111111", account_name: "Main" }]) {
+  return async (url: string, _params: any = {}, _query: any = {}) => {
+    if (url.includes("transfer/accounts")) return { results: accounts };
+    if (url.includes("portfolio/performance")) return perfBody;
+    return {};
+  };
+}
+
+const perfFixture = {
+  display_span: "year",
+  performance_baseline: { amount: "10000.00" },
+  lines: [
+    {
+      identifier: "returns",
+      segments: [
+        {
+          points: [
+            { x: 0, y: 0.0, cursor_data: { label: { value: "Jun 20, 2025" }, primary_value: { value: "$10,000.00" }, secondary_value: { main: { value: "$0.00 (0.00%)" }, description: { value: "" } } } },
+            { x: 0.5, y: 0.05, cursor_data: { label: { value: "Dec 20, 2025" }, primary_value: { value: "$10,500.00" }, secondary_value: { main: { value: "+$500.00 (5.00%)" }, description: { value: "Overnight" } } } },
+            { x: 1, y: 0.1, cursor_data: { label: { value: "Jun 19, 2026" }, primary_value: { value: "$11,000.00" }, secondary_value: { main: { value: "+$1,000.00 (10.00%)" }, description: { value: "Today" } } } }
+          ]
+        }
+      ]
+    },
+    { identifier: "benchmark", segments: [] }
+  ]
+};
+
+describe("computePerformance — portfolio equity curve", () => {
+  it("flattens the returns line into points with parsed $ value, return %, timestamp, session", async () => {
+    const r = await computePerformance({ span: "year" }, { getJson: fakeGetJson(perfFixture) });
+    expect(r.span).toBe("year");
+    expect(r.accounts).toHaveLength(1);
+    const a = r.accounts[0];
+    expect(a.summary.pointCount).toBe(3);
+    expect(a.points[0].valueUsd).toBe(10000);
+    expect(a.points[2].valueUsd).toBe(11000);
+    expect(a.points[2].returnPct).toBe(10); // y(0.10) * 100, not 100×
+    expect(a.points[0].at).toBe("Jun 20, 2025");
+    expect(a.points[2].session).toBe("Today");
+    // reads the "returns" line, not the benchmark line
+    expect(a.points.every((p: any) => Number.isFinite(p.valueUsd))).toBe(true);
+  });
+
+  it("computes summary: current value (last point), baseline, period return $ and %", async () => {
+    const r = await computePerformance({ span: "year" }, { getJson: fakeGetJson(perfFixture) });
+    const s = r.accounts[0].summary;
+    expect(s.currentValueUsd).toBe(11000);
+    expect(s.baselineUsd).toBe(10000);
+    expect(s.periodReturnUsd).toBe(1000); // 11000 - 10000
+    expect(s.periodReturnPct).toBe(10);
+  });
+
+  it("maps friendly span aliases (1y → year) and warns + defaults to day on unknown span", async () => {
+    const ok = await computePerformance({ span: "1y" }, { getJson: fakeGetJson(perfFixture) });
+    expect(ok.span).toBe("year");
+    expect(ok.warnings).toHaveLength(0);
+
+    const bad = await computePerformance({ span: "decade" }, { getJson: fakeGetJson(perfFixture) });
+    expect(bad.span).toBe("day");
+    expect(bad.warnings.some((w: string) => w.includes("Unknown span"))).toBe(true);
+  });
+
+  it("parses negative formatted money: '-$50.00' and '($50.00)' both → -50", async () => {
+    const neg = {
+      performance_baseline: { amount: "10000" },
+      lines: [{ identifier: "returns", segments: [{ points: [
+        { y: -0.005, cursor_data: { label: { value: "x" }, primary_value: { value: "-$50.00" } } },
+        { y: -0.005, cursor_data: { label: { value: "y" }, primary_value: { value: "($50.00)" } } }
+      ] }] }]
+    };
+    const r = await computePerformance({ span: "day" }, { getJson: fakeGetJson(neg) });
+    expect(r.accounts[0].points[0].valueUsd).toBe(-50);
+    expect(r.accounts[0].points[1].valueUsd).toBe(-50);
+  });
+
+  it("degrades per-account: a failing account becomes a warning; others survive", async () => {
+    const getJson = async (url: string, params: any = {}) => {
+      if (url.includes("transfer/accounts")) return { results: [
+        { type: "rhs", account_number: "111111111", account_name: "Good" },
+        { type: "rhs", account_number: "222222222", account_name: "Bad" }
+      ] };
+      if (url.includes("portfolio/performance")) {
+        if (params?.id === "222222222") throw new Error("500 Internal Server Error");
+        return perfFixture;
+      }
+      return {};
+    };
+    const r = await computePerformance({ span: "year" }, { getJson });
+    expect(r.accounts).toHaveLength(1); // only the good account
+    expect(r.accounts[0].account).toBe("…1111");
+    expect(r.warnings.some((w: string) => w.includes("…2222"))).toBe(true);
+  });
+
+  it("scopes to a single account when accountNumber is given", async () => {
+    const getJson = fakeGetJson(perfFixture, [
+      { type: "rhs", account_number: "111111111", account_name: "Main" },
+      { type: "ira_roth", account_number: "222222222", account_name: "Roth" }
+    ]);
+    const r = await computePerformance({ span: "month", accountNumber: "222222222" }, { getJson });
+    expect(r.accounts).toHaveLength(1);
+    expect(r.accounts[0].account).toBe("…2222");
+  });
+});

--- a/docs/undocumented-surface.md
+++ b/docs/undocumented-surface.md
@@ -114,6 +114,23 @@ entries are unrelated read routes).
    `discovery/lists/` POST + `discovery/lists/{id}/` PATCH/DELETE = `destructive`. All env-gated; safe
    for `brokerage execute` only behind both write gates. Wired as first-class `watchlist add/remove/create`.
 
+## 2026-06-19 — Portfolio performance / equity curve (`bonfire …/portfolio/performance/{id}/`)
+
+Wired the first-class `performance` command + `robinhood_performance` MCP tool over the desktop web
+app's own portfolio-chart route. **Corrects the prior "deferred — phoenix is TLS-walled" conclusion:**
+that was one dead path (`portfolios/historicals/` 404s; `phoenix.robinhood.com` refuses the TLS
+handshake), but the modern app reads the equity curve from a reachable `bonfire` route.
+
+1. **Discovery source.** Cross-referenced the route map + CDP `queryKeys`, then live-verified every span (242 pts day · 252 year · 382 all, back to account inception).
+2. **Request.** `GET https://bonfire.robinhood.com/portfolio/performance/{account_number}/?display_span={day|week|month|3month|ytd|year|all}&include_all_hours=true&chart_type=historical_portfolio`.
+   - **The span param is `display_span`, NOT `span`** (passing `span=` is silently ignored → always `day`).
+   - **The trailing slash is required** — `…/performance/{id}` (no slash) returns 200 with an EMPTY body; `…/performance/{id}/` returns the curve. The route-map entry carries the trailing slash for exactly this reason.
+   - **Per-account only.** No all-accounts variant (`…/performance/` → 500). Sum client-side for a portfolio-wide curve.
+3. **Auth/session.** Standard web-session bearer + web headers. Read-only.
+4. **Response shape.** `lines[identifier="returns"].segments[].points[]`; each point's dollar value is `cursor_data.primary_value.value` (formatted string) and its return fraction is `y` (both populated on 100% of points). `performance_baseline.amount` = start equity. The high-precision `price_chart_data` block is INCONSISTENT (null on year/all) — do NOT depend on it. `x` is a 0..1 layout fraction, not a timestamp; the timestamp is `cursor_data.label.value`.
+5. **Rate-limit behavior.** None observed across the span sweep.
+6. **Risk classification.** `sensitive-read`; safe for `brokerage execute` (read). Wired as `performance` / `robinhood_performance`, engine `computePerformance` (pinned by `cli/test/performance.test.ts`).
+
 When a new undocumented route is discovered, record:
 
 1. Discovery source.

--- a/ideas.md
+++ b/ideas.md
@@ -90,3 +90,31 @@ Anything that needs a route we haven't captured is flagged "(needs surface mappi
 - Dividend-account designation flow — once account-rename surface is mapped, designate an empty account as the income machine (already in pool; depends on the CDP account-management capture task).
 - MCP resources for the knowledge library — expose knowledge/*.md as MCP resources so resource-rendering clients get the library natively, plus the glossary (already in pool; pair with `glossary`).
 - Trade-card / success-graphic generator — HTML render of a completed play (entry/exit, dollar P&L, payoff diagram, thread context) as a shareable card (already in pool; idea-side: drive it from the review/round-trip join so it's evidence-backed).
+
+## ====== 2026-06-19 — MCP modernization (researched; sequence hardening → modernization) ======
+
+Researched the official MCP spec/SDK + last-30-days community pulse against the live server
+(`mcp/src/server.ts`, 73 tools, SDK `@modelcontextprotocol/sdk` ^1.x). Verdict: worth doing — but per
+the owner's directive, **hardening + docs + small wins FIRST; modernization (Resources/structuredContent/
+elicitation) AFTER**, and only where shipping clients (esp. Claude) actually support it.
+
+Spec baseline: **stay on the 2025-11-25 revision / SDK 1.x** (the officially recommended production line).
+A 2026-07-28 revision exists but rides SDK **2.0-alpha** — do NOT chase it yet (revisit ~Q3 2026).
+Already correct in our code (do not redo): `destructiveHint: isWrite` on all writes; errors `throw` → SDK wraps `isError`.
+
+TIER 1 — hardening + docs + small wins (do first):
+- Brand the ~26 bare `z.string()` inputs (accountNumber/symbol/uuid) with regex/`.uuid()` schemas — fail bad args at the boundary before they hit Robinhood. Highest-leverage hardening for a real-money tool.
+- Return INPUT-validation failures as `isError` Tool Execution Errors (SEP-1303), not thrown protocol errors, so the model self-corrects and retries.
+- Consistent error shape across the ~29 `throw` sites (tool-name prefix + stable code; keep the loud write `executionStatus`).
+- Generate `mcp/README.md` from `tools/list` (currently a 17-line stub) + a CI drift check — matches the "live truth: tools/list, never a hardcoded count" doctrine.
+- First MCP-package tests: in-memory boot asserting tools/list count + every write tool has `destructiveHint:true`/`readOnlyHint:false` + a dry-run write returns `executed:false` (locks the safety invariants).
+- `structuredContent` + `outputSchema` on the top ~5 read tools (portfolio/positions/buying_power/quote/accounts). FOOTGUN: once `outputSchema` is declared the SDK REQUIRES a matching `structuredContent` and Cursor rejects declare-but-omit — always return BOTH `content` + `structuredContent`; roll out tool-by-tool.
+- (Optional) tool-count hygiene — 73 tools is past the ~30-50 "selection accuracy" zone; consider multiplexing the rarely-used `api_map_*`/`*_routes`/`*_workflows` planners. Not urgent (Claude Code's tool-search defers defs).
+
+TIER 2 — modernization (after Tier 1), with honest client-support reality:
+- Resources (expose `ball-knowledge.md`/`trading-log.md`/`hotlist.md`/api-map as read-only context) — worth it, modest; KEEP the existing knowledge/hotlist tools as fallback for clients that ignore resources. (Subsumes the older "MCP resources for the knowledge library" idea above.)
+- Elicitation — SKIP for now: Claude Code closed it "not planned" (#7108); the env-gated dry-run switch already covers confirm-before-write better, and the 2026-07-28 revision restructures it anyway.
+- Prompts + completion — low payoff for a single-user tool (the SKILL already encodes the workflows). Defer.
+- Cursor-based pagination on the big list tools (history/review/routes) — borderline Tier-1.5; add an opaque `cursor` instead of only slicing server-side.
+
+Sources — official: modelcontextprotocol.io 2025-11-25 changelog · TS SDK `docs/server.md` · TS SDK releases (2.0-alpha + 1.x-stable policy) · Claude Code elicitation issue #7108 ("not planned"). Community (recent): The New Stack "15 best practices for MCP servers in production"; digitalapplied 2026 MCP security guide; Scott Spence on Claude Code MCP context usage. Builds on `docs/mcp-best-practices-audit-2026-06-18.md` (do not duplicate). Tier-1 actionables tracked in `tasks.md`.

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -13,6 +13,7 @@ import {
   computeCalendar,
   computeExposure,
   computeIncome,
+  computePerformance,
   computeRisk,
   computeWhatIf,
   computeNews,
@@ -1628,6 +1629,26 @@ server.registerTool(
   },
   async ({ account_number, year }) => {
     try { return jsonResponse(await computeIncome({ accountNumber: account_number, year })); }
+    catch (e: any) { return jsonResponse({ error: e.message }); }
+  }
+);
+
+// ── robinhood_performance: portfolio equity curve over time ──
+server.registerTool(
+  "robinhood_performance",
+  {
+    title: "Robinhood Portfolio Performance",
+    description:
+      "Portfolio historical performance — the equity curve over time: account value + return across day/week/month/3month/ytd/year/all spans, from the desktop app's own chart route. Per-account (RH exposes no all-accounts performance route — sum client-side for a portfolio-wide curve); each point carries timestamp, dollar value, and return %. Same shared engine as the CLI `performance` command. Live read; no gate.",
+    inputSchema: z.object({
+      account_number: z.string().optional(),
+      span: z.enum(["day", "week", "month", "3month", "ytd", "year", "all"]).optional(),
+      include_all_hours: z.boolean().optional()
+    }),
+    annotations: toolAnnotations(true, "sensitive-read")
+  },
+  async ({ account_number, span, include_all_hours }) => {
+    try { return jsonResponse(await computePerformance({ accountNumber: account_number, span, includeAllHours: include_all_hours })); }
     catch (e: any) { return jsonResponse({ error: e.message }); }
   }
 );

--- a/tasks.md
+++ b/tasks.md
@@ -89,5 +89,9 @@ Scoped from the 2026-06-13 ideas.md expansion. Unchecked, additive; existing tas
 ### Platform / reach
 - [ ] Multi-account roll-ups — `--all-accounts` variants of risk/exposure/income/brief with per-account dollar breakdown. Generalizes existing cross-account positions/wheel.
 - [ ] Export/reporting expansion (`export` command) — CSV/JSON for positions, fills, income, realized P&L (tax-ready) + printable monthly statement. Builds on documents engine. (Overlaps carried T9 export task — fold.)
-- [ ] MCP resources for knowledge library (mcp/src/server.ts) — expose knowledge/*.md (+ glossary) as MCP resources alongside the existing robinhood_knowledge tool.
+- [ ] MCP hardening (Tier 1 — see ideas.md 2026-06-19) — brand the ~26 bare `z.string()` inputs (account/symbol/uuid) with regex/`.uuid()` schemas; return input-validation failures as `isError` (SEP-1303); uniform error shape across the ~29 throw sites.
+- [ ] MCP docs — generate `mcp/README.md` from `tools/list` (currently a 17-line stub) + a CI drift check.
+- [ ] MCP package tests — in-memory boot asserting `tools/list` count + every write tool carries `destructiveHint:true`/`readOnlyHint:false` + a dry-run write returns `executed:false`.
+- [ ] `structuredContent` + `outputSchema` on the top read tools (portfolio/positions/buying_power/quote/accounts) — return BOTH `content` + `structuredContent` (Cursor rejects declare-but-omit); roll out tool-by-tool.
+- [ ] MCP resources for knowledge library (mcp/src/server.ts) — expose knowledge/*.md (+ glossary) as MCP resources alongside the existing robinhood_knowledge tool. (Tier 2 — after the hardening items above.)
 - [ ] Trade-card / success-graphic generator — evidence-backed HTML render of a completed round-trip (entry/exit, $ P&L, payoff diagram, thread). Driven off `review` round-trip join.


### PR DESCRIPTION
## performance command — the deferred feature, un-deferred
Adds the first-class **`performance`** command (alias `perf`) + **`robinhood_performance`** MCP tool over `computePerformance`: the portfolio **equity curve over time** — account value + return across day/week/month/3month/ytd/year/all, per account.

**Reverses the prior "deferred — phoenix is TLS-walled" call.** That was one dead path (`portfolios/historicals/` 404s; `phoenix` refuses the TLS handshake). The modern web app reads the curve from `bonfire.robinhood.com/portfolio/performance/{account}/?display_span=…` — reachable on the regular host, **live-verified across every span** (242 pts day · 252 year · 382 all, back to account inception).

**Two gotchas found + handled (documented in `docs/undocumented-surface.md`):**
- **Trailing slash required** — `…/performance/{id}` (no slash) returns 200 with an EMPTY body; `…/performance/{id}/` returns the curve. Route-map entry fixed to carry the slash.
- **Span param is `display_span`, not `span`** (passing `span=` is silently ignored).
- Engine reads `cursor_data.primary_value.value` + `y` (populated on 100% of points), NOT the inconsistent `price_chart_data` block. Per-account only (no all-accounts route — sum client-side).

**Parity + tests:** CLI + MCP + engine + docs (SKILL nav/MCP table, AGENTS, undocumented-surface). `cli/test/performance.test.ts` covers parse / summary / span-aliases / negative-money / per-account-degrade / single-account-scope. **355 tests pass; typecheck + lint + build clean; tool count 72→73.**

## docs(mcp): MCP-modernization research note
Per the ask: researched the official MCP spec/SDK + last-30-days community pulse, recorded a **prioritized** note in `ideas.md` (actionables in `tasks.md`), sequenced **hardening + docs + small wins first → modernization after**. Key calls: stay on **SDK 1.x / 2025-11-25** (2026-07-28 rides 2.0-alpha); **elicitation = skip** (Claude Code closed it "not planned"); `structuredContent` has a Cursor declare-but-omit footgun. Builds on the existing `docs/mcp-best-practices-audit-2026-06-18.md` — no new audit file.

Done in an isolated worktree; shared tree untouched.