### PR TITLE
Fix portfolio P&L and route-template regression

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -989,11 +989,14 @@ also the MCP tool `robinhood_portfolio`:
 - `portfolio --day` · `--by position|account|underlying` · `--account <n>` · `--json`.
 One call returns the per-account top-line, the by-underlying dollar drivers, and a reconciliation line.
 The manual composition below is only a FALLBACK if the command is unavailable: `portfolios/{account_number}/`
-(equity / extended_hours_equity / **adjusted_equity_previous_close** — note: per-account
-`equity_previous_close` is "0", use the adjusted field) + `positions/?account_number={account_number}` +
-`options aggregate_positions/` + `marketdata/{quotes,options}/`. The deliverable is one ranked,
-dollar-weighted, by-underlying answer across accounts, with the **after-hours number kept separate from
-the full-day number** — not a per-account percent dump.
+(current/extended equity and the broker-adjusted account delta) +
+`positions/?account_number={account_number}&nonzero=true` + `options aggregate_positions/` +
+`marketdata/{quotes,options}/`. Regular-session market P&L comes from the fully priced position set;
+`equity − adjusted_equity_previous_close` is retained only as a diagnostic because deposits, transfers,
+cash, dividends, and broker baseline adjustments can make it disagree with market P&L. After-hours remains
+the account-level `extended_hours_equity − equity` delta so extended index-option value is not lost. The
+deliverable is one ranked, dollar-weighted, by-underlying answer across accounts, with the **after-hours
+number kept separate from the regular-session number** — not a per-account percent dump.
 
 ## Worked Build — Iron Condor, End to End
 
@@ -1576,6 +1579,14 @@ Full details: `AGENTS.md` §9.
 4. Verify: `node cli/dist/index.js brokerage execute "<new-route>" --json --full`.
 5. Document the discovery method in `docs/undocumented-surface.md`.
 
+**Query-template invariant:** route-map merge and dedup keys must preserve the query shape, not just
+HTTP method + origin + pathname. `instruments/?symbol={symbol}`, `instruments/?ids={ids}`,
+`marketdata/quotes/?ids={ids}`, `marketdata/options/?ids={ids}`, and
+`positions/?account_number={account_number}&nonzero=true` are distinct executable operations. A
+pathname-only merge silently deletes the first-class quote/option/portfolio routes. After changing capture
+or merge code, run `node scripts/test-cdp-capture.mjs`, rebuild both packages, and live-verify one quote plus
+`portfolio --top 0 --json` with `reconciliation.mispricedPositions === 0`.
+
 ### 📊 Day / After-Hours P&L — use the `portfolio` command (don't hand-compute)
 
 "What am I down today / after hours / which names?" is **one command** — no manual quote math:
@@ -1586,13 +1597,16 @@ node cli/dist/index.js portfolio --after-hours  # rank by the after-hours move
 node cli/dist/index.js portfolio --day          # rank by the full-day move
 node cli/dist/index.js portfolio --by position --top 10 --json
 ```
-It composes accounts → `portfolios/{account_number}/` (day Δ = `equity − adjusted_equity_previous_close`;
-after-hours Δ = `extended_hours_equity − equity`) → positions + quotes + option marks, attributes in
-DOLLARS, rolls up by underlying across accounts, and prints a reconciliation line (drivers vs top-line).
+It composes accounts → `portfolios/{account_number}/` (current equity and after-hours Δ =
+`extended_hours_equity − equity`) → positions + quotes + option marks. Regular-session P&L is the fully
+priced position sum; the broker's `equity − adjusted_equity_previous_close` value is reported separately as
+`reportedAccountEquityDeltaUsd` for reconciliation and must not override the market-P&L headline. The result
+is attributed in DOLLARS, rolled up by underlying across accounts, and accompanied by day and after-hours
+residuals plus separate missing-price counts.
 After-hours is PRIMARILY equity-driven, but index/ETF options (SPX, SPXW, SPY, NDX, …) trade ~15 min past the bell and can move after-hours — always check extended marks for those underlyings. Same engine as the MCP tool
 `robinhood_portfolio`. **Don't** rebuild this by hand from `positions`+`quote` (percent math is size-blind
-and gets the metric wrong), and **don't** use `equity_previous_close` (it's "0" per-account — the command
-uses `adjusted_equity_previous_close`).
+and gets the metric wrong), and **don't** present either raw `equity_previous_close` (often `"0"`) or the
+adjusted account-equity delta as market P&L when the priced holdings disagree.
 
 **Common mistake:** `brokerage execute "positions/?nonzero=true"` FAILS (`brokerage execute` doesn't take
 query params) — use the `positions` command, or just `portfolio`.

--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -9263,6 +9263,156 @@
     ]
   },
   {
+    "url": "https://api.robinhood.com/instruments/?ids={ids}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "instruments",
+      "reference"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes",
+    "queryKeys": [
+      "ids"
+    ],
+    "fields": [
+      "account_type_tradabilities",
+      "affiliate",
+      "affiliate_tradability",
+      "all_day_tradability",
+      "bloomberg_unique",
+      "car_required",
+      "country",
+      "day_trade_ratio",
+      "default_collar_fraction",
+      "default_preset_percent_limit",
+      "extended_hours_fractional_tradability",
+      "fractional_tradability",
+      "fundamentals",
+      "high_risk_maintenance_ratio",
+      "id",
+      "internal_halt_details",
+      "internal_halt_end_time",
+      "internal_halt_reason",
+      "internal_halt_sessions",
+      "internal_halt_source",
+      "internal_halt_start_time",
+      "ipo_access_cob_deadline",
+      "ipo_access_status",
+      "ipo_access_supports_dsp",
+      "ipo_roadshow_url",
+      "ipo_s1_url",
+      "ipoa_start_date",
+      "is_high_investment_risk",
+      "is_spac",
+      "is_test",
+      "issuer_type",
+      "list_date",
+      "low_risk_maintenance_ratio",
+      "maintenance_ratio",
+      "margin_initial_ratio",
+      "market",
+      "min_tick_size",
+      "name",
+      "notional_estimated_quantity_decimals",
+      "otc_market_tier",
+      "quote",
+      "reserved_buying_power_percent_immediate",
+      "reserved_buying_power_percent_queued",
+      "rhs_tradability",
+      "short_selling_tradability",
+      "simple_name",
+      "splits",
+      "state",
+      "symbol",
+      "tax_security_type",
+      "tradability",
+      "tradable_chain_id",
+      "tradeable",
+      "type",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
+  },
+  {
+    "url": "https://api.robinhood.com/instruments/?symbol={symbol}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "instruments",
+      "reference"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution",
+    "queryKeys": [
+      "symbol"
+    ],
+    "fields": [
+      "account_type_tradabilities",
+      "affiliate",
+      "affiliate_tradability",
+      "all_day_tradability",
+      "bloomberg_unique",
+      "car_required",
+      "country",
+      "day_trade_ratio",
+      "default_collar_fraction",
+      "default_preset_percent_limit",
+      "extended_hours_fractional_tradability",
+      "fractional_tradability",
+      "fundamentals",
+      "high_risk_maintenance_ratio",
+      "id",
+      "internal_halt_details",
+      "internal_halt_end_time",
+      "internal_halt_reason",
+      "internal_halt_sessions",
+      "internal_halt_source",
+      "internal_halt_start_time",
+      "ipo_access_cob_deadline",
+      "ipo_access_status",
+      "ipo_access_supports_dsp",
+      "ipo_roadshow_url",
+      "ipo_s1_url",
+      "ipoa_start_date",
+      "is_high_investment_risk",
+      "is_spac",
+      "is_test",
+      "issuer_type",
+      "list_date",
+      "low_risk_maintenance_ratio",
+      "maintenance_ratio",
+      "margin_initial_ratio",
+      "market",
+      "min_tick_size",
+      "name",
+      "notional_estimated_quantity_decimals",
+      "otc_market_tier",
+      "quote",
+      "reserved_buying_power_percent_immediate",
+      "reserved_buying_power_percent_queued",
+      "rhs_tradability",
+      "short_selling_tradability",
+      "simple_name",
+      "splits",
+      "state",
+      "symbol",
+      "tax_security_type",
+      "tradability",
+      "tradable_chain_id",
+      "tradeable",
+      "type",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
+  },
+  {
     "url": "https://api.robinhood.com/instruments/{0}/popularity/",
     "host": "api.robinhood.com",
     "categories": [
@@ -11138,6 +11288,31 @@
     "fieldsShape": "object"
   },
   {
+    "url": "https://api.robinhood.com/marketdata/historicals/{symbol}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "marketdata"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "cdp-2026-06-04-injected-capture (observed; price historicals per symbol)",
+    "seenOn": [
+      "option-ticket"
+    ],
+    "queryKeys": [
+      "bounds",
+      "interval",
+      "span"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [],
+    "fieldsSource": "undocumented"
+  },
+  {
     "url": "https://api.robinhood.com/marketdata/insiders/summary/{id}/",
     "host": "api.robinhood.com",
     "categories": [
@@ -11624,6 +11799,66 @@
     "requestTypes": [
       "FETCH"
     ]
+  },
+  {
+    "url": "https://api.robinhood.com/marketdata/options/?ids={ids}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "marketdata",
+      "options"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup; ids key from captured queryKeys",
+    "seenOn": [
+      "portfolio-options"
+    ],
+    "queryKeys": [
+      "ids"
+    ],
+    "fields": [
+      "adjusted_mark_price",
+      "adjusted_mark_price_round_down",
+      "ask_price",
+      "ask_size",
+      "bid_price",
+      "bid_size",
+      "break_even_price",
+      "chance_of_profit_long",
+      "chance_of_profit_short",
+      "delta",
+      "gamma",
+      "high_fill_rate_buy_price",
+      "high_fill_rate_sell_price",
+      "high_price",
+      "implied_volatility",
+      "instrument",
+      "instrument_id",
+      "last_trade_price",
+      "last_trade_size",
+      "latest_quote_session",
+      "low_fill_rate_buy_price",
+      "low_fill_rate_sell_price",
+      "low_price",
+      "mark_price",
+      "occ_symbol",
+      "open_interest",
+      "previous_close_date",
+      "previous_close_price",
+      "pricing_model",
+      "reg_session",
+      "rho",
+      "state",
+      "symbol",
+      "theta",
+      "updated_at",
+      "vega",
+      "volume"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
   },
   {
     "url": "https://api.robinhood.com/marketdata/options/chains/stats/v1/{uuid}/",
@@ -12276,6 +12511,53 @@
       "schemaVersion": 2
     },
     "verificationStatus": "captured"
+  },
+  {
+    "url": "https://api.robinhood.com/marketdata/quotes/?ids={ids}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "marketdata",
+      "quotes"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes",
+    "queryKeys": [
+      "ids"
+    ],
+    "fields": [
+      "adjusted_previous_close",
+      "ask_mic",
+      "ask_price",
+      "ask_size",
+      "ask_source",
+      "bid_mic",
+      "bid_price",
+      "bid_size",
+      "bid_source",
+      "has_traded",
+      "instrument",
+      "instrument_id",
+      "last_extended_hours_trade_price",
+      "last_non_reg_trade_price",
+      "last_non_reg_trade_price_source",
+      "last_trade_price",
+      "last_trade_price_source",
+      "previous_close",
+      "previous_close_date",
+      "state",
+      "symbol",
+      "trading_halted",
+      "updated_at",
+      "venue_ask_time",
+      "venue_bid_time",
+      "venue_last_non_reg_trade_time",
+      "venue_last_trade_time"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
   },
   {
     "url": "https://api.robinhood.com/marketdata/quotes/{id}/",
@@ -15749,6 +16031,47 @@
     ]
   },
   {
+    "url": "https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "instruments",
+      "reference"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id",
+    "queryKeys": [
+      "chain_id",
+      "expiration_dates",
+      "type"
+    ],
+    "fields": [
+      "chain_id",
+      "chain_symbol",
+      "created_at",
+      "expiration_date",
+      "id",
+      "issue_date",
+      "long_strategy_code",
+      "min_ticks",
+      "rhs_tradability",
+      "sellout_datetime",
+      "short_strategy_code",
+      "state",
+      "strike_price",
+      "tradability",
+      "type",
+      "underlying_type",
+      "updated_at",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
+  },
+  {
     "url": "https://api.robinhood.com/options/instruments/{0}/",
     "host": "api.robinhood.com",
     "categories": [
@@ -18228,6 +18551,40 @@
       "FETCH",
       "XHR"
     ]
+  },
+  {
+    "url": "https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true",
+    "host": "api.robinhood.com",
+    "categories": [
+      "account"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary; placeholder filled via --param",
+    "queryKeys": [
+      "account_number",
+      "nonzero"
+    ],
+    "fields": [
+      "account",
+      "account_number",
+      "average_buy_price",
+      "instrument",
+      "instrument_id",
+      "intraday_average_buy_price",
+      "intraday_quantity",
+      "pending_average_buy_price",
+      "quantity",
+      "shares_held_for_buys",
+      "shares_held_for_options_collateral",
+      "shares_held_for_sells",
+      "updated_at",
+      "url"
+    ],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object"
   },
   {
     "url": "https://api.robinhood.com/quotes/",

--- a/api-map/curl/brokerage-route-templates.sh
+++ b/api-map/curl/brokerage-route-templates.sh
@@ -299,6 +299,12 @@
 # read GET https://api.robinhood.com/instruments/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/instruments/'
 
+# read GET https://api.robinhood.com/instruments/?ids={ids}
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/instruments/?ids={ids}'
+
+# read GET https://api.robinhood.com/instruments/?symbol={symbol}
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/instruments/?symbol={symbol}'
+
 # read GET https://api.robinhood.com/instruments/{0}/popularity/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/instruments/{0}/popularity/'
 
@@ -371,6 +377,9 @@
 # read GET https://api.robinhood.com/marketdata/historicals/{id}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/historicals/{id}/'
 
+# read GET https://api.robinhood.com/marketdata/historicals/{symbol}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/historicals/{symbol}/'
+
 # read GET https://api.robinhood.com/marketdata/insiders/summary/{id}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/insiders/summary/{id}/'
 
@@ -379,6 +388,9 @@
 
 # read GET https://api.robinhood.com/marketdata/options/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/options/'
+
+# read GET https://api.robinhood.com/marketdata/options/?ids={ids}
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/options/?ids={ids}'
 
 # read GET https://api.robinhood.com/marketdata/options/chains/stats/v1/{uuid}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/options/chains/stats/v1/{uuid}/'
@@ -394,6 +406,9 @@
 
 # read GET https://api.robinhood.com/marketdata/quotes/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/quotes/'
+
+# read GET https://api.robinhood.com/marketdata/quotes/?ids={ids}
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/quotes/?ids={ids}'
 
 # read GET https://api.robinhood.com/marketdata/quotes/{id}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/marketdata/quotes/{id}/'
@@ -515,6 +530,9 @@
 # read GET https://api.robinhood.com/options/instruments/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/instruments/'
 
+# read GET https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}'
+
 # read GET https://api.robinhood.com/options/instruments/{0}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/instruments/{0}/'
 
@@ -601,6 +619,9 @@
 
 # sensitive-read GET https://api.robinhood.com/positions/?account_number=
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/positions/?account_number='
+
+# sensitive-read GET https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true'
 
 # read GET https://api.robinhood.com/quotes/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/quotes/'

--- a/api-map/markdown/brokerage-routes.md
+++ b/api-map/markdown/brokerage-routes.md
@@ -4,8 +4,8 @@ Source: reverse-engineered routes plus sanitized authenticated Chrome/CDP captur
 
 Personal repo semantics: mapped routes can be executed live with caller-owned `ROBINHOOD_BROKERAGE_TOKEN` or `ROBINHOOD_COOKIE`. Pass `--dry-run` when you want a non-sending test plan.
 
-Current count: 361 route templates.
-Risk counts: destructive=9, read=93, sensitive-read=230, write-mutate=11, write-or-sensitive=7, write-safe=11.
+Current count: 368 route templates.
+Risk counts: destructive=9, read=99, sensitive-read=231, write-mutate=11, write-or-sensitive=7, write-safe=11.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -109,6 +109,8 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/inbox/threads/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/indexes/` |
 | read | GET | instruments, marketdata, reference | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes; self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution | `https://api.robinhood.com/instruments/` |
