### PR TITLE
fix(auth): direct CDP token extraction with verified fallbacks

### DIFF
--- a/knowledge/auth-discovery.md
+++ b/knowledge/auth-discovery.md
@@ -1,0 +1,40 @@
+# Multi-browser Robinhood auth discovery
+
+Robinhood's web client stores the primary bearer in the origin-scoped localStorage key `web:auth_state`. The token must never be printed, passed in argv, committed, or inferred from cookies.
+
+## Resolution order
+
+1. **Live Chromium CDP** (`ROBINHOOD_CDP_PORT`, default `9222`)
+   - `scripts/extract-auth-cdp.py` connects directly to the browser WebSocket
+   - creates a background `https://robinhood.com/` target
+   - reads `localStorage.web:auth_state` from the correct origin
+   - updates `.env` in-process and closes the target
+   - does not depend on an already-open Robinhood tab, Node, browser-harness, or a GUI interaction
+2. **On-disk Chromium LevelDB**
+   - Chrome, Brave, and Edge standard profile roots
+   - useful when a browser has flushed a complete auth object to disk
+   - custom `--user-data-dir` profiles should use CDP or be supplied as an additional root
+3. **Safari capability detection**
+   - Safari stores origin data under sandboxed WebKit `WebsiteDataStore` directories
+   - cache strings such as `access_token` are not proof of Robinhood auth
+   - only use Safari when the `robinhood.com` origin can be mapped to an actual `web:auth_state` record or Safari remote automation provides origin-scoped JavaScript execution
+   - never treat generic NetworkCache matches as credentials
+
+## Verification contract
+
+A refresh is successful only when all three are true:
+
+1. extractor reports `auth_state=yes token_written=yes`
+2. destination `.env` is copied/injected without exposing the token
+3. a lightweight custom-CLI read (`accounts --json`) returns parseable, non-empty JSON
+
+Exit status or file existence alone is not success.
+
+## Frostbyte services discovered
+
+The generic pattern is process-derived, not hostname-specific:
+
+- a normal Chromium process with the vendor-default user data root
+- any Chromium process with `--user-data-dir=<custom root>` and an optional `--remote-debugging-port=<port>`
+
+Inspect process command lines to identify custom roots and ports. Prefer the direct CDP extractor for a live debug service; use disk discovery for non-debug services.

