### PR TITLE
docs(readme): trim Robinhood-tracker note to a one-line jab (income hardening already landed via #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ this is so much much better. this makes their "agentic" control release whatever
 
 robinhood please hire me this is what love for the game produces. 
 
+> Robinhood shipped an in-app "Dividend tracker" on 2026-06-16 — four days after this repo's `dividends` engine (2026-06-12, commit `08bb870`). Building in the open means the commit history is the receipt.
+
 ---
 
 ## ⚠️ DISCLAIMER
@@ -26,22 +28,6 @@ robinhood please hire me this is what love for the game produces.
 - **No warranty.** This software is provided "as is" without warranty of any kind, express or implied. See the [LICENSE](LICENSE) file.
 - **Unofficial API access.** This tool accesses Robinhood's private web API using your browser session token. Robinhood's Terms of Service may prohibit automated or non-browser access. Use at your own risk.
 - **Use your own account, at your own risk.**
-
----
-
-(and it's going *so* well that robinhood's already stealing my features — they shipped a **Dividend tracker** (that's [our `dividends` engine](#-bro-robinhood-ripped-our-feature-lmao)) four days after it landed in this repo. lol. receipts below 👇)
-
----
-
-## 🏆 Bro, Robinhood ripped our feature (lmao)
-
-Our **`dividends`** engine — monthly totals, projected payouts (`$/day → $/yr`), per-symbol cadence detection, and ticker-level detail — landed **June 12, 2026** (commit [`08bb870`](https://github.com/zaydiscold/robinhood-cli/commit/08bb870)). When you ship in the open, the commit history *is* the receipt.
-
-Robinhood announced their own in-app **"Dividend tracker"** — *"monthly totals, projected payouts, early dividends, and ticker-level detail, all in one place"* — on **June 16, 2026.** Four days later. Either great minds, or somebody's reading my commits. 👀
-
-And theirs is dividends-only. This repo has been tracking **income = dividends + options/wheel premium** the whole time — the `dividends` engine covers dividend income, the `wheel` engine covers the CSP→covered-call premium side — so you get your *full* income picture, not half of it.
-
-One indie CLI, four days ahead of the $30B brokerage's product team. We're not catching up to Robinhood — we're trailblazing, and they're a few days back running the playbook. 🚀
 
 ---
 


### PR DESCRIPTION
## What this PR does

Trims the README's reaction to Robinhood shipping an in-app Dividend tracker down to **exactly two mentions**, per request — no emoji slop, no standalone celebration section.

- **Removed** the `🏆 Bro, Robinhood ripped our feature (lmao)` section and its parenthetical lead-in (16 lines).
- **Added** a single dry one-liner near the top (the "jab"):
  > Robinhood shipped an in-app "Dividend tracker" on 2026-06-16 — four days after this repo's `dividends` engine (2026-06-12, commit `08bb870`). Building in the open means the commit history is the receipt.
- **Kept** the combined-income feature bullet (mention #2) that already landed with the income-hardening salvage — it carries the superiority point: `income` = dividends **+** net options/wheel premium, *"their tracker is dividends-only; this counts both halves."*

Net: `1 file changed, 2 insertions(+), 16 deletions(-)`.

## The income-engine hardening (already on main via #20)

The substantive engineering this note refers to already merged via the salvage PR #20 (commit `999b0c3`), recovered from the stranded `admiring` worktree. Documenting it here so the notes are complete:

- **`optionOrderNetPremiumUsd()`** — classifies each filled options order as premium-*selling* income and **nets the long wings**, so a credit spread reports its **net** credit, not the gross short leg (the old code overstated). Directional long-option buys/sells and debit spreads are excluded.
- **Canonical 12-calendar-month window** shared by the dividend + premium halves, so the monthly table sums **exactly** to the TTM headline (no calendar-vs-365-day drift).
- **`monthsCovered`** — monthly average divides by months actually active, not a blind `/12`.
- **Real forward run-rate** (dividend forward projection from current holdings + trailing-12-mo net premium), distinct from the realized TTM — replacing the old `projectedAnnual == ttmTotal` tautology. Granularity `$/day → $/yr`.
- **`--year` honesty** — warns when requested-year months fall outside the dividend feed's trailing-12 window.
- **Tests:** +16 cases (classifier: CSP/CC/credit-spread/debit-spread/long/roll/condor/guards; `computeIncome`: net-credit, table↔TTM reconciliation, window bounds, run-rate granularity, `monthsCovered`, `--year`).

## Verification
- `pnpm build` clean (CLI + MCP).
- Full suite green on main: **382 tests pass**.
- Live read-only validation of `income` on the real account: monthly rows reconcile to the dividends/premium/total headlines to the penny; run-rate distinct from TTM; `$/day` = annual/365.