+| read | GET | instruments, reference | api.robinhood.com | self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes | `https://api.robinhood.com/instruments/?ids={ids}` |
+| read | GET | instruments, reference | api.robinhood.com | self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution | `https://api.robinhood.com/instruments/?symbol={symbol}` |
 | read | inferred | marketdata | api.robinhood.com | community-seed | `https://api.robinhood.com/instruments/{0}/popularity/` |
 | read | inferred | marketdata | api.robinhood.com | community-seed | `https://api.robinhood.com/instruments/{0}/splits/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/instruments/{id}/shorting/` |
@@ -133,14 +135,17 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/hedgefunds/transactions/{id}/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/marketdata/historicals/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-06-04-injected-capture (observed; cdp-2026-07-14-authenticated-sanitized-v2; price historicals per symbol) | `https://api.robinhood.com/marketdata/historicals/{id}/` |
+| read | GET | marketdata | api.robinhood.com | cdp-2026-06-04-injected-capture (observed; price historicals per symbol) | `https://api.robinhood.com/marketdata/historicals/{symbol}/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/insiders/summary/{id}/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/insiders/transactions/{id}/` |
 | read | GET | marketdata, options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; ids key from captured queryKeys; self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup | `https://api.robinhood.com/marketdata/options/` |
+| read | GET | marketdata, options | api.robinhood.com | self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup; ids key from captured queryKeys | `https://api.robinhood.com/marketdata/options/?ids={ids}` |
 | read | GET | marketdata, options | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/options/chains/stats/v1/{uuid}/` |
 | read | inferred | marketdata, options | api.robinhood.com | live-verified-2026-06-11 (batch daily closes for held contracts; powers pre-open day attribution in computePortfolioPnl) | `https://api.robinhood.com/marketdata/options/historicals/?ids={ids}&interval={interval}&span={span}` |
 | read | inferred | marketdata, options | api.robinhood.com | community-seed | `https://api.robinhood.com/marketdata/options/historicals/{0}/` |
 | read | GET | marketdata, options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/marketdata/options/strategy/quotes/` |
 | read | GET | marketdata, quotes | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes | `https://api.robinhood.com/marketdata/quotes/` |
+| read | GET | marketdata, quotes | api.robinhood.com | self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes | `https://api.robinhood.com/marketdata/quotes/?ids={ids}` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/quotes/{id}/` |
 | read | GET | marketdata | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/token/v1/` |
 | read | inferred | marketdata | api.robinhood.com | community-seed | `https://api.robinhood.com/markets/` |
@@ -181,6 +186,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | GET | options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/options/events/` |
 | read | GET | options, trading | api.robinhood.com | cdp-2026-06-04-dram-option-order-flow (observed; per-order fee schedule) | `https://api.robinhood.com/options/fees/` |
 | read | GET | instruments, marketdata, options, reference | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id | `https://api.robinhood.com/options/instruments/` |
+| read | GET | options, instruments, reference | api.robinhood.com | self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id | `https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}` |
 | read | inferred | marketdata, options | api.robinhood.com | community-seed | `https://api.robinhood.com/options/instruments/{0}/` |
 | read | GET | options, roll | api.robinhood.com | cdp-2026-06-23-googl-native-roll (observed + live-verified response) | `https://api.robinhood.com/options/maximum_rollable_quantity/{strategy_code}/` |
 | sensitive-read | GET | account, options, settings | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2; web-ui-capture-2026-06-03 (account/settings/investing) | `https://api.robinhood.com/options/option_settings/{account_number}/` |
@@ -210,6 +216,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | GET | account | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/portfolios/v2/performance/summary` |
 | sensitive-read | inferred | account | api.robinhood.com | community-seed | `https://api.robinhood.com/positions/` |
 | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; placeholder filled via --param; self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary | `https://api.robinhood.com/positions/?account_number=` |
+| sensitive-read | GET | account | api.robinhood.com | self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary; placeholder filled via --param | `https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true` |
 | read | inferred | marketdata | api.robinhood.com | community-seed | `https://api.robinhood.com/quotes/` |
 | read | inferred | marketdata | api.robinhood.com | community-seed | `https://api.robinhood.com/quotes/historicals/` |
 | sensitive-read | GET | unknown | api.robinhood.com | cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/settings/education_state/{id}/` |

--- a/api-map/markdown/endpoints/get-api-robinhood-com-instruments-2.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-instruments-2.md
@@ -1,0 +1,17 @@
+# GET /instruments/
+
+Mutation: no
+Risk: read
+
+Host: api.robinhood.com
+Categories: instruments, reference
+Source: self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/instruments/?ids={ids}
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-instruments-3.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-instruments-3.md
@@ -1,0 +1,17 @@
+# GET /instruments/
+
+Mutation: no
+Risk: read
+
+Host: api.robinhood.com
+Categories: instruments, reference
+Source: self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/instruments/?symbol={symbol}
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-marketdata-historicals-7bsymbol-7d.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-marketdata-historicals-7bsymbol-7d.md
@@ -1,0 +1,17 @@
+# GET /marketdata/historicals/%7Bsymbol%7D/
+
+Mutation: no
+Risk: read
+
+Host: api.robinhood.com
+Categories: marketdata
+Source: cdp-2026-06-04-injected-capture (observed; price historicals per symbol)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/marketdata/historicals/{symbol}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-marketdata-options-2.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-marketdata-options-2.md
@@ -1,0 +1,17 @@
+# GET /marketdata/options/
+
+Mutation: no
+Risk: read
+
+Host: api.robinhood.com
+Categories: marketdata, options
+Source: self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup; ids key from captured queryKeys
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/marketdata/options/?ids={ids}
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-marketdata-quotes-2.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-marketdata-quotes-2.md
@@ -1,0 +1,17 @@
+# GET /marketdata/quotes/
+
+Mutation: no
+Risk: read
+
+Host: api.robinhood.com
+Categories: marketdata, quotes
+Source: self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/marketdata/quotes/?ids={ids}
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-instruments-2.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-instruments-2.md
@@ -1,0 +1,17 @@
+# GET /options/instruments/
+
+Mutation: no
+Risk: read
+
+Host: api.robinhood.com
+Categories: options, instruments, reference
+Source: self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-positions-3.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-positions-3.md
@@ -1,0 +1,17 @@
+# GET /positions/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: account
+Source: self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary; placeholder filled via --param
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/robinhood-routes.md
+++ b/api-map/markdown/robinhood-routes.md
@@ -4,10 +4,10 @@ Source: official Robinhood Crypto Trading OpenAPI plus sanitized authenticated C
 
 Crypto operations are official Robinhood-published endpoints and should use Ed25519 signing. Brokerage/account operations are browser-backed route-map entries and use caller-owned brokerage token or browser cookie auth.
 
-Current count: 377 route entries.
+Current count: 384 route entries.
 Official Crypto route entries: 16.
-Brokerage/account route entries: 361.
-Risk counts: destructive=11, read=99, sensitive-read=236, write-mutate=13, write-or-sensitive=7, write-safe=11.
+Brokerage/account route entries: 368.
+Risk counts: destructive=11, read=105, sensitive-read=237, write-mutate=13, write-or-sensitive=7, write-safe=11.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -111,6 +111,8 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/inbox/threads/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/indexes/` |
 | no | read | GET | instruments, marketdata, reference | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes; self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution | `https://api.robinhood.com/instruments/` |
