### PR TITLE
Keep private runtime reports out of Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ git-crypt-key
 # local safety backups (never commit)
 _local-backups-*/
 
+# private runtime output (the rest of local/ is intentionally git-crypt tracked)
+local/portfolio-snapshots.jsonl
+local/legacy-reports/
+
 # private/working notes — never publish (research sweeps, proofs, machine-setup notes)
 research/
 proofs/

--- a/cli/test/feature-modules.test.ts
+++ b/cli/test/feature-modules.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -45,6 +45,11 @@ describe("durable order lifecycle", () => {
 });
 
 describe("portfolio time machine", () => {
+  it("keeps the default private runtime snapshot out of git", () => {
+    const ignore = readFileSync(new URL("../../.gitignore", import.meta.url), "utf8");
+    expect(ignore).toMatch(/^local\/portfolio-snapshots\.jsonl$/m);
+  });
+
   it("persists private JSONL snapshots and reports position drift", () => {
     const path = join(mkdtempSync(join(tmpdir(), "rh-snap-")), "snapshots.jsonl");
     const before: any = { version: 1, id: "a", capturedAt: "2026-01-01T00:00:00Z", source: "portfolio", data: { totals: { equity: 100, day: 1, afterHours: 0 }, drivers: [{ kind: "equity", symbol: "AAPL", value: 50, dayUsd: 1, qty: 1 }] } };

--- a/docs/safety-and-workflow-features-2026-07-10.md
+++ b/docs/safety-and-workflow-features-2026-07-10.md
@@ -24,7 +24,8 @@ bound to the supplied order body. This is pure analysis.
 
 `portfolio-snapshot capture|list|diff` and `robinhood_portfolio_snapshot` persist JSONL snapshots
 under `local/portfolio-snapshots.jsonl` by default with mode 600. Capture uses the shared portfolio
-engine; list/diff are local-only. Diffs include total and per-position drift.
+engine; list/diff are local-only. Diffs include total and per-position drift. The runtime JSONL path
+is explicitly gitignored even though other curated `local/` content is git-crypt tracked.
 
 ## Share-safe output
 


### PR DESCRIPTION
## Summary
- ignore the portfolio time-machine JSONL and migrated legacy reports under the otherwise git-crypt-tracked local directory
- add a regression test for the default snapshot path

## Verification
- CLI: 25 files, 421 tests passed
- git diff check passed