### PR TITLE
fix(auth): verify durable Robinhood session lifetime

### DIFF
--- a/knowledge/auth-discovery.md
+++ b/knowledge/auth-discovery.md
@@ -44,6 +44,17 @@ A refresh is successful only when all three are true:
 
 Exit status or file existence alone is not success.
 
+## Thirty-day session control
+
+Robinhood's login UI can mint a durable 30-day session when the user selects **stay logged in for 30 days**. A live Safari session verified on 2026-08-01 contained:
+
+- `web:auth_state.access_token` and `read_only_secondary_access_token` with matching 30-day JWT expiry
+- an opaque `refresh_token` in the same origin-scoped auth object
+- long-lived `device_id` and `logged_in` cookies
+- a short-lived `session_id` cookie that is not the durable bearer
+
+`pnpm auth:refresh` does not click or emulate this consent control. It preserves the user's choice by extracting the server-minted `web:auth_state` from the selected browser. Successful extractors report `session_remaining_days` and `token_expires_utc` without printing token contents. If the reported remaining duration is substantially shorter than 30 days immediately after login, the user must select the 30-day option during Robinhood login; the CLI must not silently extend consent or manufacture a longer session.
+
 ## Browser services and custom profiles
 
 The generic pattern is process-derived, not hostname-specific:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:api-map": "node scripts/test-cdp-capture.mjs",
     "test:skill": "python3 scripts/check-skill-integrity.py",
     "generate:api-map": "node scripts/generate-brokerage-openapi.mjs && node scripts/generate-unified-api-map.mjs && node scripts/generate-brokerage-markdown.mjs && node scripts/generate-brokerage-curl.mjs && node scripts/generate-endpoint-markdown.mjs",
-    "test": "corepack pnpm build && corepack pnpm test:built",
+    "test": "corepack pnpm build && corepack pnpm test:built && node scripts/test-auth-session.mjs",
     "test:built": "corepack pnpm --filter @zaydiscold/robinhood-cli exec vitest run && corepack pnpm --filter @zaydiscold/robinhood-cli-mcp exec vitest run",
     "coverage": "corepack pnpm build && corepack pnpm coverage:built",
     "coverage:built": "corepack pnpm --filter @zaydiscold/robinhood-cli test:coverage && corepack pnpm --filter @zaydiscold/robinhood-cli-mcp test:coverage",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,7 @@
     "format:check": "node scripts/check-format-ratchet.mjs",
     "deadcode": "knip --dependencies --reporter compact --no-progress"
   },