+| no | read | GET | instruments, reference | api.robinhood.com | self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes | `https://api.robinhood.com/instruments/?ids={ids}` |
+| no | read | GET | instruments, reference | api.robinhood.com | self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution | `https://api.robinhood.com/instruments/?symbol={symbol}` |
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/instruments/{0}/popularity/` |
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/instruments/{0}/splits/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/instruments/{id}/shorting/` |
@@ -135,14 +137,17 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/hedgefunds/transactions/{id}/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/marketdata/historicals/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-06-04-injected-capture (observed; cdp-2026-07-14-authenticated-sanitized-v2; price historicals per symbol) | `https://api.robinhood.com/marketdata/historicals/{id}/` |
+| no | read | GET | marketdata | api.robinhood.com | cdp-2026-06-04-injected-capture (observed; price historicals per symbol) | `https://api.robinhood.com/marketdata/historicals/{symbol}/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/insiders/summary/{id}/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/insiders/transactions/{id}/` |
 | no | read | GET | marketdata, options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; ids key from captured queryKeys; self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup | `https://api.robinhood.com/marketdata/options/` |
+| no | read | GET | marketdata, options | api.robinhood.com | self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup; ids key from captured queryKeys | `https://api.robinhood.com/marketdata/options/?ids={ids}` |
 | no | read | GET | marketdata, options | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/options/chains/stats/v1/{uuid}/` |
 | no | read | inferred | marketdata, options | api.robinhood.com | live-verified-2026-06-11 (batch daily closes for held contracts; powers pre-open day attribution in computePortfolioPnl) | `https://api.robinhood.com/marketdata/options/historicals/?ids={ids}&interval={interval}&span={span}` |
 | no | read | inferred | marketdata, options | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/marketdata/options/historicals/{0}/` |
 | no | read | GET | marketdata, options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized | `https://api.robinhood.com/marketdata/options/strategy/quotes/` |
 | no | read | GET | marketdata, quotes | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes | `https://api.robinhood.com/marketdata/quotes/` |
+| no | read | GET | marketdata, quotes | api.robinhood.com | self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes | `https://api.robinhood.com/marketdata/quotes/?ids={ids}` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/quotes/{id}/` |
 | no | read | GET | marketdata | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/marketdata/token/v1/` |
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/markets/` |
@@ -183,6 +188,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | sensitive-read | GET | options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/options/events/` |
 | no | read | GET | options, trading | api.robinhood.com | cdp-2026-06-04-dram-option-order-flow (observed; per-order fee schedule) | `https://api.robinhood.com/options/fees/` |
 | no | read | GET | instruments, marketdata, options, reference | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id | `https://api.robinhood.com/options/instruments/` |
+| no | read | GET | options, instruments, reference | api.robinhood.com | self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id | `https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}` |
 | no | read | inferred | marketdata, options | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/options/instruments/{0}/` |
 | no | read | GET | options, roll | api.robinhood.com | cdp-2026-06-23-googl-native-roll (observed + live-verified response) | `https://api.robinhood.com/options/maximum_rollable_quantity/{strategy_code}/` |
 | no | sensitive-read | GET | account, options, settings | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2; web-ui-capture-2026-06-03 (account/settings/investing) | `https://api.robinhood.com/options/option_settings/{account_number}/` |
@@ -212,6 +218,7 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/portfolios/v2/performance/summary` |
 | no | sensitive-read | inferred | account | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/positions/` |
 | no | sensitive-read | GET | account | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; placeholder filled via --param; self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary | `https://api.robinhood.com/positions/?account_number=` |
