### PR TITLE
fix(auth): make multi-browser refresh a public CLI workflow

### DIFF
--- a/knowledge/auth-discovery.md
+++ b/knowledge/auth-discovery.md
@@ -2,23 +2,36 @@
 
 Robinhood's web client stores the primary bearer in the origin-scoped localStorage key `web:auth_state`. The token must never be printed, passed in argv, committed, or inferred from cookies.
 
+This is a normal CLI capability, not an agent-only workflow. Humans, cron jobs, CLI self-heal, MCP servers, and agents all invoke the same public entrypoint:
+
+```bash
+pnpm auth:refresh
+```
+
+The command discovers available auth sources, updates the repo `.env`, and exits nonzero when no valid source exists. Callers must then verify with a lightweight authenticated command such as `node cli/dist/index.js accounts --json`.
+
 ## Resolution order
 
-1. **Live Chromium CDP** (`ROBINHOOD_CDP_PORT`, default `9222`)
+1. **Live Chromium CDP**
+   - explicit ports: `ROBINHOOD_CDP_PORTS="9222 9333"` (or singular `ROBINHOOD_CDP_PORT`)
+   - discovered ports: `DevToolsActivePort` in standard Chrome/Brave/Edge roots and optional `ROBINHOOD_CHROMIUM_BASES` (`os.pathsep`-delimited)
+   - conventional fallback: `9222`
    - `scripts/extract-auth-cdp.py` connects directly to the browser WebSocket
    - creates a background `https://robinhood.com/` target
    - reads `localStorage.web:auth_state` from the correct origin
    - updates `.env` in-process and closes the target
-   - does not depend on an already-open Robinhood tab, Node, browser-harness, or a GUI interaction
+   - does not depend on an already-open Robinhood tab, Node, browser-harness, an agent, or a GUI interaction
+   - Python requirement: `python -m pip install websockets`; if unavailable, the command explains the dependency and continues to disk fallback
 2. **On-disk Chromium LevelDB**
    - Chrome, Brave, and Edge standard profile roots
    - useful when a browser has flushed a complete auth object to disk
-   - custom `--user-data-dir` profiles should use CDP or be supplied as an additional root
+   - custom roots can be supplied through `ROBINHOOD_CHROMIUM_BASES`
 3. **Safari capability detection**
    - Safari stores origin data under sandboxed WebKit `WebsiteDataStore` directories
    - cache strings such as `access_token` are not proof of Robinhood auth
    - only use Safari when the `robinhood.com` origin can be mapped to an actual `web:auth_state` record or Safari remote automation provides origin-scoped JavaScript execution
    - never treat generic NetworkCache matches as credentials
+
 
 ## Verification contract
 

--- a/scripts/extract-auth-cdp.py
+++ b/scripts/extract-auth-cdp.py
@@ -9,6 +9,7 @@ import argparse
 import asyncio
 import json
 import os
+import sys
 import urllib.request
 from pathlib import Path
 
@@ -106,7 +107,11 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=9222)
     parser.add_argument("--env", type=Path, required=True)
     args = parser.parse_args()
-    asyncio.run(extract(args.port, args.env))
+    try:
+        asyncio.run(extract(args.port, args.env))
+    except Exception as exc:
+        print(f"source=cdp:{args.port} unavailable={type(exc).__name__}", file=sys.stderr)
+        raise SystemExit(2) from None
 
 
 if __name__ == "__main__":

--- a/scripts/refresh-auth.sh
+++ b/scripts/refresh-auth.sh
@@ -86,11 +86,43 @@ export EDGE_BASE
 # Opt out with ROBINHOOD_NO_CDP=1.
 cdp_try() {
     [ -n "${ROBINHOOD_NO_CDP:-}" ] && return 1
-    local port="${ROBINHOOD_CDP_PORT:-9222}"
     local helper="$REPO_DIR/scripts/extract-auth-cdp.py"
     [ -f "$helper" ] || return 1
-    "$PYTHON_BIN" -c 'import websockets' >/dev/null 2>&1 || return 1
-    "$PYTHON_BIN" "$helper" --port "$port" --env "$ROBINHOOD_ENV_PATH"
+    "$PYTHON_BIN" -c 'import websockets' >/dev/null 2>&1 || {
+        echo "[refresh-auth] CDP support unavailable: install with '$PYTHON_BIN -m pip install websockets'; trying disk fallback" >&2
+        return 1
+    }
+
+    local configured="${ROBINHOOD_CDP_PORTS:-${ROBINHOOD_CDP_PORT:-}}"
+    local discovered
+    discovered=$(CHROMIUM_BASES="${ROBINHOOD_CHROMIUM_BASES:-}" "$PYTHON_BIN" <<'PYPORTS'
+import os
+roots = [os.environ.get(k) for k in ("CHROME_BASE", "BRAVE_BASE", "EDGE_BASE")]
+roots += [p for p in os.environ.get("CHROMIUM_BASES", "").split(os.pathsep) if p]
+seen = set()
+for root in filter(None, roots):
+    for path in (os.path.join(root, "DevToolsActivePort"),):
+        try:
+            port = int(open(path, encoding="utf-8").readline().strip())
+        except (OSError, ValueError):
+            continue
+        if port not in seen:
+            seen.add(port)
+            print(port)
+PYPORTS
+)
+
+    local ports="$configured $discovered 9222"
+    local tried=" " port
+    for port in $ports; do
+        case "$port" in *[!0-9]*|'') continue ;; esac
+        case "$tried" in *" $port "*) continue ;; esac
+        tried="$tried$port "
+        if "$PYTHON_BIN" "$helper" --port "$port" --env "$ROBINHOOD_ENV_PATH"; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 # Direct CDP is authoritative and already writes the protected .env. Stop here


### PR DESCRIPTION
## Summary
- make `pnpm auth:refresh` the shared human/cron/CLI/MCP/agent contract
- discover explicit, active-profile, and conventional CDP ports with fallback
- keep expected failed probes concise instead of emitting tracebacks
- document custom Chromium roots, dependency setup, and Safari proof boundaries

## Verification
- public `pnpm auth:refresh` entrypoint tested in a clean temporary package on frostbyte
- auto-discovery rejected stale port and succeeded through live `:9222`
- protected `.env` mode 0600 with non-empty token
- CLI 437/437 tests passed; MCP 16 passed, 2 intentional skips

- delilah 🌸