### PR TITLE
Fix MCP launch through PATH symlinks

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -2,6 +2,7 @@
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { randomUUID } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import { z } from "zod";
@@ -2580,7 +2581,16 @@ export async function startStdioServer(): Promise<void> {
   await server.connect(transport);
 }
 
-const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+export function isMainModule(moduleUrl: string, argvPath: string | undefined): boolean {
+  if (!argvPath) return false;
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(resolve(argvPath));
+  } catch {
+    return false;
+  }
+}
+
+const isMain = isMainModule(import.meta.url, process.argv[1]);
 if (isMain) await startStdioServer();
 
 // Zayd Khan // cold // www.zayd.wtf

--- a/mcp/test/protocol.test.ts
+++ b/mcp/test/protocol.test.ts
@@ -1,9 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { statSync } from "node:fs";
+import { mkdtempSync, statSync, symlinkSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { server } from "../src/server.js";
+import { isMainModule, server } from "../src/server.js";
 import { CAPABILITIES, listKnowledge } from "@zaydiscold/robinhood-cli/lib";
 
 const client = new Client({ name: "robinhood-cli-protocol-test", version: "1.0.0" });
@@ -25,6 +27,13 @@ describe("MCP protocol conformance", () => {
   it.skipIf(process.platform === "win32")("builds the declared package binary as executable", () => {
     const serverBin = fileURLToPath(new URL("../dist/server.js", import.meta.url));
     expect(statSync(serverBin).mode & 0o111).not.toBe(0);
+  });
+
+  it.skipIf(process.platform === "win32")("recognizes the package binary when launched through a PATH symlink", () => {
+    const serverBin = fileURLToPath(new URL("../dist/server.js", import.meta.url));
+    const link = join(mkdtempSync(join(tmpdir(), "rh-mcp-bin-")), "robinhood-cli-mcp");
+    symlinkSync(serverBin, link);
+    expect(isMainModule(new URL("../dist/server.js", import.meta.url).href, link)).toBe(true);
   });
 
   it("advertises the complete tool/resource/prompt surface with valid schemas and annotations", async () => {


### PR DESCRIPTION
## Summary
- compare entrypoint filesystem identities instead of unresolved path strings
- keep direct node launches and make PATH/package symlink launches start the stdio server
- add a real symlink regression test

## Verification
- MCP: 6 protocol tests passed
- MCP typecheck and build passed
- installed robinhood-cli-mcp remained running until terminated and emitted its startup gate status