### PR TITLE
Rebrand to Robinhood CLI (MCP + API) — rename to robinhood-cli-mcp-api (2026-06-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Robinhood API + MCP + CLI
+# Robinhood CLI (MCP + API)
 
 > Trading at the speed of inference.
 
@@ -35,7 +35,7 @@ robinhood please hire me this is what love for the game produces.
 It drives the account you already have, across the browser-backed brokerage API surface, with reads live by default and every write behind a dry-run/live-write gate.
 
 ```bash
-git clone https://github.com/zaydiscold/robinhood-cli.git
+git clone https://github.com/zaydiscold/robinhood-cli-mcp-api.git
 cd robinhood-cli
 pnpm install && pnpm build
 node cli/dist/index.js --help
@@ -165,7 +165,7 @@ This CLI selects routes **by URL *and* HTTP method**, so a single endpoint can c
 ### 1. Install & build
 
 ```bash
-git clone https://github.com/zaydiscold/robinhood-cli.git
+git clone https://github.com/zaydiscold/robinhood-cli-mcp-api.git
 cd robinhood-cli
 pnpm install
 pnpm build        # builds the CLI and copies the API map into dist (see "rebuild" note below)
@@ -609,9 +609,9 @@ Pattern: CLI + skill + MCP. Capture the surface once, expose it cleanly everywhe
 ## Star History
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zaydiscold/robinhood-cli&type=Date&theme=dark" />
-  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zaydiscold/robinhood-cli&type=Date" />
-  <img alt="Star history chart for zaydiscold/robinhood-cli" src="https://api.star-history.com/svg?repos=zaydiscold/robinhood-cli&type=Date" />
+  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zaydiscold/robinhood-cli-mcp-api&type=Date&theme=dark" />
+  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zaydiscold/robinhood-cli-mcp-api&type=Date" />
+  <img alt="Star history chart for zaydiscold/robinhood-cli-mcp-api" src="https://api.star-history.com/svg?repos=zaydiscold/robinhood-cli-mcp-api&type=Date" />
 </picture>
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -136,7 +136,7 @@ then this file. When the answer isn't obvious, the docs already have it — read
 
 Operate real Robinhood brokerage accounts from the terminal or via MCP tools.
 
-**Repo:** `github.com/zaydiscold/robinhood-cli`
+**Repo:** `github.com/zaydiscold/robinhood-cli-mcp-api`
 **Deep reference:** `AGENTS.md` in repo root — the complete API surface, worked examples, and every command. Hand that file to any agent and it's self-contained. This SKILL.md is the Hermes trigger + boot doc: quick-start, the 80/20 commands, and all the operational pitfalls learned across sessions.
 
 > This is exactly the security-research mindset — a breakthrough is a waypoint, not a finish line.

--- a/docs/release-notes-2026-06-22.md
+++ b/docs/release-notes-2026-06-22.md
@@ -1,0 +1,23 @@
+# Release notes — 2026-06-22
+
+## Rebrand: repo renamed to `robinhood-cli-mcp-api`
+
+On **2026-06-22 (13:40 PDT)** the GitHub repository `zaydiscold/robinhood-cli` was renamed to
+**`zaydiscold/robinhood-cli-mcp-api`**, and the README title changed from "Robinhood API + MCP + CLI"
+to **"Robinhood CLI (MCP + API)"**.
+
+This adopts the `<venue>-cli-mcp-api` naming convention now shared across the personal CLI repos
+(matching `goodreads-cli-mcp-api`).
+
+### What changed
+
+- GitHub repository slug: `robinhood-cli` → `robinhood-cli-mcp-api` (GitHub auto-redirects the old URL).
+- README H1 title and the GitHub description.
+- In-repo references to the repo URL (clone command, star-history chart, `SKILL.md` repo line).
+
+### What did NOT change
+
+- The npm package and bin names (`@zaydiscold/robinhood-cli`, `@zaydiscold/robinhood-cli-mcp`,
+  `robinhood-cli`) are unchanged, so installs, imports, MCP registration, and any local scripts are
+  unaffected.
+- No code, route-map, or behavior changes — this is branding and references only.


### PR DESCRIPTION
## Rebrand to Robinhood CLI (MCP + API)

On **2026-06-22 (13:40 PDT)** the repository `zaydiscold/robinhood-cli` was renamed to
**`zaydiscold/robinhood-cli-mcp-api`**, adopting the `<venue>-cli-mcp-api` naming convention now
shared across the personal CLI repos (matching `goodreads-cli-mcp-api`).

### Changes — branding + references only (no code)
- README H1: "Robinhood API + MCP + CLI" → **"Robinhood CLI (MCP + API)"**.
- In-repo repo-URL references updated: clone command, star-history chart, `SKILL.md` repo line.
- GitHub repository description updated.
- New `docs/release-notes-2026-06-22.md` recording the rename + exact date/time.

### Unchanged
- npm package and bin names (`@zaydiscold/robinhood-cli`, `@zaydiscold/robinhood-cli-mcp`, `robinhood-cli`) — installs, imports, and MCP registration are unaffected.
- No code, route-map, or behavior changes.

This PR is merged to cement the rename in the repository history.