--- a/scripts/extract-auth-cdp.py
+++ b/scripts/extract-auth-cdp.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Extract Robinhood web auth from a live Chromium CDP endpoint.
+
+Creates a temporary background robinhood.com target, reads web:auth_state from
+that origin, updates the target .env without exposing the token on stdout or in
+argv, and closes the target. Requires the Python `websockets` package.
+"""
+import argparse
+import asyncio
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+import websockets
+
+
+async def extract(port: int, env_path: Path) -> None:
+    version = json.load(
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/json/version", timeout=5)
+    )
+    async with websockets.connect(
+        version["webSocketDebuggerUrl"], origin=None, max_size=2**24
+    ) as ws:
+        seq = 0
+
+        async def call(method, params=None, session=None):
+            nonlocal seq
+            seq += 1
+            request_id = seq
+            msg = {"id": request_id, "method": method, "params": params or {}}
+            if session:
+                msg["sessionId"] = session
+            await ws.send(json.dumps(msg))
+            while True:
+                reply = json.loads(await ws.recv())
+                if reply.get("id") == request_id:
+                    if "error" in reply:
+                        raise RuntimeError(reply["error"])
+                    return reply["result"]
+
+        target = (
+            await call(
+                "Target.createTarget",
+                {"url": "https://robinhood.com/", "background": True},
+            )
+        )["targetId"]
+        try:
+            session = (
+                await call(
+                    "Target.attachToTarget", {"targetId": target, "flatten": True}
+                )
+            )["sessionId"]
+            await call("Runtime.enable", session=session)
+            state = ""
+            for _ in range(30):
+                await asyncio.sleep(1)
+                result = await call(
+                    "Runtime.evaluate",
+                    {
+                        "expression": (
+                            "JSON.stringify({origin:location.origin,"
+                            "state:localStorage.getItem('web:auth_state')||''})"
+                        ),
+                        "returnByValue": True,
+                    },
+                    session,
+                )
+                wrapped = json.loads(result.get("result", {}).get("value", "{}"))
+                if (
+                    wrapped.get("origin") == "https://robinhood.com"
+                    and wrapped.get("state")
+                ):
+                    state = wrapped["state"]
+                    break
+            if not state:
+                raise RuntimeError(
+                    "live debug Chromium has no web:auth_state for robinhood.com"
+                )
+            obj = json.loads(state)
+            token = obj.get("access_token")
+            if not token:
+                raise RuntimeError("web:auth_state missing access_token")
+
+            old = env_path.read_text() if env_path.exists() else ""
+            keep = [
+                line
+                for line in old.splitlines()
+                if not line.startswith("ROBINHOOD_BROKERAGE_TOKEN=")
+            ]
+            env_path.write_text(
+                "ROBINHOOD_BROKERAGE_TOKEN="
+                + token
+                + "\n"
+                + "\n".join(keep)
+                + ("\n" if keep else "")
+            )
+            os.chmod(env_path, 0o600)
+            print(f"source=cdp:{port} auth_state=yes token_written=yes")
+        finally:
+            await call("Target.closeTarget", {"targetId": target})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=9222)
+    parser.add_argument("--env", type=Path, required=True)
+    args = parser.parse_args()
+    asyncio.run(extract(args.port, args.env))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-auth.sh
+++ b/scripts/refresh-auth.sh
@@ -85,43 +85,19 @@ export EDGE_BASE
 # below; on any failure we fall through to the disk scan (headless/offline path).
 # Opt out with ROBINHOOD_NO_CDP=1.
 cdp_try() {
-    [ -n "${ROBINHOOD_NO_CDP:-}" ] && return 0
-    command -v curl >/dev/null || return 0
+    [ -n "${ROBINHOOD_NO_CDP:-}" ] && return 1
     local port="${ROBINHOOD_CDP_PORT:-9222}"
-    curl -fsS --max-time 2 "http://127.0.0.1:${port}/json/version" >/dev/null 2>&1 || return 0
-    command -v browser-harness-js >/dev/null || return 0
-    browser-harness-js --start >/dev/null 2>&1 || return 0
+    local helper="$REPO_DIR/scripts/extract-auth-cdp.py"
+    [ -f "$helper" ] || return 1
+    "$PYTHON_BIN" -c 'import websockets' >/dev/null 2>&1 || return 1
+    "$PYTHON_BIN" "$helper" --port "$port" --env "$ROBINHOOD_ENV_PATH"
+}
 
-    local payload repl_url log b64
-    repl_url="http://127.0.0.1:${CDP_REPL_PORT:-9876}"
-    log="${CDP_REPL_LOG:-/tmp/browser-harness-js.log}"
-    payload='
-try { await session.Target.getTargets(); } catch (e) {
-  const ws = (await (await fetch("http://127.0.0.1:'"${port}"'/json/version")).json()).webSocketDebuggerUrl;
-  await session.connect({wsUrl: ws, timeoutMs: 30000});
-}
-let ts = await session.Target.getTargets();
-let rh = ts.targetInfos.find(t => t.type === "page" && t.url.includes("robinhood.com"));
-let made = false;
-if (!rh) {
-  const {targetId} = await session.Target.createTarget({url: "https://robinhood.com/", background: true});
-  made = true; await new Promise(r => setTimeout(r, 6000));
-  ts = await session.Target.getTargets();
-  rh = ts.targetInfos.find(t => t.targetId === targetId);
-}
-await session.use(rh.targetId);
-const res = await session.Runtime.evaluate({expression: "localStorage.getItem(\"web:auth_state\") || \"\"", returnByValue: true});
-if (made) { try { await session.Target.closeTarget({targetId: rh.targetId}); } catch (e) {} }
-console.log("RHCDP_OUT:" + (res.result.value ? Buffer.from(res.result.value).toString("base64") : "MISSING"));
-"done"'
-    curl -fsS --max-time 60 --data-binary "$payload" "$repl_url/eval" >/dev/null 2>&1 || return 0
-    b64=$(grep 'RHCDP_OUT:' "$log" 2>/dev/null | tail -1 | sed 's/.*RHCDP_OUT://')
-    [ -z "$b64" ] || [ "$b64" = "MISSING" ] && return 0
-    RH_CDP_JSON=$(printf '%s' "$b64" | base64 -d 2>/dev/null) || return 0
-    export RH_CDP_JSON
-    echo "[refresh-auth] token read live via CDP (port ${port})"
-}
-cdp_try || true
+# Direct CDP is authoritative and already writes the protected .env. Stop here
+# on success; otherwise fall through to generic on-disk Chromium discovery.
+if cdp_try; then
+    exit 0
+fi
 
 # Python prefers RH_CDP_JSON (live) when present; else does the disk scan. It
 # writes .env, chmods it, and prints the status — so the token value never


### PR DESCRIPTION
## Summary
- replace browser-harness-dependent auth refresh with direct CDP WebSocket extraction
- create a background Robinhood origin target so no existing tab is required
- preserve LevelDB fallback and document browser/Safari verification boundaries
- never expose bearer tokens through stdout or argv

## Verification
- `pnpm test`: CLI 437/437; MCP 16 passed, 2 intentional skips
- live frostbyte CDP extraction: auth_state=yes, token_written=yes, mode 0600
- mothership custom CLI `accounts --json`: parseable non-empty response

- delilah 🌸