+| no | sensitive-read | GET | account | api.robinhood.com | self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary; placeholder filled via --param | `https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true` |
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/quotes/` |
 | no | read | inferred | marketdata | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/quotes/historicals/` |
 | no | sensitive-read | GET | unknown | api.robinhood.com | cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/settings/education_state/{id}/` |

--- a/api-map/openapi/robinhood-brokerage.openapi.json
+++ b/api-map/openapi/robinhood-brokerage.openapi.json
@@ -15684,7 +15684,9 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/instruments/"
+          "https://api.robinhood.com/instruments/",
+          "https://api.robinhood.com/instruments/?ids={ids}",
+          "https://api.robinhood.com/instruments/?symbol={symbol}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -19811,6 +19813,78 @@
         ]
       }
     },
+    "/marketdata/historicals/{symbol}/": {
+      "get": {
+        "operationId": "brokerage_get_marketdata_historicals_symbol",
+        "summary": "Marketdata brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "marketdata"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder symbol. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "bounds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "span",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/marketdata/historicals/{symbol}/"
+        ],
+        "x-robinhood-sources": [
+          "cdp-2026-06-04-injected-capture (observed",
+          "price historicals per symbol)"
+        ],
+        "x-robinhood-seen-on": [
+          "option-ticket"
+        ]
+      }
+    },
     "/marketdata/insiders/summary/{id}/": {
       "get": {
         "operationId": "brokerage_get_marketdata_insiders_summary_id",
@@ -20286,7 +20360,8 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/marketdata/options/"
+          "https://api.robinhood.com/marketdata/options/",
+          "https://api.robinhood.com/marketdata/options/?ids={ids}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -21011,7 +21086,8 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/marketdata/quotes/"
+          "https://api.robinhood.com/marketdata/quotes/",
+          "https://api.robinhood.com/marketdata/quotes/?ids={ids}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -25324,7 +25400,8 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/options/instruments/"
+          "https://api.robinhood.com/options/instruments/",
+          "https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -29837,7 +29914,8 @@
         ],
         "x-robinhood-route-templates": [
           "https://api.robinhood.com/positions/",
-          "https://api.robinhood.com/positions/?account_number="
+          "https://api.robinhood.com/positions/?account_number=",
+          "https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",

--- a/api-map/openapi/robinhood-unified.openapi.json
+++ b/api-map/openapi/robinhood-unified.openapi.json
@@ -17692,7 +17692,9 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/instruments/"
+          "https://api.robinhood.com/instruments/",
+          "https://api.robinhood.com/instruments/?ids={ids}",
+          "https://api.robinhood.com/instruments/?symbol={symbol}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -21861,6 +21863,79 @@
         "x-robinhood-source": "brokerage-browser-map"
       }
     },
+    "/marketdata/historicals/{symbol}/": {
+      "get": {
+        "operationId": "brokerage_get_marketdata_historicals_symbol",
+        "summary": "Marketdata brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "marketdata"
+        ],
+        "parameters": [
+          {
+            "name": "symbol",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder symbol. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "bounds",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "span",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/marketdata/historicals/{symbol}/"
+        ],
+        "x-robinhood-sources": [
+          "cdp-2026-06-04-injected-capture (observed",
+          "price historicals per symbol)"
+        ],
+        "x-robinhood-seen-on": [
+          "option-ticket"
+        ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
     "/marketdata/insiders/summary/{id}/": {
       "get": {
         "operationId": "brokerage_get_marketdata_insiders_summary_id",
@@ -22338,7 +22413,8 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/marketdata/options/"
+          "https://api.robinhood.com/marketdata/options/",
+          "https://api.robinhood.com/marketdata/options/?ids={ids}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -23068,7 +23144,8 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/marketdata/quotes/"
+          "https://api.robinhood.com/marketdata/quotes/",
+          "https://api.robinhood.com/marketdata/quotes/?ids={ids}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -27423,7 +27500,8 @@
           "api.robinhood.com"
         ],
         "x-robinhood-route-templates": [
-          "https://api.robinhood.com/options/instruments/"
+          "https://api.robinhood.com/options/instruments/",
+          "https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",
@@ -31977,7 +32055,8 @@
         ],
         "x-robinhood-route-templates": [
           "https://api.robinhood.com/positions/",
-          "https://api.robinhood.com/positions/?account_number="
+          "https://api.robinhood.com/positions/?account_number=",
+          "https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true"
         ],
         "x-robinhood-sources": [
           "cdp-2026-05-26-stock-account-sanitized",

--- a/api-map/robinhood-routes.json
+++ b/api-map/robinhood-routes.json
@@ -9263,6 +9263,156 @@
     ]
   },
   {
+    "url": "https://api.robinhood.com/instruments/?ids={ids}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "instruments",
+      "reference"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes",
+    "queryKeys": [
+      "ids"
+    ],
+    "fields": [
+      "account_type_tradabilities",
+      "affiliate",
+      "affiliate_tradability",
+      "all_day_tradability",
+      "bloomberg_unique",
+      "car_required",
+      "country",
+      "day_trade_ratio",
+      "default_collar_fraction",
+      "default_preset_percent_limit",
+      "extended_hours_fractional_tradability",
+      "fractional_tradability",
+      "fundamentals",
+      "high_risk_maintenance_ratio",
+      "id",
+      "internal_halt_details",
+      "internal_halt_end_time",
+      "internal_halt_reason",
+      "internal_halt_sessions",
+      "internal_halt_source",
+      "internal_halt_start_time",
+      "ipo_access_cob_deadline",
+      "ipo_access_status",
+      "ipo_access_supports_dsp",
+      "ipo_roadshow_url",
+      "ipo_s1_url",
+      "ipoa_start_date",
+      "is_high_investment_risk",
+      "is_spac",
+      "is_test",
+      "issuer_type",
+      "list_date",
+      "low_risk_maintenance_ratio",
+      "maintenance_ratio",
+      "margin_initial_ratio",
+      "market",
+      "min_tick_size",
+      "name",
+      "notional_estimated_quantity_decimals",
+      "otc_market_tier",
+      "quote",
+      "reserved_buying_power_percent_immediate",
+      "reserved_buying_power_percent_queued",
+      "rhs_tradability",
+      "short_selling_tradability",
+      "simple_name",
+      "splits",
+      "state",
+      "symbol",
+      "tax_security_type",
+      "tradability",
+      "tradable_chain_id",
+      "tradeable",
+      "type",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
+  },
+  {
+    "url": "https://api.robinhood.com/instruments/?symbol={symbol}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "instruments",
+      "reference"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: symbol->instrument_id + tradable_chain_id resolution",
+    "queryKeys": [
+      "symbol"
+    ],
+    "fields": [
+      "account_type_tradabilities",
+      "affiliate",
+      "affiliate_tradability",
+      "all_day_tradability",
+      "bloomberg_unique",
+      "car_required",
+      "country",
+      "day_trade_ratio",
+      "default_collar_fraction",
+      "default_preset_percent_limit",
+      "extended_hours_fractional_tradability",
+      "fractional_tradability",
+      "fundamentals",
+      "high_risk_maintenance_ratio",
+      "id",
+      "internal_halt_details",
+      "internal_halt_end_time",
+      "internal_halt_reason",
+      "internal_halt_sessions",
+      "internal_halt_source",
+      "internal_halt_start_time",
+      "ipo_access_cob_deadline",
+      "ipo_access_status",
+      "ipo_access_supports_dsp",
+      "ipo_roadshow_url",
+      "ipo_s1_url",
+      "ipoa_start_date",
+      "is_high_investment_risk",
+      "is_spac",
+      "is_test",
+      "issuer_type",
+      "list_date",
+      "low_risk_maintenance_ratio",
+      "maintenance_ratio",
+      "margin_initial_ratio",
+      "market",
+      "min_tick_size",
+      "name",
+      "notional_estimated_quantity_decimals",
+      "otc_market_tier",
+      "quote",
+      "reserved_buying_power_percent_immediate",
+      "reserved_buying_power_percent_queued",
+      "rhs_tradability",
+      "short_selling_tradability",
+      "simple_name",
+      "splits",
+      "state",
+      "symbol",
+      "tax_security_type",
+      "tradability",
+      "tradable_chain_id",
+      "tradeable",
+      "type",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
+  },
+  {
     "url": "https://api.robinhood.com/instruments/{0}/popularity/",
     "host": "api.robinhood.com",
     "categories": [
@@ -11138,6 +11288,31 @@
     "fieldsShape": "object"
   },
   {
+    "url": "https://api.robinhood.com/marketdata/historicals/{symbol}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "marketdata"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "cdp-2026-06-04-injected-capture (observed; price historicals per symbol)",
+    "seenOn": [
+      "option-ticket"
+    ],
+    "queryKeys": [
+      "bounds",
+      "interval",
+      "span"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [],
+    "fieldsSource": "undocumented"
+  },
+  {
     "url": "https://api.robinhood.com/marketdata/insiders/summary/{id}/",
     "host": "api.robinhood.com",
     "categories": [
@@ -11624,6 +11799,66 @@
     "requestTypes": [
       "FETCH"
     ]
+  },
+  {
+    "url": "https://api.robinhood.com/marketdata/options/?ids={ids}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "marketdata",
+      "options"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: templated ids= form of marketdata/options for single/batch option mark (adjusted_mark_price) lookup; ids key from captured queryKeys",
+    "seenOn": [
+      "portfolio-options"
+    ],
+    "queryKeys": [
+      "ids"
+    ],
+    "fields": [
+      "adjusted_mark_price",
+      "adjusted_mark_price_round_down",
+      "ask_price",
+      "ask_size",
+      "bid_price",
+      "bid_size",
+      "break_even_price",
+      "chance_of_profit_long",
+      "chance_of_profit_short",
+      "delta",
+      "gamma",
+      "high_fill_rate_buy_price",
+      "high_fill_rate_sell_price",
+      "high_price",
+      "implied_volatility",
+      "instrument",
+      "instrument_id",
+      "last_trade_price",
+      "last_trade_size",
+      "latest_quote_session",
+      "low_fill_rate_buy_price",
+      "low_fill_rate_sell_price",
+      "low_price",
+      "mark_price",
+      "occ_symbol",
+      "open_interest",
+      "previous_close_date",
+      "previous_close_price",
+      "pricing_model",
+      "reg_session",
+      "rho",
+      "state",
+      "symbol",
+      "theta",
+      "updated_at",
+      "vega",
+      "volume"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
   },
   {
     "url": "https://api.robinhood.com/marketdata/options/chains/stats/v1/{uuid}/",
@@ -12276,6 +12511,53 @@
       "schemaVersion": 2
     },
     "verificationStatus": "captured"
+  },
+  {
+    "url": "https://api.robinhood.com/marketdata/quotes/?ids={ids}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "marketdata",
+      "quotes"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: bulk ids= resolution for holdings → tickers/quotes",
+    "queryKeys": [
+      "ids"
+    ],
+    "fields": [
+      "adjusted_previous_close",
+      "ask_mic",
+      "ask_price",
+      "ask_size",
+      "ask_source",
+      "bid_mic",
+      "bid_price",
+      "bid_size",
+      "bid_source",
+      "has_traded",
+      "instrument",
+      "instrument_id",
+      "last_extended_hours_trade_price",
+      "last_non_reg_trade_price",
+      "last_non_reg_trade_price_source",
+      "last_trade_price",
+      "last_trade_price_source",
+      "previous_close",
+      "previous_close_date",
+      "state",
+      "symbol",
+      "trading_halted",
+      "updated_at",
+      "venue_ask_time",
+      "venue_bid_time",
+      "venue_last_non_reg_trade_time",
+      "venue_last_trade_time"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
   },
   {
     "url": "https://api.robinhood.com/marketdata/quotes/{id}/",
@@ -15749,6 +16031,47 @@
     ]
   },
   {
+    "url": "https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "instruments",
+      "reference"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id",
+    "queryKeys": [
+      "chain_id",
+      "expiration_dates",
+      "type"
+    ],
+    "fields": [
+      "chain_id",
+      "chain_symbol",
+      "created_at",
+      "expiration_date",
+      "id",
+      "issue_date",
+      "long_strategy_code",
+      "min_ticks",
+      "rhs_tradability",
+      "sellout_datetime",
+      "short_strategy_code",
+      "state",
+      "strike_price",
+      "tradability",
+      "type",
+      "underlying_type",
+      "updated_at",
+      "url"
+    ],
+    "fieldsSource": "verified",
+    "fieldsShape": "list"
+  },
+  {
     "url": "https://api.robinhood.com/options/instruments/{0}/",
     "host": "api.robinhood.com",
     "categories": [
@@ -18228,6 +18551,40 @@
       "FETCH",
       "XHR"
     ]
+  },
+  {
+    "url": "https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true",
+    "host": "api.robinhood.com",
+    "categories": [
+      "account"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "self-extension 2026-05-28: templated account_number form so any account (individual, Roth/IRA, etc.) can be queried, not just primary; placeholder filled via --param",
+    "queryKeys": [
+      "account_number",
+      "nonzero"
+    ],
+    "fields": [
+      "account",
+      "account_number",
+      "average_buy_price",
+      "instrument",
+      "instrument_id",
+      "intraday_average_buy_price",
+      "intraday_quantity",
+      "pending_average_buy_price",
+      "quantity",
+      "shares_held_for_buys",
+      "shares_held_for_options_collateral",
+      "shares_held_for_sells",
+      "updated_at",
+      "url"
+    ],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object"
   },
   {
     "url": "https://api.robinhood.com/quotes/",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2780,8 +2780,8 @@ program
 // ── portfolio: one-call P&L across ALL accounts — DOLLARS, day vs after-hours, by underlying ──
 // The composed answer to "how am I down?". The compute lives in lib.computePortfolioPnl (shared with
 // the MCP robinhood_portfolio tool); this command is a thin renderer over its structured result.
-//   after-hours Δ = extended_hours_equity − equity         (NOT − previous_close; that's the full day)
-//   day Δ         = equity − adjusted_equity_previous_close (equity_previous_close is "0" per-account)
+//   after-hours Δ = extended_hours_equity − equity
+//   regular-session P&L = sum of fully priced equity + option position moves
 program
   .command("portfolio")
   .aliases(["pnl", "snapshot"])
@@ -2799,7 +2799,7 @@ program
     if (!["day", "after-hours", "both"].includes(window)) throw new Error(`--window must be day|after-hours|both (got "${window}")`);
     const top = Number.isFinite(Number(opts.top)) ? Number(opts.top) : 0;
     // Shared engine — identical code path to the MCP robinhood_portfolio tool (alignment invariant).
-    const r = await computePortfolioPnl({ by: opts.by, window: window as any, accountNumber: opts.account, top: 0 });
+    const r = await computePortfolioPnl({ by: opts.by, window: window as any, accountNumber: opts.account, top });
 
     if (opts.json) { printJson({ generatedAt: new Date().toISOString(), ...r }); return; }
 
@@ -2834,7 +2834,7 @@ program
       }
     }
     const mp = r.reconciliation.mispricedPositions;
-    process.stdout.write(`\nDrivers explain ${usd(r.reconciliation.driverDayChangeUsd)} of the ${usd(r.totals.dayChangeUsd)} day move; residual ${usd(r.reconciliation.residualUsd)} = cash / dividends / transfers / option-vs-equity timing${mp ? ` (${mp} position(s) could not be priced)` : ""}. After-hours shown is EQUITY only (options don't print after-hours).\n`);
+    process.stdout.write(`\nPriced-position regular-session P&L: ${usd(r.totals.dayChangeUsd)}${mp ? ` (${mp} position(s) could not be priced)` : ""}. Broker adjusted account-equity delta: ${usd(r.reconciliation.reportedAccountEquityDeltaUsd)}; diagnostic difference ${usd(r.reconciliation.residualUsd)} can reflect cash flows and broker baseline adjustments. After-hours uses account equity because index options can trade extended sessions.\n`);
     const warns = [...(r.warnings ?? []), ...r.accounts.flatMap((a: any) => a.warnings)];
     if (warns.length) process.stdout.write(`${warns.map((w: string) => "⚠️  " + w).join("\n")}\n`);
   });

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -3018,8 +3018,10 @@ export interface PortfolioPnlOptions {
  * command and the MCP `robinhood_portfolio` tool (single source per the alignment invariant; the CLI
  * just renders this object, MCP returns it as JSON). Metrics agents get wrong, pinned here:
  *   after-hours Δ = extended_hours_equity − equity        (NOT − previous_close; that's the full day)
- *   day Δ         = equity − adjusted_equity_previous_close (equity_previous_close is "0" per-account)
- * Per-position $ drivers: equity day = qty×(last − adjusted_previous_close), AH = qty×(ext − last);
+ *   regular-session P&L = sum of priced position moves. Do NOT label
+ *     equity − adjusted_equity_previous_close as P&L: that account field can be cash-flow adjusted and
+ *     live-verified to disagree with both Robinhood's chart and the fully priced position book.
+ * Per-position $ P&L: equity day = qty×(last − adjusted_previous_close), AH = qty×(ext − last);
  * option day = (adjusted_mark − previous_close)×100×qty, AH = 0 (options don't print after-hours —
  * mark−last is mid-drift; the account-level extended_hours_equity already captures real index-option AH).
  * Returns a unit-explicit object; never throws on a per-account read failure (degrades + flags).
@@ -3078,82 +3080,34 @@ export async function computePortfolioPnl(
   };
 
   // 2. Per-account top-line + raw positions + buying power, in parallel; a failure degrades to a warning.
-  const perAccount = await Promise.all(
-    accts.map(async (acct) => {
-      const a: any = {
-        acct,
-        label: labelFor(acct),
-        equity: Number.NaN,
-        day: Number.NaN,
-        afterHours: Number.NaN,
-        buyingPower: Number.NaN,
-        equityPositions: [],
-        optionPositions: [],
-        warnings: [] as string[],
-      };
-      try {
-        const p = await getJson("https://api.robinhood.com/portfolios/{account_number}/", {
-          account_number: acct,
-        });
-        const equity = n(p.equity),
-          ext = n(p.extended_hours_equity);
-        const adjPrev = n(p.adjusted_equity_previous_close),
-          rawPrev = n(p.equity_previous_close);
-        const prevClose =
-          Number.isFinite(adjPrev) && adjPrev !== 0
-            ? adjPrev
-            : Number.isFinite(rawPrev) && rawPrev !== 0
-              ? rawPrev
-              : Number.NaN;
-        a.equity = equity;
-        a.afterHours = Number.isFinite(ext) && Number.isFinite(equity) ? ext - equity : Number.NaN;
-        a.day =
-          Number.isFinite(equity) && Number.isFinite(prevClose) ? equity - prevClose : Number.NaN;
-      } catch (e: any) {
-        a.warnings.push(`portfolio read failed (${acct}): ${(e as Error).message.slice(0, 50)}`);
-      }
-      try {
-        const bp = await getJson(
-          "https://api.robinhood.com/accounts/{num}/buying_power_breakdown",
-          { num: acct },
-        );
-        a.buyingPower = n(bp.buying_power);
-      } catch {
-        /* buying power is best-effort; degrade silently */
-      }
-      try {
-        const eq = await getAll(
-          "https://api.robinhood.com/positions/",
-          {},
-          { nonzero: "true", account_number: acct },
-        );
-        a.equityPositions = eq
-          .filter((x: any) => n(x.quantity) > 0)
-          .map((x: any) => ({ symbol: x.symbol, iid: x.instrument_id, qty: n(x.quantity) }));
-      } catch {
-        a.warnings.push(`equity positions read failed (${acct})`);
-      }
-      try {
-        const od = await getAll(
-          "https://api.robinhood.com/options/aggregate_positions/?account_numbers=",
-          {},
-          { account_numbers: acct, nonzero: "true" },
-        );
-        a.optionPositions = od
-          .filter((x: any) => n(x.quantity) > 0)
-          .map((x: any) => ({
-            symbol: x.symbol,
-            name: `${x.symbol} ${x.detail_display_name ?? x.strategy ?? ""}`.trim(),
-            oid: x.legs?.[0]?.option_id,
-            qty: n(x.quantity),
-            underlyingType: x.underlying_type ?? null,
-          }));
-      } catch {
-        a.warnings.push(`option positions read failed (${acct})`);
-      }
-      return a;
-    }),
-  );
+  const perAccount = await Promise.all(accts.map(async (acct) => {
+    const a: any = { acct, label: labelFor(acct), equity: Number.NaN, currentEquity: Number.NaN, reportedDay: Number.NaN, day: Number.NaN, afterHours: Number.NaN, buyingPower: Number.NaN, equityPositions: [], optionPositions: [], warnings: [] as string[] };
+    try {
+      const p = await getJson("https://api.robinhood.com/portfolios/{account_number}/", { account_number: acct });
+      const equity = n(p.equity), ext = n(p.extended_hours_equity);
+      const adjPrev = n(p.adjusted_equity_previous_close), rawPrev = n(p.equity_previous_close);
+      const prevClose = Number.isFinite(adjPrev) && (adjPrev !== 0 || equity === 0)
+        ? adjPrev
+        : (Number.isFinite(rawPrev) && (rawPrev !== 0 || equity === 0) ? rawPrev : Number.NaN);
+      a.equity = equity;
+      a.currentEquity = Number.isFinite(ext) ? ext : equity;
+      a.afterHours = Number.isFinite(ext) && Number.isFinite(equity) ? ext - equity : Number.NaN;
+      a.reportedDay = Number.isFinite(equity) && Number.isFinite(prevClose) ? equity - prevClose : Number.NaN;
+    } catch (e: any) { a.warnings.push(`portfolio read failed (${acct}): ${(e as Error).message.slice(0, 50)}`); }
+    try {
+      const bp = await getJson("https://api.robinhood.com/accounts/{num}/buying_power_breakdown", { num: acct });
+      a.buyingPower = n(bp.buying_power);
+    } catch { a.warnings.push(`buying power read failed (${acct})`); }
+    try {
+      const eq = await getAll("https://api.robinhood.com/positions/", {}, { nonzero: "true", account_number: acct });
+      a.equityPositions = eq.filter((x: any) => n(x.quantity) > 0).map((x: any) => ({ symbol: x.symbol, iid: x.instrument_id, qty: n(x.quantity) }));
+    } catch { a.warnings.push(`equity positions read failed (${acct})`); }
+    try {
+      const od = await getAll("https://api.robinhood.com/options/aggregate_positions/?account_numbers=", {}, { account_numbers: acct, nonzero: "true" });
+      a.optionPositions = od.filter((x: any) => n(x.quantity) > 0).map((x: any) => ({ symbol: x.symbol, name: `${x.symbol} ${x.detail_display_name ?? x.strategy ?? ""}`.trim(), oid: x.legs?.[0]?.option_id, qty: n(x.quantity), underlyingType: x.underlying_type ?? null }));
+    } catch { a.warnings.push(`option positions read failed (${acct})`); }
+    return a;
+  }));
 
   // 3. Batch quotes + option marks across all accounts (one ticker quoted once).
   const allEqIds = [
@@ -3170,27 +3124,15 @@ export async function computePortfolioPnl(
     }
     return map;
   };
-  // The batch quote/marks fetch must NOT take down the whole command — the account top-line is fully
-  // computable from portfolios/{num}/ alone. Degrade per-name drivers to a warning on any failure.
+  // The batch quote/marks fetch must NOT take down the whole command. Account value and after-hours
+  // top-lines remain available, but regular-session P&L must degrade rather than falling back to the
+  // cash-flow-adjusted account-equity delta (which is not a market P&L measure).
   const globalWarnings: string[] = [];
-  let quotes = new Map<string, any>(),
-    marks = new Map<string, any>();
-  try {
-    if (allEqIds.length)
-      quotes = await fetchMap("https://api.robinhood.com/marketdata/quotes/?ids={ids}", allEqIds);
-  } catch (e: any) {
-    globalWarnings.push(
-      `equity quotes batch failed — per-name drivers degraded; account top-line is authoritative (${(e as Error).message.slice(0, 50)})`,
-    );
-  }
-  try {
-    if (allOptIds.length)
-      marks = await fetchMap("https://api.robinhood.com/marketdata/options/?ids={ids}", allOptIds);
-  } catch (e: any) {
-    globalWarnings.push(
-      `option marks batch failed — option drivers degraded (${(e as Error).message.slice(0, 50)})`,
-    );
-  }
+  let quotes = new Map<string, any>(), marks = new Map<string, any>();
+  try { if (allEqIds.length) quotes = await fetchMap("https://api.robinhood.com/marketdata/quotes/?ids={ids}", allEqIds); }
+  catch (e: any) { globalWarnings.push(`equity quotes batch failed — regular-session P&L and per-name drivers degraded (${(e as Error).message.slice(0, 50)})`); }
+  try { if (allOptIds.length) marks = await fetchMap("https://api.robinhood.com/marketdata/options/?ids={ids}", allOptIds); }
+  catch (e: any) { globalWarnings.push(`option marks batch failed — option drivers degraded (${(e as Error).message.slice(0, 50)})`); }
 
   // 3b. WINDOW COHERENCE (the pre-open $0-options bug). Between a session close and the next open,
   // marketdata/options/ rolls previous_close_price to the JUST-COMPLETED session while equity quotes
@@ -3256,12 +3198,16 @@ export async function computePortfolioPnl(
     ? {
         phase: "between-sessions",
         sessionDate: optPrevDate,
-        note: `Market not in regular session — 'day' figures are the LAST COMPLETED session (${optPrevDate}); option drivers re-anchored to the ${eqPrevDate} close so they attribute that session instead of $0.`,
+        baselineCloseDate: eqPrevDate,
+        note: `Market not in regular session — option drivers were re-anchored to the ${eqPrevDate} close so they measure the same completed session as equities. The report generation timestamp remains the as-of time.`,
       }
     : {
         phase: "session",
-        sessionDate: eqPrevDate ? `after ${eqPrevDate} close` : null,
-        note: null,
+        sessionDate: null,
+        baselineCloseDate: eqPrevDate,
+        note: eqPrevDate
+          ? `Regular-session position P&L uses the broker's ${eqPrevDate} previous-close baseline. Use generatedAt—not this baseline date—as the report as-of time.`
+          : null,
       };
 
   // 4. Per-position dollar drivers.
@@ -3275,17 +3221,12 @@ export async function computePortfolioPnl(
           ? n(q.last_extended_hours_trade_price)
           : Number.NaN;
       const prev = n(q.adjusted_previous_close ?? q.previous_close);
-      drivers.push({
-        acct: a.acct,
-        label: a.label,
-        kind: "equity",
-        symbol: p.symbol,
-        name: p.symbol,
-        qty: p.qty,
-        value: Number.isFinite(last) ? p.qty * last : Number.NaN,
+      drivers.push({ acct: a.acct, label: a.label, kind: "equity", symbol: p.symbol, name: p.symbol, qty: p.qty,
+        value: Number.isFinite(ext) ? p.qty * ext : (Number.isFinite(last) ? p.qty * last : Number.NaN),
         dayUsd: Number.isFinite(last) && Number.isFinite(prev) ? p.qty * (last - prev) : Number.NaN,
-        ahUsd: Number.isFinite(ext) && Number.isFinite(last) ? p.qty * (ext - last) : Number.NaN,
-      });
+        // No extended-hours print means no observed per-name AH move, not a failed quote. The account-level
+        // extended equity remains authoritative and any unattributed amount is surfaced as AH residual.
+        ahUsd: Number.isFinite(last) ? (Number.isFinite(ext) ? p.qty * (ext - last) : 0) : Number.NaN });
     }
     for (const p of a.optionPositions) {
       const m = marks.get(p.oid) ?? {};
@@ -3317,22 +3258,48 @@ export async function computePortfolioPnl(
 
   // 5. Totals, reconciliation, rollups.
   const sum = (xs: number[]) => xs.filter((x) => Number.isFinite(x)).reduce((s, x) => s + x, 0);
-  const totals = {
-    equity: sum(perAccount.map((a) => a.equity)),
-    day: sum(perAccount.map((a) => a.day)),
-    afterHours: sum(perAccount.map((a) => a.afterHours)),
-  };
-  const failedReads = perAccount.filter((a) => !Number.isFinite(a.equity)).length;
+  const accountNeedsDay = window !== "after-hours";
+  const accountNeedsAfterHours = window !== "day";
+  const mispricedDayPositions = drivers.filter((d) => !Number.isFinite(d.dayUsd)).length;
+  const mispricedAfterHoursPositions = drivers.filter((d) => !Number.isFinite(d.ahUsd)).length;
+  const mispricedPositions = window === "day"
+    ? mispricedDayPositions
+    : window === "after-hours"
+      ? mispricedAfterHoursPositions
+      : drivers.filter((d) => !Number.isFinite(d.dayUsd) || !Number.isFinite(d.ahUsd)).length;
+  for (const a of perAccount) {
+    const accountDrivers = drivers.filter((d) => d.acct === a.acct);
+    a.day = accountDrivers.some((d) => !Number.isFinite(d.dayUsd))
+      ? Number.NaN
+      : sum(accountDrivers.map((d) => d.dayUsd));
+  }
+  const failedReads = perAccount.filter((a) =>
+    !Number.isFinite(a.currentEquity) ||
+    (accountNeedsDay && !Number.isFinite(a.day)) ||
+    (accountNeedsAfterHours && !Number.isFinite(a.afterHours)),
+  ).length;
   const driverDaySum = drivers.reduce((s, d) => s + (Number.isFinite(d.dayUsd) ? d.dayUsd : 0), 0);
-  const residual = Number.isFinite(totals.day) ? totals.day - driverDaySum : Number.NaN;
-  // Distinguish legitimate unattributed flow (cash/dividends) from failed pricing: count positions we
-  // couldn't price, so an operator can tell a $X dividend residual from a "$X of positions weren't priced".
-  const mispricedPositions = drivers.filter((d) => !Number.isFinite(d.dayUsd)).length;
+  const driverAfterHoursSum = drivers.reduce((s, d) => s + (Number.isFinite(d.ahUsd) ? d.ahUsd : 0), 0);
+  const reportedAccountDayDelta = perAccount.every((a) => Number.isFinite(a.reportedDay))
+    ? sum(perAccount.map((a) => a.reportedDay))
+    : Number.NaN;
+  const totals = {
+    equity: sum(perAccount.map((a) => a.currentEquity)),
+    regularCloseEquity: sum(perAccount.map((a) => a.equity)),
+    day: mispricedDayPositions === 0 ? driverDaySum : Number.NaN,
+    afterHours: perAccount.every((a) => Number.isFinite(a.afterHours))
+      ? sum(perAccount.map((a) => a.afterHours))
+      : Number.NaN,
+  };
+  const residual = Number.isFinite(reportedAccountDayDelta) && mispricedDayPositions === 0
+    ? reportedAccountDayDelta - driverDaySum
+    : Number.NaN;
   // After-hours is meaningful only in an extended session; intraday/closed it's ~0. Flag so callers don't
   // read a regular-session "$0 after-hours / no AH losers" as a failed or flat session.
-  const afterHoursActive = perAccount.some(
-    (a) => Number.isFinite(a.afterHours) && Math.abs(a.afterHours) > 0.005,
-  );
+  const afterHoursActive = perAccount.some((a) => Number.isFinite(a.afterHours) && Math.abs(a.afterHours) > 0.005);
+  const hasDegradingWarning =
+    perAccount.some((account) => account.warnings.length > 0) ||
+    globalWarnings.some((warning) => !warning.startsWith("index options held"));
 
   const byU = new Map<string, any>();
   for (const d of drivers) {
@@ -3388,29 +3355,36 @@ export async function computePortfolioPnl(
 
   return {
     window,
-    complete: failedReads === 0 && globalWarnings.length === 0,
+    complete: failedReads === 0 && mispricedPositions === 0 && !hasDegradingWarning,
     afterHoursActive,
     dayWindow,
-    totals: {
-      equityUsd: totals.equity,
-      dayChangeUsd: totals.day,
-      afterHoursChangeUsd: totals.afterHours,
-    },
+    totals: { equityUsd: totals.equity, regularCloseEquityUsd: totals.regularCloseEquity, dayChangeUsd: totals.day, afterHoursChangeUsd: totals.afterHours },
     reconciliation: {
       driverDayChangeUsd: driverDaySum,
       totalsDayChangeUsd: totals.day,
+      reportedAccountEquityDeltaUsd: reportedAccountDayDelta,
       residualUsd: residual,
+      driverAfterHoursChangeUsd: driverAfterHoursSum,
+      afterHoursResidualUsd: Number.isFinite(totals.afterHours) && mispricedAfterHoursPositions === 0
+        ? totals.afterHours - driverAfterHoursSum
+        : Number.NaN,
       mispricedPositions,
-      note: "residual = cash/dividends/transfers/option-vs-equity timing (NOT failed pricing — see mispricedPositions); after-hours is EQUITY-only (options don't print after-hours)",
+      mispricedDayPositions,
+      mispricedAfterHoursPositions,
+      note: "regular-session P&L is the fully priced position sum. reportedAccountEquityDeltaUsd is diagnostic only; its residual can reflect transfers, deposits, cash, dividends, and broker baseline adjustments. after-hours is account-level because index options can trade extended sessions.",
     },
     accounts: perAccount.map((a) => ({
       accountNumber: a.acct,
       label: a.label,
-      equityUsd: a.equity,
+      equityUsd: a.currentEquity,
+      regularCloseEquityUsd: a.equity,
       dayChangeUsd: a.day,
       afterHoursChangeUsd: a.afterHours,
+      reportedAccountEquityDeltaUsd: a.reportedDay,
       buyingPower: a.buyingPower,
-      partial: !Number.isFinite(a.equity),
+      partial: !Number.isFinite(a.currentEquity) ||
+        (accountNeedsDay && !Number.isFinite(a.day)) ||
+        (accountNeedsAfterHours && !Number.isFinite(a.afterHours)),
       warnings: a.warnings,
     })),
     byUnderlying: top ? byUnderlying.slice(0, top) : byUnderlying,

--- a/cli/test/lib.test.ts
+++ b/cli/test/lib.test.ts
@@ -63,6 +63,17 @@ describe("Robinhood API map", () => {
     expect(
       filterBrokerageRoutes(routes, { host: "bonfire.robinhood.com" }).length,
     ).toBeGreaterThanOrEqual(80);
+    expect(routes.map((route) => route.url)).toEqual(
+      expect.arrayContaining([
+        "https://api.robinhood.com/instruments/?symbol={symbol}",
+        "https://api.robinhood.com/instruments/?ids={ids}",
+        "https://api.robinhood.com/marketdata/quotes/?ids={ids}",
+        "https://api.robinhood.com/marketdata/options/?ids={ids}",
+        "https://api.robinhood.com/marketdata/historicals/{symbol}/",
+        "https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}",
+        "https://api.robinhood.com/positions/?account_number={account_number}&nonzero=true",
+      ]),
+    );
   });
 
   it("keeps read and write methods split so writes cannot inherit read-level risk", () => {

--- a/cli/test/portfolio-pnl.test.ts
+++ b/cli/test/portfolio-pnl.test.ts
@@ -10,15 +10,21 @@ interface Fix {
   portfolios: Record<string, any>;
   positions: Record<string, any[]>;
   optionPositions: Record<string, any[]>;
+  buyingPower: Record<string, any>;
   quotes: any;
   optionMarks: any;
   throwOnQuotes?: boolean;
+  throwOnBuyingPower?: boolean;
 }
 
 function deps(fix: Fix) {
   const getJson = async (url: string, params: any = {}) => {
     if (url.includes("transfer/accounts")) return fix.accounts;
     if (url.includes("portfolios/{account_number}")) return fix.portfolios[params.account_number];
+    if (url.includes("buying_power_breakdown")) {
+      if (fix.throwOnBuyingPower) throw new Error("503");
+      return fix.buyingPower[params.num];
+    }
     if (url.includes("marketdata/quotes")) { if (fix.throwOnQuotes) throw new Error("503"); return fix.quotes; }
     if (url.includes("marketdata/options")) return fix.optionMarks;
     throw new Error("unexpected getJson " + url);
@@ -31,8 +37,9 @@ function deps(fix: Fix) {
   return { getJson, getAll };
 }
 
-// Two accounts: 111 (down) and 222 (up). 111 holds equity AAA + option BBB. equity_previous_close is "0"
-// on both (the per-account trap) → the engine MUST use adjusted_equity_previous_close.
+// Two accounts. 111 holds equity AAA + option BBB; 222 is empty. The portfolio endpoint's
+// adjusted_equity_previous_close implies an account delta that conflicts with priced positions. The engine
+// must report price-based position P&L, not mislabel cash-flow-adjusted account equity deltas as market P&L.
 const base = (): Fix => ({
   accounts: { results: [
     { type: "rhs", account_number: "111", account_name: "Acct A" },
@@ -44,17 +51,20 @@ const base = (): Fix => ({
   },
   positions: { "111": [{ symbol: "AAA", instrument_id: "iidA", quantity: "10" }], "222": [] },
   optionPositions: { "111": [{ symbol: "BBB", detail_display_name: "$5 Call 1/1", legs: [{ option_id: "oidB" }], quantity: "1" }], "222": [] },
+  buyingPower: { "111": { buying_power: "250" }, "222": { buying_power: "500" } },
   quotes: { results: [{ instrument_id: "iidA", last_trade_price: "95", last_extended_hours_trade_price: "94", adjusted_previous_close: "100" }] },
   optionMarks: { results: [{ instrument_id: "oidB", adjusted_mark_price: "4.0", previous_close_price: "5.0", last_trade_price: "4.2" }] }
 });
 
 describe("computePortfolioPnl — metric definitions (golden fixtures)", () => {
-  it("computes per-account day Δ = equity − adjusted_equity_previous_close (ignoring equity_previous_close='0')", async () => {
+  it("computes regular-session P&L from priced positions, not adjusted account-equity deltas", async () => {
     const r = await computePortfolioPnl({}, deps(base()));
     const a111 = r.accounts.find((a: any) => a.accountNumber === "111");
     const a222 = r.accounts.find((a: any) => a.accountNumber === "222");
-    expect(a111.dayChangeUsd).toBe(-100);          // 1000 − 1100 (adjusted, NOT the "0" raw field)
-    expect(a222.dayChangeUsd).toBe(100);           // 2000 − 1900
+    expect(a111.dayChangeUsd).toBe(-150);          // AAA −50 + BBB −100
+    expect(a222.dayChangeUsd).toBe(0);             // no priced positions moved
+    expect(a111.reportedAccountEquityDeltaUsd).toBe(-100); // diagnostic only, never presented as P&L
+    expect(a222.reportedAccountEquityDeltaUsd).toBe(100);
     expect(a111.label).toBe("Acct A");             // RH account_name surfaced
   });
 
@@ -67,8 +77,9 @@ describe("computePortfolioPnl — metric definitions (golden fixtures)", () => {
 
   it("totals: equity summed, day nets across accounts", async () => {
     const r = await computePortfolioPnl({}, deps(base()));
-    expect(r.totals.equityUsd).toBe(3000);
-    expect(r.totals.dayChangeUsd).toBe(0);         // −100 + 100
+    expect(r.totals.equityUsd).toBe(2980);         // latest extended-hours equity
+    expect(r.totals.regularCloseEquityUsd).toBe(3000);
+    expect(r.totals.dayChangeUsd).toBe(-150);      // priced position P&L
     expect(r.complete).toBe(true);
   });
 
@@ -89,7 +100,8 @@ describe("computePortfolioPnl — metric definitions (golden fixtures)", () => {
   it("reconciliation: residual = top-line − driver sum; mispricedPositions = 0 when all priced", async () => {
     const r = await computePortfolioPnl({}, deps(base()));
     expect(r.reconciliation.driverDayChangeUsd).toBe(-150);  // −50 (AAA) + −100 (BBB)
-    expect(r.reconciliation.totalsDayChangeUsd).toBe(0);
+    expect(r.reconciliation.totalsDayChangeUsd).toBe(-150);
+    expect(r.reconciliation.reportedAccountEquityDeltaUsd).toBe(0);
     expect(r.reconciliation.residualUsd).toBe(150);          // 0 − (−150)
     expect(r.reconciliation.mispricedPositions).toBe(0);
   });
@@ -97,12 +109,59 @@ describe("computePortfolioPnl — metric definitions (golden fixtures)", () => {
   it("degrades (not crashes) when the quotes batch fails: top-line intact, warned, position mispriced", async () => {
     const fix = base(); fix.throwOnQuotes = true;
     const r = await computePortfolioPnl({}, deps(fix));
-    expect(r.totals.dayChangeUsd).toBe(0);                   // top-line still computed from portfolios/
+    expect(Number.isNaN(r.totals.dayChangeUsd)).toBe(true);  // never emit a partial total as complete P&L
     expect(r.complete).toBe(false);                          // a degrade marks incomplete
     expect(r.warnings.some((w: string) => /quotes batch failed/i.test(w))).toBe(true);
     const aaa = r.byPosition.find((d: any) => d.symbol === "AAA");
     expect(Number.isNaN(aaa.dayChangeUsd)).toBe(true);       // unpriced
     expect(r.reconciliation.mispricedPositions).toBeGreaterThanOrEqual(1);
+  });
+
+  it("stays complete when the only warning is informational index-option after-hours attribution", async () => {
+    const fix = base();
+    fix.optionPositions["111"][0].underlying_type = "index";
+    const r = await computePortfolioPnl({}, deps(fix));
+    expect(r.reconciliation.mispricedPositions).toBe(0);
+    expect(r.warnings.some((w: string) => w.startsWith("index options held"))).toBe(true);
+    expect(r.complete).toBe(true);
+  });
+
+  it("marks the report incomplete when buying power fails instead of silently returning a missing field", async () => {
+    const fix = base();
+    fix.throwOnBuyingPower = true;
+    const r = await computePortfolioPnl({}, deps(fix));
+    expect(r.accounts.every((account: any) => Number.isNaN(account.buyingPower))).toBe(true);
+    expect(r.accounts.every((account: any) => account.warnings.some((w: string) => /buying power read failed/i.test(w)))).toBe(true);
+    expect(r.complete).toBe(false);
+  });
+
+  it("marks a day report incomplete when a held position lacks a previous-close price", async () => {
+    const fix = base();
+    delete fix.quotes.results[0].adjusted_previous_close;
+    const r = await computePortfolioPnl({ window: "day" }, deps(fix));
+    expect(Number.isNaN(r.accounts.find((account: any) => account.accountNumber === "111").dayChangeUsd)).toBe(true);
+    expect(r.complete).toBe(false);
+  });
+
+  it("keeps an after-hours-only report complete when day baselines are absent but AH prices are valid", async () => {
+    const fix = base();
+    delete fix.quotes.results[0].adjusted_previous_close;
+    delete fix.optionMarks.results[0].previous_close_price;
+    const r = await computePortfolioPnl({ window: "after-hours" }, deps(fix));
+    expect(r.reconciliation.mispricedPositions).toBe(0);
+    expect(r.totals.afterHoursChangeUsd).toBe(-20);
+    expect(r.complete).toBe(true);
+  });
+
+  it("treats an absent extended-hours trade as zero per-name AH movement, not a pricing failure", async () => {
+    const fix = base();
+    delete fix.quotes.results[0].last_extended_hours_trade_price;
+    const r = await computePortfolioPnl({ window: "after-hours" }, deps(fix));
+    const aaa = r.byPosition.find((position: any) => position.symbol === "AAA");
+    expect(aaa.afterHoursChangeUsd).toBe(0);
+    expect(r.reconciliation.mispricedAfterHoursPositions).toBe(0);
+    expect(r.reconciliation.afterHoursResidualUsd).toBe(-20);
+    expect(r.complete).toBe(true);
   });
 
   it("scopes to one account when accountNumber given; throws on an unowned account", async () => {

--- a/docs/portfolio-route-template-regression-2026-07-16.md
+++ b/docs/portfolio-route-template-regression-2026-07-16.md
@@ -1,0 +1,118 @@
+# Portfolio route-template regression — 2026-07-16
+
+## What was found
+
+PR #36 (`39d31c74`) bundled an MCP discovery-efficiency change with a route-map
+regeneration. Commit `45e7226` consolidated captured routes by HTTP method, origin,
+and pathname while discarding the executable query template. That deleted distinct
+first-class read routes sharing the same path:
+
+- `instruments/?symbol={symbol}`
+- `instruments/?ids={ids}`
+- `marketdata/quotes/?ids={ids}`
+- `marketdata/options/?ids={ids}`
+- `marketdata/historicals/{symbol}/`
+- `options/instruments/?chain_id=...`
+- `positions/?account_number={account_number}&nonzero=true`
+
+The MCP profile reduction was not the cause. The query-template collapse in the API
+map was the cause.
+
+The incident also exposed a separate reporting error. The portfolio engine presented
+`equity - adjusted_equity_previous_close` as authoritative regular-session P&L even
+when that broker baseline diverged materially from fully priced position P&L. The
+adjusted account delta is now diagnostic only; regular-session P&L is derived from
+the complete priced position set, while after-hours P&L remains the account-level
+`extended_hours_equity - equity` delta.
+
+## How it was reproduced
+
+All steps were read-only.
+
+1. Compare the executable route map immediately before and after `45e7226`:
+
+   ```bash
+   git show 45e7226^:api-map/brokerage-routes.json
+   git show 45e7226:api-map/brokerage-routes.json
+   ```
+
+   The pre-change map contained the query-template variants. The regenerated map did
+   not.
+
+2. Run the installed portfolio command from the checkout used by Hermes:
+
+   ```bash
+   robinhood-cli portfolio --top 0 --json
+   ```
+
+   Before repair, quote and option-mark reads failed, `complete` was false, and all
+   168 position valuations were reported unavailable or mispriced.
+
+3. Restore query-aware operation keys, regenerate the API artifacts, rebuild both
+   packages, and repeat the same read.
+
+   After repair, the live result had 168 priced positions, 86 resolved underlyings,
+   `mispricedPositions: 0`, and a complete report. The regular-session position sum
+   was negative while the broker-adjusted account delta was positive with a large
+   reconciliation residual, proving the second issue.
+
+4. Verify the Hermes registration and live tool roster:
+
+   ```bash
+   hermes mcp test robinhood-cli
+   ```
+
+   Hermes launched `mcp/dist/server.js` from this checkout and discovered the lean
+   15-tool profile. The checkout itself was still on the deleted PR branch at
+   `b076933` while GitHub `main` was at `39d31c7`, so source, build, and branch parity
+   were not guaranteed.
+
+## Why it matters
+
+A route catalog is an executable allow-list, not just documentation. Query shapes on
+the same pathname can represent different first-class operations. Collapsing them can
+silently break quotes, option marks, account scoping, and portfolio valuation while
+leaving the MCP server healthy enough to answer with authoritative-sounding totals.
+
+Account-level adjusted-equity baselines can also include broker adjustments that do
+not equal market P&L. A large residual must not be translated into a confident gain or
+loss headline when fully priced holdings show the opposite direction.
+
+## Sanitized evidence
+
+- Breaking commit: `45e7226a9d56b5fbcf1a2d3bd1d99d8c79335f06`
+- PR merge: `39d31c74a9b7aed9e79fa87fe12602f4c76dc3dc`
+- Route count immediately before regeneration: 313
+- Route count immediately after the breaking regeneration: 361
+- Repaired route count: 368
+- Broken live portfolio: 168 mispriced positions
+- Repaired live portfolio: 168 priced positions, 86 underlyings, zero mispriced
+- Verification: 434 CLI tests + 16 MCP tests passed; quality and API-map contracts passed
+
+No account numbers, credentials, cookies, order identifiers, or raw private brokerage
+responses are stored in this document.
+
+## Permanent guards
+
+- `canonicalOperationKey()` includes normalized query templates.
+- The capture merge preserves sorted query keys as placeholders.
+- API-map tests assert that the seven first-class query-template routes survive.
+- Portfolio tests pin priced-position P&L, after-hours account deltas, missing-mark
+  degradation, and the diagnostic-only account-equity delta.
+- `SKILL.md` documents the query-template invariant and live portfolio acceptance
+  check.
+
+## Reproducibility
+
+```bash
+node scripts/test-cdp-capture.mjs
+corepack pnpm test
+corepack pnpm quality
+python3 scripts/check-skill-token-budget.py
+node scripts/equity-buy.mjs --preflight
+robinhood-cli portfolio --top 0 --json
+hermes mcp test robinhood-cli
+```
+
+The last three commands touch live read-only account data. Redact account identifiers
+and balances before sharing their output.

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1255,7 +1255,7 @@ server.registerTool(
   {
     title: "Robinhood Portfolio P&L",
     description:
-      "One-call portfolio P&L across ALL owned accounts (or one) in DOLLARS. Per-account day change (equity − adjusted_equity_previous_close) AND after-hours change (extended_hours_equity − equity), then dollar-weighted drivers rolled up by underlying (or position) across accounts — equities AND options. Answers 'how am I down today / after hours and which names'. Ranks by DOLLARS not percent. Discloses a reconciliation residual (cash/dividends/transfers) so the drivers vs top-line gap is explicit. After-hours is EQUITY-only (options don't print after-hours). Live read; no gate.",
+      "One-call portfolio P&L across ALL owned accounts (or one) in DOLLARS. Regular-session P&L is the sum of fully priced equity and option position moves; it does not mislabel the broker's cash-flow-adjusted account-equity delta as market P&L. After-hours change uses extended account equity so index options are included. Returns current equity, regular-close equity, dollar-weighted drivers, pricing completeness, and the broker account-equity delta as a diagnostic only. Answers 'how am I down today / after hours and which names'. Live read; no gate.",
     inputSchema: z.object({
       by: z.enum(["underlying", "account", "position"]).default("underlying"),
       window: z.enum(["day", "after-hours", "both"]).default("both"),

--- a/scripts/lib/cdp-capture.mjs
+++ b/scripts/lib/cdp-capture.mjs
@@ -29,6 +29,21 @@ export function normalizePath(pathname) {
   return value;
 }
 
+export function canonicalOperationKey(method, url) {
+  const parsed = new URL(url);
+  const path = decodeURIComponent(parsed.pathname)
+    .replace(/\{[^}]*\}/g, "{param}")
+    .replace(/\/+$/, "/");
+  const query = [...parsed.searchParams.entries()]
+    .map(([key, value]) => [key, decodeURIComponent(value).replace(/\{[^}]*\}/g, "{param}")])
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) =>
+      leftKey.localeCompare(rightKey) || leftValue.localeCompare(rightValue),
+    )
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+  return `${String(method).toUpperCase()} ${parsed.origin}${path}${query ? `?${query}` : ""}`;
+}
+
 function headerValue(headers, name) {
   if (!headers || typeof headers !== "object") return undefined;
   const match = Object.entries(headers).find(([key]) => key.toLowerCase() === name);

--- a/scripts/merge-cdp-capture.mjs
+++ b/scripts/merge-cdp-capture.mjs
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   assertSanitizedCapture,
+  canonicalOperationKey,
   capturePolicy,
   mergeSchemas,
   normalizePath,
@@ -18,22 +19,26 @@ if (!captureArg) {
 const capturePath = resolve(captureArg);
 const captureDate =
   capturePath.match(/(\d{4}-\d{2}-\d{2})/)?.[1] ?? new Date().toISOString().slice(0, 10);
-const routesPath = resolve(root, "api-map/brokerage-routes.json");
-const browserRoutesPath = resolve(root, `api-map/browser-cdp-routes-${captureDate}.json`);
+const routesPath = process.env.ROBINHOOD_ROUTES_PATH
+  ? resolve(process.env.ROBINHOOD_ROUTES_PATH)
+  : resolve(root, "api-map/brokerage-routes.json");
+const browserRoutesPath = process.env.ROBINHOOD_BROWSER_ROUTES_PATH
+  ? resolve(process.env.ROBINHOOD_BROWSER_ROUTES_PATH)
+  : resolve(root, `api-map/browser-cdp-routes-${captureDate}.json`);
 
 const capture = assertSanitizedCapture(JSON.parse(await readFile(capturePath, "utf8")));
 let existingRoutes = JSON.parse(await readFile(routesPath, "utf8"));
 
-function routeUrl(origin, pathname) {
-  return `${origin}${normalizePath(pathname)}`;
-}
-
-function canonicalUrl(url) {
-  const parsed = new URL(url);
-  const path = decodeURIComponent(parsed.pathname)
-    .replace(/\{[^}]*\}/g, "{param}")
-    .replace(/\/+$/, "/");
-  return `${parsed.origin}${path}`;
+function routeUrl(origin, pathname, queryKeys = []) {
+  const base = `${origin}${normalizePath(pathname)}`;
+  const query = [...new Set(queryKeys)]
+    .sort()
+    .map((key) => {
+      const token = String(key).replace(/[^a-zA-Z0-9_-]/g, "_");
+      return `${encodeURIComponent(key)}={${token}}`;
+    })
+    .join("&");
+  return query ? `${base}?${query}` : base;
 }
 
 function categoriesFor(pathname) {
@@ -126,7 +131,8 @@ for (const item of capture.routeIndex ?? []) {
   const requestType = String(item.type ?? "").toUpperCase();
   if (requestType && !requestType.includes("XHR") && !requestType.includes("FETCH")) continue;
   const normalizedPath = normalizePath(item.url.path);
-  const key = `${item.method} ${item.url.origin}${normalizedPath}`;
+  const queryKeys = [...new Set(item.url.queryKeys ?? [])].sort();
+  const key = canonicalOperationKey(item.method, routeUrl(item.url.origin, normalizedPath, queryKeys));
   const group = grouped.get(key) ?? {
     methodSet: new Set(),
     typeSet: new Set(),
@@ -139,7 +145,7 @@ for (const item of capture.routeIndex ?? []) {
     responseBodySchemas: {},
     requiresAuth: false,
     observationCount: 0,
-    url: { ...item.url, path: normalizedPath },
+    url: { ...item.url, path: normalizedPath, queryKeys },
   };
   group.methodSet.add(item.method);
   if (item.type) group.typeSet.add(item.type);
@@ -169,7 +175,7 @@ const browserRoutes = [...grouped.values()]
     const categories = categoriesFor(group.url.path);
     const fieldEvidence = fieldSummary(group.responseBodySchemas);
     return {
-      url: routeUrl(group.url.origin, group.url.path),
+      url: routeUrl(group.url.origin, group.url.path, queryKeys),
       host: new URL(group.url.origin).hostname,
       categories,
       risk: riskFor({ url: group.url, methods }, categories),
@@ -264,10 +270,10 @@ const byOperation = new Map();
 for (const existing of existingRoutes) {
   const methods = existing.methods?.length ? existing.methods : ["GET"];
   if (methods.length !== 1) continue;
-  byOperation.set(`${methods[0]} ${canonicalUrl(existing.url)}`, existing);
+  byOperation.set(canonicalOperationKey(methods[0], existing.url), existing);
 }
 for (const route of browserRoutes) {
-  const key = `${route.methods[0]} ${canonicalUrl(route.url)}`;
+  const key = canonicalOperationKey(route.methods[0], route.url);
   const existing = byOperation.get(key);
   if (existing) {
     mergeRouteEvidence(existing, route);
@@ -284,7 +290,7 @@ for (const route of existingRoutes) {
     dedupedRoutes.push(route);
     continue;
   }
-  const key = `${route.methods[0]} ${canonicalUrl(route.url)}`;
+  const key = canonicalOperationKey(route.methods[0], route.url);
   const existing = exactOperations.get(key);
   if (existing) mergeRouteEvidence(existing, route);
   else {

--- a/scripts/test-cdp-capture.mjs
+++ b/scripts/test-cdp-capture.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { assertSanitizedCapture, sanitizeCapture } from "./lib/cdp-capture.mjs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  assertSanitizedCapture,
+  canonicalOperationKey,
+  sanitizeCapture,
+} from "./lib/cdp-capture.mjs";
 
 const secret = "secret-value-that-must-not-survive";
 const output = sanitizeCapture({
@@ -74,5 +82,73 @@ assert.throws(
     }),
   /forbidden raw field requestHeaders/,
 );
+
+assert.notEqual(
+  canonicalOperationKey("GET", "https://api.robinhood.com/instruments/"),
+  canonicalOperationKey("GET", "https://api.robinhood.com/instruments/?symbol={symbol}"),
+  "route-map merging must preserve query-template variants used by first-class tools",
+);
+assert.notEqual(
+  canonicalOperationKey("GET", "https://api.robinhood.com/instruments/?ids={ids}"),
+  canonicalOperationKey("GET", "https://api.robinhood.com/instruments/?symbol={symbol}"),
+  "different query shapes on the same path must not collapse into one route",
+);
+
+const mergeDir = await mkdtemp(join(tmpdir(), "robinhood-cdp-merge-"));
+try {
+  const routesPath = join(mergeDir, "routes.json");
+  const browserRoutesPath = join(mergeDir, "browser-routes.json");
+  const capturePath = join(mergeDir, "capture-2026-07-16.json");
+  const baseRoute = {
+    host: "api.robinhood.com",
+    categories: ["instruments"],
+    risk: "read",
+    methods: ["GET"],
+    source: "fixture",
+    fields: [],
+    fieldsSource: "undocumented",
+  };
+  await writeFile(
+    routesPath,
+    JSON.stringify([
+      { ...baseRoute, url: "https://api.robinhood.com/instruments/" },
+    ]),
+  );
+  await writeFile(
+    capturePath,
+    JSON.stringify({
+      schemaVersion: 2,
+      sanitized: true,
+      capturedAt: "2026-07-16T00:00:00.000Z",
+      routeIndex: [
+        { method: "GET", type: "XHR", url: { origin: "https://api.robinhood.com", path: "/instruments/", queryKeys: [] } },
+        { method: "GET", type: "XHR", url: { origin: "https://api.robinhood.com", path: "/instruments/", queryKeys: ["ids"] } },
+        { method: "GET", type: "XHR", url: { origin: "https://api.robinhood.com", path: "/instruments/", queryKeys: ["symbol"] } },
+      ],
+    }),
+  );
+  const merged = spawnSync(process.execPath, ["scripts/merge-cdp-capture.mjs", capturePath], {
+    cwd: new URL("..", import.meta.url),
+    env: {
+      ...process.env,
+      ROBINHOOD_ROUTES_PATH: routesPath,
+      ROBINHOOD_BROWSER_ROUTES_PATH: browserRoutesPath,
+    },
+    encoding: "utf8",
+  });
+  assert.equal(merged.status, 0, merged.stderr || merged.stdout);
+  const urls = JSON.parse(await readFile(routesPath, "utf8")).map((route) => route.url);
+  assert.deepEqual(
+    urls.sort(),
+    [
+      "https://api.robinhood.com/instruments/",
+      "https://api.robinhood.com/instruments/?ids={ids}",
+      "https://api.robinhood.com/instruments/?symbol={symbol}",
+    ].sort(),
+    "the actual merge path must preserve base, ids, and symbol route variants",
+  );
+} finally {
+  await rm(mergeDir, { recursive: true, force: true });
+}
 
 console.log("CDP capture sanitizer contract passed");


### PR DESCRIPTION
## Summary\n- preserve executable query-template variants during CDP route-map merges\n- report regular-session P&L from fully priced positions instead of broker-adjusted account baselines\n- keep after-hours totals account-level and expose day/AH reconciliation diagnostics\n- retain the full 31.8k-token skill and full MCP default from v1.0.0\n- add regression tests, regenerated route artifacts, and a sanitized incident report\n\n## Root cause\nPR #36 commit `45e7226` deduplicated routes by method + pathname and collapsed distinct query templates. That removed the routes used for symbol/ID lookup, equity quotes, option marks, and account-scoped positions. The same run also trusted `adjusted_equity_previous_close` as market P&L even when it diverged materially from fully priced holdings.\n\n## Verification\n- 437 CLI tests passed\n- 18 MCP protocol tests passed\n- quality suite passed\n- route-map capture contract passed\n- SKILL.md integrity: 1,729 lines, 126,489 bytes, 31,812 tokens\n- live read-only portfolio: 168 priced positions, 86 underlyings, 0 mispriced\n\nNo live orders or account mutations were performed.