### PR TITLE
Fix portfolio snapshot compatibility after P&L repair

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4210,7 +4210,7 @@ program
       return printJson(diffPortfolioSnapshots(snapshots.at(-2)!, snapshots.at(-1)!));
     }
     if (action !== "capture") throw new Error("action must be capture|list|diff");
-    const snapshot = { version: 1 as const, id: randomUUID(), capturedAt: new Date().toISOString(), source: "portfolio" as const, data: await computePortfolioPnl({ accountNumber: opts.account, top: 0 }) };
+    const snapshot = { version: 2 as const, id: randomUUID(), capturedAt: new Date().toISOString(), source: "portfolio" as const, data: await computePortfolioPnl({ accountNumber: opts.account, top: 0 }) };
     appendPortfolioSnapshot(opts.path, snapshot);
     printJson({ path: opts.path, snapshot });
   });

--- a/cli/src/time-machine.ts
+++ b/cli/src/time-machine.ts
@@ -2,11 +2,39 @@ import { appendFileSync, chmodSync, existsSync, mkdirSync, readFileSync } from "
 import { dirname } from "node:path";
 
 export interface PortfolioSnapshot {
-  version: 1;
+  version: 1 | 2;
   id: string;
   capturedAt: string;
   source: "portfolio";
-  data: any;
+  data: PortfolioSnapshotData;
+}
+
+interface SnapshotPosition {
+  accountNumber?: unknown;
+  acct?: unknown;
+  kind?: unknown;
+  symbol?: unknown;
+  name?: unknown;
+  marketValueUsd?: unknown;
+  value?: unknown;
+  dayChangeUsd?: unknown;
+  dayUsd?: unknown;
+  qty?: unknown;
+}
+
+interface PortfolioSnapshotData {
+  totals?: {
+    equity?: unknown;
+    day?: unknown;
+    afterHours?: unknown;
+    equityUsd?: unknown;
+    regularCloseEquityUsd?: unknown;
+    dayChangeUsd?: unknown;
+    afterHoursChangeUsd?: unknown;
+  };
+  reconciliation?: { driverDayChangeUsd?: unknown };
+  drivers?: SnapshotPosition[];
+  byPosition?: SnapshotPosition[];
 }
 
 export function appendPortfolioSnapshot(path: string, snapshot: PortfolioSnapshot): void {
@@ -17,32 +45,86 @@ export function appendPortfolioSnapshot(path: string, snapshot: PortfolioSnapsho
 
 export function readPortfolioSnapshots(path: string): PortfolioSnapshot[] {
   if (!existsSync(path)) return [];
-  return readFileSync(path, "utf8").split("\n").filter(Boolean).map((line, index) => {
-    try { return JSON.parse(line) as PortfolioSnapshot; }
-    catch { throw new Error(`Invalid portfolio snapshot JSONL at line ${index + 1}`); }
-  });
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line) as PortfolioSnapshot;
+      } catch {
+        throw new Error(`Invalid portfolio snapshot JSONL at line ${index + 1}`);
+      }
+    });
 }
 
 function numericDelta(after: unknown, before: unknown): number | null {
-  const a = Number(after), b = Number(before);
+  const a = Number(after),
+    b = Number(before);
   return Number.isFinite(a) && Number.isFinite(b) ? Number((a - b).toFixed(4)) : null;
 }
 
 export function diffPortfolioSnapshots(before: PortfolioSnapshot, after: PortfolioSnapshot) {
-  const beforeDrivers = new Map<string, any>((before.data?.drivers ?? []).map((d: any) => [`${d.kind}:${d.symbol}:${d.name ?? ""}`, d]));
-  const afterDrivers = new Map<string, any>((after.data?.drivers ?? []).map((d: any) => [`${d.kind}:${d.symbol}:${d.name ?? ""}`, d]));
-  const positions = [...new Set([...beforeDrivers.keys(), ...afterDrivers.keys()])].map((key) => {
-    const a = afterDrivers.get(key) ?? {}, b = beforeDrivers.get(key) ?? {};
-    return { key, valueDelta: numericDelta(a.value, b.value), dayUsdDelta: numericDelta(a.dayUsd, b.dayUsd), quantityDelta: numericDelta(a.qty, b.qty) };
-  }).filter((row) => row.valueDelta !== 0 || row.dayUsdDelta !== 0 || row.quantityDelta !== 0);
+  const crossVersion = before.version !== after.version;
+  const positionsFor = (snapshot: PortfolioSnapshot) =>
+    snapshot.data.byPosition ?? snapshot.data.drivers ?? [];
+  const keyFor = (position: SnapshotPosition) =>
+    [position.accountNumber ?? position.acct, position.kind, position.symbol, position.name]
+      .map((part) => (part == null ? "" : String(part)))
+      .join(":");
+  const beforeDrivers = new Map<string, SnapshotPosition>(
+    positionsFor(before).map((position) => [keyFor(position), position]),
+  );
+  const afterDrivers = new Map<string, SnapshotPosition>(
+    positionsFor(after).map((position) => [keyFor(position), position]),
+  );
+  const positions = [...new Set([...beforeDrivers.keys(), ...afterDrivers.keys()])]
+    .map((key) => {
+      const a = afterDrivers.get(key) ?? {},
+        b = beforeDrivers.get(key) ?? {};
+      return {
+        key,
+        valueDelta: numericDelta(a.marketValueUsd ?? a.value, b.marketValueUsd ?? b.value),
+        dayUsdDelta: numericDelta(a.dayChangeUsd ?? a.dayUsd, b.dayChangeUsd ?? b.dayUsd),
+        quantityDelta: numericDelta(a.qty, b.qty),
+      };
+    })
+    .filter((row) => row.valueDelta !== 0 || row.dayUsdDelta !== 0 || row.quantityDelta !== 0);
+  const equityBasis = (snapshot: PortfolioSnapshot) => {
+    const totals = snapshot.data.totals;
+    if (snapshot.version === 2)
+      return crossVersion
+        ? (totals?.regularCloseEquityUsd ?? totals?.equityUsd)
+        : totals?.equityUsd;
+    return totals?.equityUsd ?? totals?.equity;
+  };
+  const dayBasis = (snapshot: PortfolioSnapshot) => {
+    const totals = snapshot.data.totals;
+    if (snapshot.version === 1)
+      return (
+        snapshot.data.reconciliation?.driverDayChangeUsd ?? totals?.dayChangeUsd ?? totals?.day
+      );
+    return totals?.dayChangeUsd;
+  };
   return {
     before: { id: before.id, capturedAt: before.capturedAt },
     after: { id: after.id, capturedAt: after.capturedAt },
-    totals: {
-      equityDelta: numericDelta(after.data?.totals?.equity, before.data?.totals?.equity),
-      dayDelta: numericDelta(after.data?.totals?.day, before.data?.totals?.day),
-      afterHoursDelta: numericDelta(after.data?.totals?.afterHours, before.data?.totals?.afterHours)
+    comparison: {
+      crossVersion,
+      equityBasis: crossVersion
+        ? "regular-close"
+        : after.version === 2
+          ? "current"
+          : "legacy-regular-close",
+      dayBasis: "priced-position",
     },
-    positions
+    totals: {
+      equityDelta: numericDelta(equityBasis(after), equityBasis(before)),
+      dayDelta: numericDelta(dayBasis(after), dayBasis(before)),
+      afterHoursDelta: numericDelta(
+        after.data.totals?.afterHoursChangeUsd ?? after.data.totals?.afterHours,
+        before.data.totals?.afterHoursChangeUsd ?? before.data.totals?.afterHours,
+      ),
+    },
+    positions,
   };
 }

--- a/cli/test/feature-modules.test.ts
+++ b/cli/test/feature-modules.test.ts
@@ -6,6 +6,7 @@ import {
   appendPortfolioSnapshot,
   buildOptionsWorkbench,
   diffPortfolioSnapshots,
+  type PortfolioSnapshot,
   redactShareSafe,
   readPortfolioSnapshots,
   repositoryRoot,
@@ -76,31 +77,58 @@ describe("portfolio time machine", () => {
 
   it("persists private JSONL snapshots and reports position drift", () => {
     const path = join(mkdtempSync(join(tmpdir(), "rh-snap-")), "snapshots.jsonl");
-    const before: any = {
+    const before: PortfolioSnapshot = {
       version: 1,
       id: "a",
       capturedAt: "2026-01-01T00:00:00Z",
       source: "portfolio",
       data: {
-        totals: { equity: 100, day: 1, afterHours: 0 },
-        drivers: [{ kind: "equity", symbol: "AAPL", value: 50, dayUsd: 1, qty: 1 }],
+        totals: { equityUsd: 100, dayChangeUsd: 50, afterHoursChangeUsd: 0 },
+        reconciliation: { driverDayChangeUsd: 1 },
+        byPosition: [
+          {
+            accountNumber: "111",
+            kind: "equity",
+            symbol: "AAPL",
+            name: "AAPL",
+            marketValueUsd: 50,
+            dayChangeUsd: 1,
+            qty: 1,
+          },
+        ],
       },
     };
-    const after: any = {
-      version: 1,
+    const after: PortfolioSnapshot = {
+      version: 2,
       id: "b",
       capturedAt: "2026-01-02T00:00:00Z",
       source: "portfolio",
       data: {
-        totals: { equity: 110, day: 3, afterHours: 1 },
-        drivers: [{ kind: "equity", symbol: "AAPL", value: 60, dayUsd: 2, qty: 1 }],
+        totals: {
+          equityUsd: 108,
+          regularCloseEquityUsd: 110,
+          dayChangeUsd: 3,
+          afterHoursChangeUsd: -2,
+        },
+        byPosition: [
+          {
+            accountNumber: "111",
+            kind: "equity",
+            symbol: "AAPL",
+            name: "AAPL",
+            marketValueUsd: 60,
+            dayChangeUsd: 2,
+            qty: 1,
+          },
+        ],
       },
     };
     appendPortfolioSnapshot(path, before);
     appendPortfolioSnapshot(path, after);
     expect(readPortfolioSnapshots(path)).toHaveLength(2);
     expect(diffPortfolioSnapshots(before, after)).toMatchObject({
-      totals: { equityDelta: 10, dayDelta: 2, afterHoursDelta: 1 },
+      comparison: { crossVersion: true, equityBasis: "regular-close", dayBasis: "priced-position" },
+      totals: { equityDelta: 10, dayDelta: 2, afterHoursDelta: -2 },
       positions: [{ valueDelta: 10 }],
     });
   });

--- a/docs/portfolio-route-template-regression-2026-07-16.md
+++ b/docs/portfolio-route-template-regression-2026-07-16.md
@@ -87,7 +87,7 @@ loss headline when fully priced holdings show the opposite direction.
 - Repaired route count: 368
 - Broken live portfolio: 168 mispriced positions
 - Repaired live portfolio: 168 priced positions, 86 underlyings, zero mispriced
-- Verification: 434 CLI tests + 16 MCP tests passed; quality and API-map contracts passed
+- Verification: 437 CLI tests + 18 MCP tests passed; quality and API-map contracts passed
 
 No account numbers, credentials, cookies, order identifiers, or raw private brokerage
 responses are stored in this document.
@@ -99,6 +99,10 @@ responses are stored in this document.
 - API-map tests assert that the seven first-class query-template routes survive.
 - Portfolio tests pin priced-position P&L, after-hours account deltas, missing-mark
   degradation, and the diagnostic-only account-equity delta.
+- New portfolio snapshots use schema version 2. Snapshot diffs understand both the
+  legacy account-delta schema and the priced-position schema, and compare a v1/v2
+  pair on the regular-close equity basis so after-hours movement is not counted as
+  a false portfolio-value change.
 - `SKILL.md` documents the query-template invariant and live portfolio acceptance
   check.
 
@@ -108,7 +112,7 @@ responses are stored in this document.
 node scripts/test-cdp-capture.mjs
 corepack pnpm test
 corepack pnpm quality
-python3 scripts/check-skill-token-budget.py
+python3 scripts/check-skill-integrity.py
 node scripts/equity-buy.mjs --preflight
 robinhood-cli portfolio --top 0 --json
 hermes mcp test robinhood-cli

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -3517,7 +3517,7 @@ registerCapabilityTool(
       return jsonResponse(diffPortfolioSnapshots(snapshots.at(-2)!, snapshots.at(-1)!));
     }
     const snapshot = {
-      version: 1 as const,
+      version: 2 as const,
       id: randomUUID(),
       capturedAt: new Date().toISOString(),
       source: "portfolio" as const,


### PR DESCRIPTION
## Summary
- write new portfolio snapshots as schema version 2
- diff legacy v1 snapshots using priced-position day P&L and regular-close equity
- preserve v1/v2 position compatibility and document the migration

## Verification
- workspace quality gates pass
- 437 CLI tests and 18 MCP tests pass
- focused portfolio snapshot tests pass