-  "pnpm": {
-    "overrides": {
-      "esbuild": "0.28.1",
-      "vite": "8.1.4",
-      "hono": "4.12.25"
-    }
-  },
+
   "devDependencies": {
     "@types/node": "^25.9.1",
     "@typescript-eslint/eslint-plugin": "^8.64.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   esbuild: 0.28.1
   vite: 8.1.4
   hono: 4.12.25
+  fast-uri: 3.1.4
+  brace-expansion: 5.0.8
 
 importers:
 
@@ -827,9 +829,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1020,8 +1022,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -2312,7 +2314,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2340,7 +2342,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2570,7 +2572,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fd-package-json@2.0.0:
     dependencies:
@@ -2829,7 +2831,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.8
 
   ms@2.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,12 @@ packages:
   - cli
   - mcp
 
+overrides:
+  esbuild: 0.28.1
+  vite: 8.1.4
+  hono: 4.12.25
+  fast-uri: 3.1.4
+  brace-expansion: 5.0.8
+
 ignoredBuiltDependencies:
   - esbuild

--- a/scripts/auth_session.py
+++ b/scripts/auth_session.py
@@ -1,0 +1,25 @@
+"""Token-safe access-token session metadata."""
+import base64
+import json
+from datetime import datetime, timezone
+from time import time
+from typing import Optional
+
+
+def describe_session_token(token: str, *, now: Optional[float] = None) -> dict[str, object]:
+    """Return expiry and lifetime metadata without returning the token or claims."""
+    if token.count(".") != 2:
+        return {}
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * ((4 - len(payload) % 4) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        expires = int(claims["exp"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return {
+        "session_remaining_days": round((expires - (time() if now is None else now)) / 86400, 2),
+        "token_expires_utc": datetime.fromtimestamp(
+            expires, timezone.utc
+        ).isoformat(),
+    }

--- a/scripts/extract-auth-cdp.py
+++ b/scripts/extract-auth-cdp.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import websockets
 
+from auth_session import describe_session_token
+
 
 async def extract(port: int, env_path: Path) -> None:
     version = json.load(
@@ -97,7 +99,12 @@ async def extract(port: int, env_path: Path) -> None:
                 + ("\n" if keep else "")
             )
             os.chmod(env_path, 0o600)
-            print(f"source=cdp:{port} auth_state=yes token_written=yes")
+            metadata = describe_session_token(token)
+            suffix = " ".join(f"{key}={value}" for key, value in metadata.items())
+            print(
+                f"source=cdp:{port} auth_state=yes token_written=yes"
+                + (f" {suffix}" if suffix else "")
+            )
         finally:
             await call("Target.closeTarget", {"targetId": target})
 

--- a/scripts/extract-auth-safari.py
+++ b/scripts/extract-auth-safari.py
@@ -10,6 +10,9 @@ import json
 import os
 import sqlite3
 from pathlib import Path
+from typing import Optional
+
+from auth_session import describe_session_token
 
 
 def is_robinhood_origin(db_path: Path) -> bool:
@@ -40,7 +43,7 @@ def candidate_databases() -> list[Path]:
     )
 
 
-def read_auth_state(db_path: Path) -> dict | None:
+def read_auth_state(db_path: Path) -> Optional[dict]:
     if not is_robinhood_origin(db_path):
         return None
     connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
@@ -99,7 +102,12 @@ def main() -> None:
         token = state.get("access_token") if state else None
         if token:
             write_token(args.env, str(token))
-            print("source=safari auth_state=yes token_written=yes")
+            metadata = describe_session_token(str(token))
+            suffix = " ".join(f"{key}={value}" for key, value in metadata.items())
+            print(
+                "source=safari auth_state=yes token_written=yes"
+                + (f" {suffix}" if suffix else "")
+            )
             return
     print("source=safari unavailable=no_origin_scoped_auth_state", file=os.sys.stderr)
     raise SystemExit(2)

--- a/scripts/test-auth-session.mjs
+++ b/scripts/test-auth-session.mjs
@@ -1,0 +1,11 @@
+import { spawnSync } from "node:child_process";
+
+const candidates = process.platform === "win32" ? ["python", "py"] : ["python3", "python"];
+for (const candidate of candidates) {
+  const args = candidate === "py" ? ["-3", "scripts/test_auth_session.py"] : ["scripts/test_auth_session.py"];
+  const result = spawnSync(candidate, args, { stdio: "inherit" });
+  if (result.error && result.error.code === "ENOENT") continue;
+  process.exit(result.status ?? 1);
+}
+console.error("No Python 3 interpreter found (tried: " + candidates.join(", ") + ")");
+process.exit(1);

--- a/scripts/test_auth_session.py
+++ b/scripts/test_auth_session.py
@@ -1,0 +1,31 @@
+import base64
+import json
+import unittest
+from datetime import datetime, timezone
+
+from auth_session import describe_session_token
+
+
+def segment(value: dict) -> str:
+    raw = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+class SessionMetadataTest(unittest.TestCase):
+    def test_reports_expiry_and_thirty_days_remaining_without_token(self) -> None:
+        now = 1_800_000_000
+        token = f"{segment({'alg': 'none'})}.{segment({'exp': now + 30 * 86400})}.x"
+        metadata = describe_session_token(token, now=now)
+        self.assertEqual(metadata["session_remaining_days"], 30)
+        self.assertEqual(
+            metadata["token_expires_utc"],
+            datetime.fromtimestamp(now + 30 * 86400, timezone.utc).isoformat(),
+        )
+        self.assertNotIn(token, json.dumps(metadata))
+
+    def test_returns_unknown_for_opaque_refresh_token(self) -> None:
+        self.assertEqual(describe_session_token("opaque-token"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- report token expiry and remaining session days without exposing token contents
- support Python 3.9 Safari extraction on frostbyte
- run deterministic auth-session tests through a cross-platform launcher
- document the 30-day Robinhood login control and durable session behavior

## Verification
- `pnpm test`: CLI 437/437; MCP 16 passed, 2 intentional skips; Python 2/2
- live Safari extraction on frostbyte: ~29.93 days remaining, expiry 2026-08-31T17:42:27Z
- staged diff: Gitleaks no leaks

- delilah 🌸