### PR TITLE
Fix installed CLI and MCP runtime paths

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -112,6 +112,7 @@ import {
   setRecurringState,
   finiteNumber,
   optionMoney,
+  repositoryRoot,
   appendPortfolioSnapshot,
   buildOptionsWorkbench,
   diffPortfolioSnapshots,
@@ -4177,7 +4178,7 @@ program
   .description("Offline health check: auth-file hygiene, source/dist parity, route verification, write-gate state, knowledge files, share-safe state, and MCP profile. Never calls Robinhood.")
   .option("--json", "emit JSON")
   .action((opts: any) => {
-    const result = runDoctor(process.cwd());
+    const result = runDoctor(repositoryRoot());
     if (opts.json) return printJson(result);
     printTable(result.checks.map((check) => ({ ...check })), ["id", "status", "message"]);
     process.stdout.write(`\n${result.ok ? "PASS" : "FAIL"}: ${result.summary.pass} pass, ${result.summary.warn} warn, ${result.summary.fail} fail\n`);
@@ -4196,7 +4197,7 @@ program
   .description("Capture/list/diff timestamped local portfolio snapshots. Capture performs normal portfolio reads; data is stored mode 600 under local/.")
   .argument("[action]", "capture|list|diff", "capture")
   .option("--account <number>")
-  .option("--path <path>", "snapshot JSONL path", resolvePath("local/portfolio-snapshots.jsonl"))
+  .option("--path <path>", "snapshot JSONL path", resolvePath(repositoryRoot(), "local/portfolio-snapshots.jsonl"))
   .action(async (action: string, opts: any) => {
     const snapshots = readPortfolioSnapshots(opts.path);
     if (action === "list") return printJson({ path: opts.path, count: snapshots.length, snapshots: snapshots.map(({ id, capturedAt }) => ({ id, capturedAt })) });

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -45,6 +45,14 @@ function repoRoot(): string {
   return ascendToRepoRoot() ?? join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 }
 
+/**
+ * Absolute repository root resolved from the installed module location, never the caller's cwd.
+ * CLI commands and MCP clients are commonly launched from $HOME or an application directory.
+ */
+export function repositoryRoot(): string {
+  return repoRoot();
+}
+
 // Auto-load the repo .env so every consumer (CLI, MCP server, scripts) gets auth
 // with no shell sourcing. Explicit env vars always win — only unset keys are filled.
 // Runs once at module load; a missing/garbled file is non-fatal.

--- a/cli/test/feature-modules.test.ts
+++ b/cli/test/feature-modules.test.ts
@@ -8,6 +8,7 @@ import {
   diffPortfolioSnapshots,
   redactShareSafe,
   readPortfolioSnapshots,
+  repositoryRoot,
   runDoctor,
   watchOrderLifecycle
 } from "../src/lib.js";
@@ -86,6 +87,22 @@ describe("options workbench", () => {
 });
 
 describe("doctor", () => {
+  it("resolves the repository from the module location instead of the caller cwd", () => {
+    const originalCwd = process.cwd();
+    const unrelatedCwd = mkdtempSync(join(tmpdir(), "rh-cwd-"));
+    try {
+      process.chdir(unrelatedCwd);
+      const root = repositoryRoot();
+      expect(root).not.toBe(unrelatedCwd);
+      expect(readFileSync(join(root, "pnpm-workspace.yaml"), "utf8")).toContain("packages:");
+      const doctor = runDoctor(root);
+      expect(doctor.checks.find((check) => check.id === "source-dist-parity")?.status).not.toBe("fail");
+      expect(doctor.checks.find((check) => check.id === "knowledge")?.status).toBe("pass");
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it("is offline, detects source/dist drift, and never emits credential values", () => {
     const root = mkdtempSync(join(tmpdir(), "rh-doctor-"));
     for (const path of ["api-map", "cli/dist/api-map", "docs"]) mkdirSync(join(root, path), { recursive: true });

--- a/cli/test/workspace-scripts.test.ts
+++ b/cli/test/workspace-scripts.test.ts
@@ -10,4 +10,10 @@ describe("workspace package scripts", () => {
       }
     }
   });
+
+  it("repairs the Unix executable mode for the declared MCP package binary", () => {
+    const manifest = JSON.parse(readFileSync(new URL("../../mcp/package.json", import.meta.url), "utf8"));
+    expect(manifest.bin?.["robinhood-cli-mcp"]).toBe("dist/server.js");
+    expect(manifest.scripts?.build).toContain("ensure-bin-mode.mjs");
+  });
 });

--- a/docs/safety-and-workflow-features-2026-07-10.md
+++ b/docs/safety-and-workflow-features-2026-07-10.md
@@ -6,7 +6,8 @@ These features are offline or read-only unless explicitly noted. None sends an o
 
 `robinhood-cli doctor --json` checks Node compatibility, credential-file permissions without
 printing values, source/dist route-map parity, inferred mutation counts, required knowledge files,
-the live-write gate, share-safe state, and the active MCP profile. MCP: `robinhood_doctor`.
+the live-write gate, share-safe state, and the active MCP profile. MCP: `robinhood_doctor`. Both
+resolve the repository from the installed module path, so they work from any current directory.
 
 ## Durable order lifecycle
 
@@ -25,7 +26,8 @@ bound to the supplied order body. This is pure analysis.
 `portfolio-snapshot capture|list|diff` and `robinhood_portfolio_snapshot` persist JSONL snapshots
 under `local/portfolio-snapshots.jsonl` by default with mode 600. Capture uses the shared portfolio
 engine; list/diff are local-only. Diffs include total and per-position drift. The runtime JSONL path
-is explicitly gitignored even though other curated `local/` content is git-crypt tracked.
+is explicitly gitignored even though other curated `local/` content is git-crypt tracked, and its
+default remains anchored to the repository when CLI/MCP callers launch from another directory.
 
 ## Share-safe output
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -9,8 +9,8 @@
     "robinhood-cli-mcp": "dist/server.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "pretest": "corepack pnpm --filter @zaydiscold/robinhood-cli build",
+    "build": "tsc -p tsconfig.json && node scripts/ensure-bin-mode.mjs",
+    "pretest": "corepack pnpm --filter @zaydiscold/robinhood-cli build && corepack pnpm --filter @zaydiscold/robinhood-cli-mcp build",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/mcp/scripts/ensure-bin-mode.mjs
+++ b/mcp/scripts/ensure-bin-mode.mjs
@@ -1,0 +1,9 @@
+import { chmodSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// npm/pnpm generate command shims, but this repo also exposes dist/server.js directly via a
+// stable ~/.local/bin symlink. TypeScript can preserve a restrictive pre-existing mode, so make
+// the shebang-bearing executable deterministic after every Unix build. Windows uses .cmd shims.
+if (process.platform !== "win32") {
+  chmodSync(fileURLToPath(new URL("../dist/server.js", import.meta.url)), 0o755);
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -98,6 +98,7 @@ import {
   detectAccountClass,
   buildAtomicRollOrderBody,
   resolveRollModel,
+  repositoryRoot,
   appendPortfolioSnapshot,
   buildOptionsWorkbench,
   CAPABILITIES,
@@ -2451,7 +2452,7 @@ registerCapabilityTool("doctor", {
   title: "Robinhood Doctor",
   description: "Offline health check for source/dist parity, credential-file hygiene, route provenance, write-gate state, knowledge files, share-safe state, and MCP profile. Never calls Robinhood.",
   inputSchema: z.object({}), outputSchema: doctorOutputSchema, annotations: toolAnnotations(true, "read")
-}, async () => jsonResponse(runDoctor(process.cwd())));
+}, async () => jsonResponse(runDoctor(repositoryRoot())));
 
 registerCapabilityTool("order-lifecycle", {
   title: "Robinhood Durable Order Watch",
@@ -2475,7 +2476,7 @@ registerCapabilityTool("options-workbench", {
 registerCapabilityTool("portfolio-snapshot", {
   title: "Robinhood Portfolio Time Machine",
   description: "Capture, list, or diff private timestamped portfolio snapshots. Capture performs live reads; list/diff are local-only.",
-  inputSchema: z.object({ action: z.enum(["capture", "list", "diff"]).default("capture"), account_number: z.string().optional(), path: z.string().default(resolve(process.cwd(), "local/portfolio-snapshots.jsonl")) }),
+  inputSchema: z.object({ action: z.enum(["capture", "list", "diff"]).default("capture"), account_number: z.string().optional(), path: z.string().default(resolve(repositoryRoot(), "local/portfolio-snapshots.jsonl")) }),
   outputSchema: z.object({}).catchall(z.unknown()), annotations: toolAnnotations(true, "read")
 }, async ({ action, account_number, path }: any) => {
   const snapshots = readPortfolioSnapshots(path);

--- a/mcp/test/protocol.test.ts
+++ b/mcp/test/protocol.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { server } from "../src/server.js";
@@ -20,6 +22,11 @@ afterAll(async () => {
 });
 
 describe("MCP protocol conformance", () => {
+  it.skipIf(process.platform === "win32")("builds the declared package binary as executable", () => {
+    const serverBin = fileURLToPath(new URL("../dist/server.js", import.meta.url));
+    expect(statSync(serverBin).mode & 0o111).not.toBe(0);
+  });
+
   it("advertises the complete tool/resource/prompt surface with valid schemas and annotations", async () => {
     const [tools, resources, templates, prompts] = await Promise.all([
       client.listTools(),


### PR DESCRIPTION
## Summary
- resolve Doctor and portfolio snapshot paths from the installed module instead of caller cwd
- rebuild MCP before protocol tests and repair its Unix package-binary mode
- verify Doctor from an unrelated working directory and the executable MCP artifact

## Verification
- CLI: 26 files, 425 tests passed
- MCP: 5 protocol tests passed
- workspace typecheck and build passed
- installed robinhood-cli Doctor succeeds from /private/tmp
- robinhood-cli-mcp is discoverable on PATH after build