### PR TITLE
feat(auth): add token-safe Safari WebKit fallback

### DIFF
--- a/knowledge/auth-discovery.md
+++ b/knowledge/auth-discovery.md
@@ -22,15 +22,16 @@ The command discovers available auth sources, updates the repo `.env`, and exits
    - updates `.env` in-process and closes the target
    - does not depend on an already-open Robinhood tab, Node, browser-harness, an agent, or a GUI interaction
    - Python requirement: `python -m pip install websockets`; if unavailable, the command explains the dependency and continues to disk fallback
-2. **On-disk Chromium LevelDB**
+2. **Safari WebKit LocalStorage** (macOS, stdlib-only)
+   - `scripts/extract-auth-safari.py` scans Safari's sandboxed WebKit `WebsiteDataStore` directories
+   - requires origin metadata containing both `https` and `robinhood.com`
+   - reads only `ItemTable['web:auth_state']` from `LocalStorage/localstorage.sqlite3`
+   - updates `.env` in-process at mode `0600`; the value never appears on stdout or argv
+   - generic NetworkCache strings such as `access_token` are never treated as credentials
+3. **On-disk Chromium LevelDB fallback**
    - Chrome, Brave, and Edge standard profile roots
    - useful when a browser has flushed a complete auth object to disk
    - custom roots can be supplied through `ROBINHOOD_CHROMIUM_BASES`
-3. **Safari capability detection**
-   - Safari stores origin data under sandboxed WebKit `WebsiteDataStore` directories
-   - cache strings such as `access_token` are not proof of Robinhood auth
-   - only use Safari when the `robinhood.com` origin can be mapped to an actual `web:auth_state` record or Safari remote automation provides origin-scoped JavaScript execution
-   - never treat generic NetworkCache matches as credentials
 
 
 ## Verification contract
@@ -43,7 +44,7 @@ A refresh is successful only when all three are true:
 
 Exit status or file existence alone is not success.
 
-## Frostbyte services discovered
+## Browser services and custom profiles
 
 The generic pattern is process-derived, not hostname-specific:
 

--- a/scripts/extract-auth-safari.py
+++ b/scripts/extract-auth-safari.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Extract Robinhood auth from Safari's origin-scoped WebKit LocalStorage.
+
+Uses only Python stdlib. It requires an origin metadata file containing both
+`https` and `robinhood.com`, reads only ItemTable['web:auth_state'], and writes
+the bearer directly to the target .env without exposing it on stdout or argv.
+"""
+import argparse
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+
+def is_robinhood_origin(db_path: Path) -> bool:
+    origin_path = db_path.parent.parent / "origin"
+    try:
+        raw = origin_path.read_bytes().lower()
+    except OSError:
+        return False
+    return b"https" in raw and b"robinhood.com" in raw
+
+
+def candidate_databases() -> list[Path]:
+    root = (
+        Path.home()
+        / "Library"
+        / "Containers"
+        / "com.apple.Safari"
+        / "Data"
+        / "Library"
+        / "WebKit"
+    )
+    if not root.is_dir():
+        return []
+    return sorted(
+        root.glob("**/LocalStorage/localstorage.sqlite3"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+
+
+def read_auth_state(db_path: Path) -> dict | None:
+    if not is_robinhood_origin(db_path):
+        return None
+    connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        row = connection.execute(
+            "SELECT value FROM ItemTable WHERE key = ? LIMIT 1",
+            ("web:auth_state",),
+        ).fetchone()
+    finally:
+        connection.close()
+    if not row:
+        return None
+    value = row[0]
+    candidates: list[str] = []
+    if isinstance(value, bytes):
+        for encoding in ("utf-8", "utf-16le"):
+            try:
+                candidates.append(value.decode(encoding))
+            except UnicodeDecodeError:
+                continue
+    elif isinstance(value, str):
+        candidates.append(value)
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def write_token(env_path: Path, token: str) -> None:
+    old = env_path.read_text() if env_path.exists() else ""
+    keep = [
+        line
+        for line in old.splitlines()
+        if not line.startswith("ROBINHOOD_BROKERAGE_TOKEN=")
+    ]
+    env_path.write_text(
+        "ROBINHOOD_BROKERAGE_TOKEN="
+        + token
+        + "\n"
+        + "\n".join(keep)
+        + ("\n" if keep else "")
+    )
+    os.chmod(env_path, 0o600)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", type=Path, required=True)
+    args = parser.parse_args()
+    for database in candidate_databases():
+        state = read_auth_state(database)
+        token = state.get("access_token") if state else None
+        if token:
+            write_token(args.env, str(token))
+            print("source=safari auth_state=yes token_written=yes")
+            return
+    print("source=safari unavailable=no_origin_scoped_auth_state", file=os.sys.stderr)
+    raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-auth.sh
+++ b/scripts/refresh-auth.sh
@@ -126,10 +126,18 @@ PYPORTS
 }
 
 # Direct CDP is authoritative and already writes the protected .env. Stop here
-# on success; otherwise fall through to generic on-disk Chromium discovery.
+# on success. Safari is a macOS-only, stdlib fallback that validates the
+# robinhood.com WebKit origin before reading the exact web:auth_state key.
 if cdp_try; then
     exit 0
 fi
+if [ "$(uname -s)" = "Darwin" ] && [ -f "$REPO_DIR/scripts/extract-auth-safari.py" ]; then
+    if "$PYTHON_BIN" "$REPO_DIR/scripts/extract-auth-safari.py" --env "$ROBINHOOD_ENV_PATH"; then
+        exit 0
+    fi
+fi
+
+# Final fallback: generic on-disk Chromium discovery.
 
 # Python prefers RH_CDP_JSON (live) when present; else does the disk scan. It
 # writes .env, chmods it, and prints the status — so the token value never


### PR DESCRIPTION
## Summary
- add stdlib-only Safari WebKit LocalStorage auth extraction
- require origin metadata for `https://robinhood.com`
- read only `ItemTable[web:auth_state]` and write `.env` in-process at 0600
- wire Safari between direct CDP and Chromium LevelDB fallback
- remove machine-specific documentation

## Live verification
- forced `ROBINHOOD_NO_CDP=1 pnpm auth:refresh` on macOS
- `source=safari auth_state=yes token_written=yes`
- live custom CLI accounts response parseable and non-empty
- CLI 437/437 tests passed; MCP 16 passed, 2 intentional skips

## Safety
- intended-file regex scan: zero JWTs, bearers, cookies, secret assignments, opaque blobs, private paths, hostnames, or private IPs
- full Git history gitleaks scan: 196 commits, no leaks
- no `.env`, token, cookie, or Safari database is tracked

- delilah 🌸