### PR TITLE
fix(options): honor order-flow request contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ One line per question. All reads are live and free; the order/settings commands 
 | `options events [--account N]` | "What expirations, assignments, or exercises happened?" — canonical nested path; legacy `options-events` stays supported |
 | `options history <CONTRACT_UUID>` | "What were this contract's historical OHLC, volume, and session points?" — interval `5minute|10minute|hour`, span `day|week`, bounded to 1–500 points |
 | `options chain-stats <SYM>` | "What are ATM IV and expected move for each expiration?" — each row is expiration-specific and expected move is dollars |
+| `options order-flow --account N [--legs-json A] [--order-json O]` | Read-only buying power plus order-specific fee/collateral quote; JSON request models are query-serialized exactly like the web app, missing drafts are skipped, and optional chain collateral is labeled supplemental |
 | `options strategy-quote <id> ...` | "Price this spread/condor/CSP and build the exact dry-run order body" |
 | `wheel [SYM]` | "Where am I in the Wheel, and what's the next leg?" — evidence-based stage + the literal next command |
 | `dividends [--upcoming]` | "How much dividend income am I making — $/day · $/wk · $/mo · $/qtr · $/yr — and what's about to pay?" |

--- a/api-map/recipes.json
+++ b/api-map/recipes.json
@@ -286,7 +286,7 @@
     },
     {
       "id": "options-order-flow",
-      "intent": "Pre-trade options context: buying power, fees, collateral",
+      "intent": "Read-only options order context: account buying power plus order-specific fees and collateral",
       "triggers": [
         "options buying power",
         "options fees",
@@ -294,10 +294,10 @@
         "can I afford this option",
         "pre-trade options"
       ],
-      "command": "options order-flow --account <N> [--chain-id <id>]",
+      "command": "options order-flow --account <N> [--chain-id <id>] [--legs-json '<array>'] [--order-json '<object>']",
       "mcpTool": "robinhood_options_order_flow",
       "risk": "sensitive-read",
-      "notes": "Options buying power is the REAL gate on opens (not regular BP, esp. GTC overnight). The options/orders/review preview is a gated POST until verified non-mutating."
+      "notes": "Options buying power is the real per-account gate on opens. Fees require prospective legs serialized as JSON in the legs query field; exact collateral requires the complete prospective order serialized in the order query field. chain-id adds supplemental chain context only. Missing drafts are skipped locally—never sent as malformed naked GETs. This command never reviews or submits the order."
     },
     {
       "id": "place-option-order",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1572,12 +1572,24 @@ options
 
 options
   .command("order-flow")
-  .description("Pre-trade options context (live reads): options buying power (per account), the fee schedule, and collateral requirements")
+  .description("Read-only pre-trade options context: account buying power plus order-specific fees/collateral when prospective legs/order JSON are supplied")
   .option("--account <account_number>", "account for options buying power (per-account)")
-  .option("--chain-id <chain_id>", "chain id for chain-level collateral (else order-level collateral)")
+  .option("--chain-id <chain_id>", "optional supplemental chain-level collateral context")
+  .option("--legs-json <json>", "prospective option legs JSON array for an order-specific fee quote")
+  .option("--order-json <json>", "complete prospective options order JSON object for order-specific collateral")
   .option("--json", "emit JSON")
-  .action(async (opts: { account?: string; chainId?: string; json?: boolean }) => {
-    const flow = await readOptionsOrderFlow({ accountNumber: opts.account, chainId: opts.chainId });
+  .action(async (opts: { account?: string; chainId?: string; legsJson?: string; orderJson?: string; json?: boolean }) => {
+    const legs = opts.legsJson ? JSON.parse(opts.legsJson) : undefined;
+    const order = opts.orderJson ? JSON.parse(opts.orderJson) : undefined;
+    if (legs != null && !Array.isArray(legs)) throw new Error("--legs-json must decode to an array.");
+    if (order != null && (Array.isArray(order) || typeof order !== "object"))
+      throw new Error("--order-json must decode to an object.");
+    const flow = await readOptionsOrderFlow({
+      accountNumber: opts.account,
+      chainId: opts.chainId,
+      legs,
+      order,
+    });
     if (opts.json) {
       printJson(flow);
       return;
@@ -1586,15 +1598,13 @@ options
       const bp = flow.buyingPower;
       process.stdout.write(`Options buying power (…${String(opts.account).slice(-4)}): ${usd(num(bp.options_buying_power ?? bp.buying_power ?? bp.amount))}\n`);
     }
-    if (flow.fees) {
-      const f = flow.fees;
-      process.stdout.write(`Options fees: ${JSON.stringify(f).slice(0, 200)}\n`);
-    }
-    if (flow.collateral) {
-      process.stdout.write(`Collateral: ${JSON.stringify(flow.collateral).slice(0, 200)}\n`);
-    }
+    if (flow.fees) process.stdout.write(`Order-specific options fees: ${JSON.stringify(flow.fees).slice(0, 200)}\n`);
+    if (flow.collateral)
+      process.stdout.write(`Order-specific collateral: ${JSON.stringify(flow.collateral).slice(0, 200)}\n`);
+    if (flow.chainCollateral)
+      process.stdout.write(`Supplemental chain collateral: ${JSON.stringify(flow.chainCollateral).slice(0, 200)}\n`);
     for (const w of flow.warnings) process.stderr.write(`warning: ${w}\n`);
-    process.stdout.write(`\nNote: the options/orders/review PREVIEW is a POST — run it via \`brokerage execute "options/orders/review" --method POST\` (gated) until a live pass confirms it is non-mutating.\n`);
+    process.stdout.write(`\nRead-only context only: this command never reviews or submits the prospective order.\n`);
   });
 
 options
@@ -3087,20 +3097,26 @@ const documents = new Command("documents").description(
 
 documents
   .command("list")
-  .description("List documents (newest first) with type, date, tax/statement year, account, and download URL. --type is prefix-matched (1099 catches 1099_crypto + 1099r_roth); --year is the tax year for tax forms, calendar year otherwise.")
+  .description("List documents (newest first) with type, date, tax/statement year, account, and download URL. --type is prefix-matched (1099 catches 1099_crypto + 1099r_roth); --year is the tax year for tax forms, calendar year otherwise. Use --limit for a bounded newest-first page.")
   .option("--type <type>", "1099 | 1099_crypto | 1099r_roth | 5498_roth | account_statement | trade_confirm (prefix match)")
   .option("--year <yyyy>", "tax year for tax forms; calendar year for statements/confirms")
   .option("--account <number>", "scope to one account")
+  .option("--limit <n>", "return at most N matching documents (newest first)", "100")
   .option("--json", "emit JSON")
-  .action(async (opts: { type?: string; year?: string; account?: string; json?: boolean }) => {
-    const r = await listDocuments({ type: opts.type, year: opts.year, accountNumber: opts.account });
+  .action(async (opts: { type?: string; year?: string; account?: string; limit?: string; json?: boolean }) => {
+    const r = await listDocuments({
+      type: opts.type,
+      year: opts.year,
+      accountNumber: opts.account,
+      limit: Number(opts.limit ?? "100"),
+    });
     if (opts.json) { printJson(r); return; }
     if (!r.count) { process.stdout.write("No documents match those filters.\n"); return; }
     printTable(
       r.documents.map((d) => ({ date: d.date, year: d.year, type: d.type, acct: `…${d.accountLast4}`, file: d.filetype })),
       ["date", "year", "type", "acct", "file"]
     );
-    process.stdout.write(`\n${r.count} document(s): ${Object.entries(r.byType).map(([t, c]) => `${t}×${c}`).join(", ")}.\n`);
+    process.stdout.write(`\nShowing ${r.count} of ${r.total} matching document(s): ${Object.entries(r.byType).map(([t, c]) => `${t}×${c}`).join(", ")}${r.hasMore ? " — raise --limit for more" : ""}.\n`);
     process.stdout.write("Download with: documents download [--type T] [--year YYYY] [--account N] [--limit N]\n");
   });
 

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -3498,11 +3498,19 @@ export interface OptionsOrderFlow {
   accountNumber?: string;
   buyingPower?: any;
   fees?: any;
+  /** Order-specific collateral derived from a complete prospective order draft. */
   collateral?: any;
+  /** Supplemental chain-level context; never a substitute for order-specific collateral. */
+  chainCollateral?: unknown;
   warnings: string[];
 }
 export async function readOptionsOrderFlow(
-  opts: { accountNumber?: string; chainId?: string } = {},
+  opts: {
+    accountNumber?: string;
+    chainId?: string;
+    legs?: Array<Record<string, unknown>>;
+    order?: Record<string, unknown>;
+  } = {},
   deps: { getJson?: typeof brokerageGetJson } = {},
 ): Promise<OptionsOrderFlow> {
   const getJson = deps.getJson ?? brokerageGetJson;
@@ -3519,19 +3527,41 @@ export async function readOptionsOrderFlow(
   } else {
     out.warnings.push("no --account given: options buying power is per-account and was skipped.");
   }
-  try {
-    out.fees = await getJson("https://api.robinhood.com/options/fees/");
-  } catch (e: any) {
-    out.warnings.push(`options fees read failed: ${(e as Error).message.slice(0, 60)}`);
+  if (opts.legs) {
+    try {
+      out.fees = await getJson(
+        "https://api.robinhood.com/options/fees/",
+        {},
+        { legs: JSON.stringify(opts.legs) },
+      );
+    } catch (e: unknown) {
+      out.warnings.push(`options fees read failed: ${(e as Error).message.slice(0, 60)}`);
+    }
+  } else {
+    out.warnings.push("no prospective legs given: order-specific options fees were skipped.");
   }
-  try {
-    out.collateral = opts.chainId
-      ? await getJson("https://api.robinhood.com/options/chains/{id}/collateral/", {
-          id: opts.chainId,
-        })
-      : await getJson("https://api.robinhood.com/options/orders/collateral/");
-  } catch (e: any) {
-    out.warnings.push(`options collateral read failed: ${(e as Error).message.slice(0, 60)}`);
+  if (opts.order) {
+    try {
+      out.collateral = await getJson(
+        "https://api.robinhood.com/options/orders/collateral/",
+        {},
+        { order: JSON.stringify(opts.order) },
+      );
+    } catch (e: unknown) {
+      out.warnings.push(`options collateral read failed: ${(e as Error).message.slice(0, 60)}`);
+    }
+  } else {
+    out.warnings.push("no prospective order given: order-specific options collateral was skipped.");
+  }
+  if (opts.chainId) {
+    try {
+      out.chainCollateral = await getJson(
+        "https://api.robinhood.com/options/chains/{id}/collateral/",
+        { id: opts.chainId },
+      );
+    } catch (e: unknown) {
+      out.warnings.push(`chain collateral context read failed: ${(e as Error).message.slice(0, 60)}`);
+    }
   }
   return out;
 }
@@ -5500,7 +5530,8 @@ export async function runPretradeChecks(
     }
   }
 
-  // (c) options buying power / fees / collateral — shared pre-trade reads, each degrades inside.
+  // (c) options buying power + supplemental chain collateral. Order-specific fee/collateral
+  // reads require prospective legs/full order inputs and are therefore performed by options order-flow.
   try {
     const flow = await readOptionsOrderFlow({ accountNumber: acct, chainId }, { getJson });
     const obp = n(
@@ -5517,14 +5548,13 @@ export async function runPretradeChecks(
     });
     checks.push({
       id: "collateral",
-      status: flow.collateral ? "PASS" : chainId ? "WARN" : "SKIP",
-      detail: flow.collateral
-        ? `Collateral requirements read OK${chainId ? ` for chain ${chainId}` : " (account-level)"} — covered calls need 100 shares/contract in the SAME account; CSPs need the cash.`
+      status: flow.chainCollateral ? "PASS" : chainId ? "WARN" : "SKIP",
+      detail: flow.chainCollateral
+        ? `Supplemental chain collateral read OK for chain ${chainId}. Exact collateral still requires the complete prospective order; covered calls need 100 shares/contract in the SAME account and CSPs need the cash.`
         : chainId
-          ? `collateral read failed: ${flow.warnings.join("; ").slice(0, 100)}`
-          : "no --symbol/--chain-id given; per-chain collateral skipped.",
+          ? `supplemental chain collateral read failed: ${flow.warnings.join("; ").slice(0, 100)}`
+          : "no --symbol/--chain-id given; supplemental chain collateral skipped.",
     });
-    if (flow.fees) resolved.feesRead = true;
   } catch (e: any) {
     checks.push({
       id: "options-buying-power",
@@ -6618,10 +6648,12 @@ export function documentFilename(doc: {
  *   - accountNumber is exact.
  */
 export async function listDocuments(
-  opts: { type?: string; year?: string; accountNumber?: string } = {},
+  opts: { type?: string; year?: string; accountNumber?: string; limit?: number } = {},
   deps: { getAll?: typeof brokerageGetAllResults } = {},
 ): Promise<{
+  total: number;
   count: number;
+  hasMore: boolean;
   documents: DocumentRecord[];
   byType: Record<string, number>;
   warnings: string[];
@@ -6652,9 +6684,19 @@ export async function listDocuments(
         (!opts.accountNumber || d.accountNumber === String(opts.accountNumber)),
     )
     .sort((a: DocumentRecord, b: DocumentRecord) => b.date.localeCompare(a.date));
+  const total = documents.length;
+  const limit = Number.isFinite(opts.limit) && Number(opts.limit) > 0 ? Math.floor(Number(opts.limit)) : total;
+  const boundedDocuments = documents.slice(0, limit);
   const byType: Record<string, number> = {};
-  for (const d of documents) byType[d.type] = (byType[d.type] ?? 0) + 1;
-  return { count: documents.length, documents, byType, warnings: [] };
+  for (const d of boundedDocuments) byType[d.type] = (byType[d.type] ?? 0) + 1;
+  return {
+    total,
+    count: boundedDocuments.length,
+    hasMore: boundedDocuments.length < total,
+    documents: boundedDocuments,
+    byType,
+    warnings: [],
+  };
 }
 
 /**
@@ -6676,7 +6718,10 @@ export async function downloadDocuments(
   skipped: number;
 }> {
   const fetchImpl = deps.fetchImpl ?? fetch;
-  const listing = await listDocuments(opts, deps);
+  const listing = await listDocuments(
+    { type: opts.type, year: opts.year, accountNumber: opts.accountNumber },
+    deps,
+  );
   const docs =
     opts.limit && opts.limit > 0 ? listing.documents.slice(0, opts.limit) : listing.documents;
   const directory = deps.outDir ?? join(repoRoot(), "local", "documents");

--- a/cli/test/dividends-documents-margin.test.ts
+++ b/cli/test/dividends-documents-margin.test.ts
@@ -245,6 +245,15 @@ describe("listDocuments — prefix type filter, tax-year filter, account filter"
     const all = await listDocuments({}, deps);
     expect(all.documents[0].id).toBe("d1");  // 2026-02-11 sorts first
   });
+
+  it("bounds the returned document inventory after filtering and preserves the full matching total", async () => {
+    const r = await listDocuments({ type: "1099", limit: 2 }, deps);
+    expect(r.total).toBe(4);
+    expect(r.count).toBe(2);
+    expect(r.documents.map((d) => d.id)).toEqual(["d1", "d2"]);
+    expect(r.hasMore).toBe(true);
+    expect(r.byType).toEqual({ "1099": 1, "1099_crypto": 1 });
+  });
 });
 
 // ── documents: the bearer must never leave the Robinhood allow-list ─────────────────────────────

--- a/cli/test/options-order-flow.test.ts
+++ b/cli/test/options-order-flow.test.ts
@@ -1,49 +1,108 @@
 import { describe, expect, it } from "vitest";
 import { readOptionsOrderFlow } from "../src/lib.js";
 
-// T5: options order-flow reads (buying power / fees / collateral) composed into one pre-trade context,
-// each degrading independently so one failure never blanks the rest.
+// Options order-flow reads are strictly non-ordering. Fee and collateral models require
+// prospective-order context serialized as JSON inside query fields; a naked GET is malformed.
 
-function deps(fix: { bp?: any; fees?: any; collateral?: any; throwOn?: string[] }) {
-  const getJson = async (url: string) => {
+function deps(fix: { bp?: any; fees?: any; collateral?: any; chainCollateral?: any; throwOn?: string[] }) {
+  const calls: Array<{ url: string; params: Record<string, string>; query: Record<string, string> }> = [];
+  const getJson = async (
+    url: string,
+    params: Record<string, string> = {},
+    query: Record<string, string> = {},
+  ) => {
+    calls.push({ url, params, query });
     const fail = (k: string) => fix.throwOn?.includes(k);
     if (url.includes("options_buying_power")) { if (fail("bp")) throw new Error("503"); return fix.bp; }
     if (url.includes("options/fees")) { if (fail("fees")) throw new Error("503"); return fix.fees; }
-    if (url.includes("collateral")) { if (fail("collateral")) throw new Error("503"); return fix.collateral; }
+    if (url.includes("options/orders/collateral")) { if (fail("collateral")) throw new Error("503"); return fix.collateral; }
+    if (url.includes("options/chains/") && url.includes("collateral")) {
+      if (fail("chainCollateral")) throw new Error("503");
+      return fix.chainCollateral;
+    }
     throw new Error("unexpected " + url);
   };
-  return { getJson };
+  return { getJson, calls };
 }
 
-const base = { bp: { options_buying_power: "1234.56" }, fees: { regulatory_fees: "0.03" }, collateral: { collateral: [] } };
+const legs = [
+  {
+    option: "https://api.robinhood.com/options/instruments/option-1/",
+    side: "buy",
+    position_effect: "open",
+    ratio_quantity: 1,
+  },
+];
+const order = {
+  account: "https://api.robinhood.com/accounts/account-1/",
+  direction: "debit",
+  legs,
+  price: "1.00",
+  quantity: "1",
+  time_in_force: "gfd",
+  trigger: "immediate",
+  type: "limit",
+};
+const base = {
+  bp: { options_buying_power: "1234.56" },
+  fees: { regulatory_fees: "0.03" },
+  collateral: { collateral: [] },
+  chainCollateral: { collateral: [] },
+};
 
 describe("readOptionsOrderFlow", () => {
-  it("composes buying power + fees + collateral when an account is given", async () => {
-    const r = await readOptionsOrderFlow({ accountNumber: "111" }, deps(base));
+  it("composes buying power, order-specific fees, and order-specific collateral", async () => {
+    const d = deps(base);
+    const r = await readOptionsOrderFlow({ accountNumber: "111", legs, order }, d);
     expect(r.buyingPower.options_buying_power).toBe("1234.56");
     expect(r.fees).toBeTruthy();
     expect(r.collateral).toBeTruthy();
     expect(r.warnings).toEqual([]);
   });
 
-  it("uses chain-level collateral when chainId is given (else order-level)", async () => {
-    let seen = "";
-    const probe = { getJson: async (url: string) => { if (url.includes("collateral")) seen = url; return {}; } };
-    await readOptionsOrderFlow({ accountNumber: "111", chainId: "abc" }, probe);
-    expect(seen).toContain("options/chains/{id}/collateral/");
-    await readOptionsOrderFlow({ accountNumber: "111" }, probe);
-    expect(seen).toContain("options/orders/collateral/");
+  it("JSON-serializes prospective legs and the full order into query fields", async () => {
+    const d = deps(base);
+    await readOptionsOrderFlow({ accountNumber: "111", legs, order }, d);
+
+    const feeCall = d.calls.find((c) => c.url.includes("options/fees"));
+    const collateralCall = d.calls.find((c) => c.url.includes("options/orders/collateral"));
+    expect(feeCall?.params).toEqual({});
+    expect(JSON.parse(feeCall?.query.legs ?? "null")).toEqual(legs);
+    expect(collateralCall?.params).toEqual({});
+    expect(JSON.parse(collateralCall?.query.order ?? "null")).toEqual(order);
   });
 
-  it("warns (does not crash) when account omitted — buying power is per-account", async () => {
-    const r = await readOptionsOrderFlow({}, deps(base));
+  it("skips malformed fee/collateral requests when prospective inputs are absent", async () => {
+    const d = deps(base);
+    const r = await readOptionsOrderFlow({ accountNumber: "111" }, d);
+    expect(d.calls.some((c) => c.url.includes("options/fees"))).toBe(false);
+    expect(d.calls.some((c) => c.url.includes("options/orders/collateral"))).toBe(false);
+    expect(r.fees).toBeUndefined();
+    expect(r.collateral).toBeUndefined();
+    expect(r.warnings.some((w) => /prospective legs/.test(w))).toBe(true);
+    expect(r.warnings.some((w) => /prospective order/.test(w))).toBe(true);
+  });
+
+  it("keeps chain-level collateral as separately labeled supplemental context", async () => {
+    const d = deps(base);
+    const r = await readOptionsOrderFlow({ accountNumber: "111", chainId: "abc", legs, order }, d);
+    expect(r.collateral).toEqual(base.collateral);
+    expect(r.chainCollateral).toEqual(base.chainCollateral);
+    expect(d.calls.some((c) => c.url.includes("options/chains/{id}/collateral/"))).toBe(true);
+  });
+
+  it("warns without crashing when account is omitted", async () => {
+    const d = deps(base);
+    const r = await readOptionsOrderFlow({ legs, order }, d);
     expect(r.buyingPower).toBeUndefined();
     expect(r.warnings.some((w) => /per-account/.test(w))).toBe(true);
-    expect(r.fees).toBeTruthy(); // global reads still happen
+    expect(r.fees).toBeTruthy();
+    expect(r.collateral).toBeTruthy();
   });
 
-  it("degrades each read independently — one failure doesn't blank the others", async () => {
-    const r = await readOptionsOrderFlow({ accountNumber: "111" }, deps({ ...base, throwOn: ["fees"] }));
+  it("degrades each read independently", async () => {
+    const d = deps({ ...base, throwOn: ["fees"] });
+    const r = await readOptionsOrderFlow({ accountNumber: "111", legs, order }, d);
     expect(r.buyingPower).toBeTruthy();
     expect(r.collateral).toBeTruthy();
     expect(r.fees).toBeUndefined();

--- a/docs/options-order-flow-contract-2026-08-04.md
+++ b/docs/options-order-flow-contract-2026-08-04.md
@@ -1,0 +1,56 @@
+# Options order-flow request contracts — 2026-08-04
+
+## Why this changed
+
+The previous `options order-flow` sent naked GETs to `/options/fees/` and `/options/orders/collateral/`. Public 2026 web-bundle analysis proved the routes were plausible but the requests were malformed: both endpoints are request-model reads whose nested objects are JSON-serialized into query fields.
+
+## Current read-only contracts
+
+| Surface | Request |
+|---|---|
+| Fee quote | `GET /options/fees/?legs=<JSON-stringified prospective legs>` |
+| Exact collateral | `GET /options/orders/collateral/?order=<JSON-stringified complete prospective order>` |
+| Supplemental chain context | `GET /options/chains/{id}/collateral/` |
+
+The engine supplies query objects to `brokerageGetJson`; the URL planner performs percent encoding. No request body is sent. Chain-level context is deliberately returned as `chainCollateral` and is never presented as exact order collateral.
+
+## CLI
+
+```bash
+node cli/dist/index.js options order-flow \
+  --account <ACCOUNT> \
+  --legs-json '<prospective-leg-array>' \
+  --order-json '<complete-prospective-order-object>' \
+  --json
+```
+
+`--chain-id` is optional supplemental context. If `--legs-json` or `--order-json` is absent, that request is skipped locally with an actionable warning instead of sending a malformed naked GET.
+
+## MCP
+
+`robinhood_options_order_flow` accepts the same typed inputs:
+
+- `accountNumber?`
+- `chainId?`
+- `legs?: Record<string, unknown>[]`
+- `order?: Record<string, unknown>`
+
+It never reviews or submits the prospective order.
+
+## Evidence classification
+
+- Serialization contracts: `observed-contract` from public web bundle modules `557131` (fees) and `474280` (collateral).
+- Authenticated no-draft behavior: live-verified 2026-08-04; account buying power succeeded and malformed fee/collateral calls were skipped.
+- Production response semantics for real prospective orders remain `observed-contract` until a sanitized authenticated read is exercised with a user-approved draft.
+
+## Regression proof
+
+`cli/test/options-order-flow.test.ts` asserts:
+
+1. decoded `legs` deep-equals the supplied synthetic legs;
+2. decoded `order` deep-equals the supplied synthetic full draft;
+3. no-input paths make neither malformed request;
+4. chain context remains separately labeled;
+5. independent read failures degrade to warnings.
+
+No account identifiers, option UUIDs, live order drafts, quotes, holdings, auth state, or response payloads are retained in this document.

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -405,15 +405,17 @@ server.registerTool(
   {
     title: "Robinhood Options Order Flow",
     description:
-      "Pre-trade options context (live reads): options buying power (per account — the real gate on opens), the fee schedule, and collateral requirements. Each read degrades to a warning independently. The options/orders/review preview is a POST and stays behind the gated write path.",
+      "Read-only pre-trade options context. Reads per-account options buying power; when prospective legs and a complete prospective order are supplied, quotes order-specific fees and collateral using the web-app's JSON-in-query contracts. Optional chainId adds separately labeled supplemental chain collateral. Never reviews or submits an order.",
     annotations: toolAnnotations(true, "sensitive-read"),
     inputSchema: z.object({
       accountNumber: accountNumberOptionalSchema,
       chainId: uuidOptionalSchema,
+      legs: z.array(z.record(z.string(), z.unknown())).optional(),
+      order: z.record(z.string(), z.unknown()).optional(),
     }),
   },
-  async ({ accountNumber, chainId }) =>
-    jsonResponse(await readOptionsOrderFlow({ accountNumber, chainId })),
+  async ({ accountNumber, chainId, legs, order }) =>
+    jsonResponse(await readOptionsOrderFlow({ accountNumber, chainId, legs, order })),
 );
 
 server.registerTool(
@@ -2364,17 +2366,20 @@ server.registerTool(
   {
     title: "Robinhood Documents",
     description:
-      "List account documents (account statements, trade confirms, 1099/1099_crypto/1099r_roth/5498_roth tax forms) across all accounts with their download_urls. LIST ONLY — this tool never writes files; hand the download_url to the operator or use the CLI `documents download` for local PDFs. type is PREFIX-matched ('1099' catches every 1099 variant — the tax-season one-shot is type=1099 + year=2025). year is the TAX year for tax forms (a 1099 dated Feb 2026 is tax year 2025) and the calendar year otherwise. Live read; no gate.",
+      "List a bounded newest-first page of account documents (account statements, trade confirms, 1099/1099_crypto/1099r_roth/5498_roth tax forms) across all accounts with their download_urls. LIST ONLY — this tool never writes files; use the CLI `documents download` for local PDFs. type is PREFIX-matched ('1099' catches every 1099 variant). year is the TAX year for tax forms and the calendar year otherwise. Defaults to 100 rows; response includes total/count/hasMore. Live read; no gate.",
     inputSchema: z.object({
       type: z.string().optional(),
       year: z.string().optional(),
       account_number: accountNumberOptionalSchema,
+      limit: z.number().int().positive().max(500).default(100),
     }),
     annotations: toolAnnotations(true, "sensitive-read"),
   },
-  async ({ type, year, account_number }) => {
+  async ({ type, year, account_number, limit }) => {
     try {
-      return jsonResponse(await listDocuments({ type, year, accountNumber: account_number }));
+      return jsonResponse(
+        await listDocuments({ type, year, accountNumber: account_number, limit }),
+      );
     } catch (e: any) {
       return mcpError(e);
     }


### PR DESCRIPTION
## Summary

- add bounded newest-first document inventory semantics (`total`, `count`, `hasMore`) across engine, CLI, and MCP
- repair options fee quoting to send prospective `legs` as JSON-in-query, matching the current web-app contract
- repair order collateral reads to send the complete prospective `order` as JSON-in-query
- keep chain collateral separately labeled as supplemental context rather than exact order collateral
- skip malformed fee/collateral requests locally when required prospective inputs are absent
- update CLI/MCP inputs, intent recipes, README, and dated contract documentation

## Evidence

- public 2026 web bundle module `557131`: `OptionFeesRecord` serializes `legs`
- public 2026 web bundle module `474280`: collateral model serializes the full order
- sanitized live CLI proof: authenticated session enumerated 5 accounts; buying-power read succeeded; missing-draft fee/collateral calls were skipped with exactly two warnings

## Verification

- `pnpm test` — 466 CLI tests + 16 MCP protocol tests passed
- `pnpm run quality` — lint ratchet 361/363, format, deadcode, API-map sanitizer, skill integrity, portability passed
- `pnpm audit --audit-level high` — no high/critical findings
- `gitleaks detect --no-banner --redact --source .` — no leaks
- `git diff --check` — clean

No order review, placement, cancellation, account mutation, enrollment, transfer, or write was performed.

- delilah 🌸
