### PR TITLE
feat(accounts): add privacy-safe account pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For maintainers and agents that need the system map, [`docs/cli-mcp-architecture
 
 ## Coverage
 
-- **Accounts** — multiple accounts including retirement / Roth, balances, identity, settings.
+- **Accounts** — multiple accounts including retirement / Roth, balances, identity, settings. `account-pulse` adds a privacy-normalized all-account health view: options buying power, recent-order counts/failures, options expiration settings, and optional Ceres futures position/cost-basis counts (Ceres is not mislabeled as universal brokerage P&L).
 - **Positions** — equity holdings, cost basis, day-trade counters.
 - **Options** — chains, Greeks, multi-leg spreads, rolling, and selling.
 - **Performance** — windowed returns: YTD, 1w, 1m, 1y, 5y, and all-time.

--- a/api-map/recipes.json
+++ b/api-map/recipes.json
@@ -272,6 +272,21 @@
       "notes": "Full graph via transfer/accounts/ (bare accounts/ under-reports). Never hardcode account numbers."
     },
     {
+      "id": "account-pulse",
+      "intent": "Read a compact health pulse across all owned accounts",
+      "triggers": [
+        "account pulse",
+        "account health",
+        "recent order health",
+        "options settings by account",
+        "futures exposure by account"
+      ],
+      "command": "account-pulse [--account <N>]",
+      "mcpTool": "robinhood_account_pulse",
+      "risk": "sensitive-read",
+      "notes": "Fans out over the complete owned trading graph. Returns account last-four labels, options buying power, recent-order counts/failures, normalized options settings, and optional Ceres futures position/cost-basis counts. Ceres is futures-only here, not universal brokerage P&L."
+    },
+    {
       "id": "buy-equity",
       "intent": "Buy a stock (dollars or shares)",
       "triggers": [

--- a/cli/src/capabilities.ts
+++ b/cli/src/capabilities.ts
@@ -23,6 +23,7 @@ const LEGACY_MCP_TOOLS = [
   "robinhood_account_context_url",
   "robinhood_account_context_workflows",
   "robinhood_accounts",
+  "robinhood_account_pulse",
   "robinhood_api_map_directory",
   "robinhood_api_map_summary",
   "robinhood_autopilot",
@@ -107,6 +108,7 @@ type LegacyMcpTool = (typeof LEGACY_MCP_TOOLS)[number];
 const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly string[]> = {
   lean: [
     "robinhood_accounts",
+    "robinhood_account_pulse",
     "robinhood_portfolio",
     "robinhood_positions",
     "robinhood_quote",
@@ -124,6 +126,7 @@ const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly st
   ],
   core: [
     "robinhood_accounts",
+    "robinhood_account_pulse",
     "robinhood_autopilot",
     "robinhood_buying_power",
     "robinhood_gold_fees",
@@ -168,6 +171,7 @@ const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly st
   ],
   trading: [
     "robinhood_accounts",
+    "robinhood_account_pulse",
     "robinhood_autopilot",
     "robinhood_brokerage_execute",
     "robinhood_buy",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -38,6 +38,7 @@ import {
   brokerageGetJson,
   brokerageGetAllResults,
   loadOwnedAccounts,
+  readAccountPulse,
   assertAccountOwned as assertOwnedAccount,
   fetchOptionMarks,
   fetchQuotes,
@@ -2680,6 +2681,32 @@ program
       ["account", "nickname", "class", "cash", "buying_power", "margin", "roll", "naked"]
     );
     for (const row of rows) process.stdout.write(`\n${row.accountNumber} (${row.class}): ${row.capabilityNote}\n`);
+  });
+
+program
+  .command("account-pulse")
+  .description(
+    "Compact read-only pulse across every owned account: options buying power, recent-order health, options settings, and optional Ceres futures exposure.",
+  )
+  .option("--account <account_number>", "scope to one owned account")
+  .option("--json", "emit JSON")
+  .action(async (opts: { account?: string; json?: boolean }) => {
+    const pulse = await readAccountPulse({ accountNumber: opts.account });
+    if (opts.json) {
+      printJson(pulse);
+      return;
+    }
+    printTable(
+      pulse.accounts.map((row) => ({
+        account: `…${row.accountLast4}`,
+        nickname: row.label || "—",
+        recent_orders: row.recentOrderCount ?? "unavailable",
+        expiration: row.optionSettings?.tradingOnExpirationState ?? "unavailable",
+        futures_positions: row.futures?.aggregatedPositionCount ?? "n/a",
+        warnings: row.warnings.length,
+      })),
+      ["account", "nickname", "recent_orders", "expiration", "futures_positions", "warnings"],
+    );
   });
 
 // Unified account history: /account/history in the web app aggregates several

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -6308,6 +6308,163 @@ export async function listOwnedTradingAccounts(
   return accts;
 }
 
+export interface AccountPulseAccount {
+  accountLast4: string;
+  label: string;
+  optionsBuyingPower?: unknown;
+  recentOrderCount?: number;
+  recentFailedAssetTypes?: string[];
+  optionSettings?: {
+    tradingOnExpirationState?: string;
+    tradingOnExpirationEnabled?: boolean;
+    shortSharesOnOptionEventsEnabled?: boolean;
+    defaultPrice?: string;
+  };
+  futures?: {
+    accountTypes: string[];
+    aggregatedPositionCount: number;
+    costBasisContractCount: number;
+  };
+  warnings: string[];
+}
+
+/**
+ * Compact, read-only health pulse across every owned trading account (or one).
+ *
+ * Universal surfaces are scoped by account number. Ceres is NOT treated as a universal brokerage
+ * P&L API: it resolves optional futures subaccounts (SWAP/FUTURES/CFTC_30_7) and is included only
+ * when `/ceres/v1/accounts?rhsAccountNumber=` returns exact matches.
+ */
+export async function readAccountPulse(
+  opts: { accountNumber?: string } = {},
+  deps: { getJson?: typeof brokerageGetJson } = {},
+): Promise<{ accounts: AccountPulseAccount[] }> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const owned = await listOwnedTradingAccounts(getJson, opts.accountNumber);
+  const accounts = await Promise.all(
+    owned.map(async ({ acct, label }): Promise<AccountPulseAccount> => {
+      const out: AccountPulseAccount = {
+        accountLast4: acct.slice(-4),
+        label,
+        warnings: [],
+      };
+
+      await Promise.all([
+        (async () => {
+          try {
+            out.optionsBuyingPower = await getJson(
+              "https://bonfire.robinhood.com/accounts/{account_number}/options_buying_power",
+              { account_number: acct },
+            );
+          } catch {
+            out.warnings.push("options buying power unavailable");
+          }
+        })(),
+        (async () => {
+          try {
+            const recent = await getJson(
+              "https://api.robinhood.com/wormhole/bw/orders/recent",
+              {},
+              { accountNumber: acct },
+            );
+            out.recentOrderCount = Array.isArray(recent?.results) ? recent.results.length : 0;
+            out.recentFailedAssetTypes = Array.isArray(recent?.failedAssetTypes)
+              ? recent.failedAssetTypes.map(String)
+              : [];
+          } catch {
+            out.warnings.push("recent orders unavailable");
+          }
+        })(),
+        (async () => {
+          try {
+            const settings = await getJson(
+              "https://api.robinhood.com/options/option_settings/{account_number}/",
+              { account_number: acct },
+            );
+            out.optionSettings = {
+              tradingOnExpirationState: settings?.trading_on_expiration_state,
+              tradingOnExpirationEnabled: settings?.trading_on_expiration_enabled,
+              shortSharesOnOptionEventsEnabled: settings?.short_shares_on_option_events_enabled,
+              defaultPrice: settings?.default_price,
+            };
+          } catch {
+            out.warnings.push("options settings unavailable");
+          }
+        })(),
+        (async () => {
+          try {
+            const ceres = await getJson(
+              "https://api.robinhood.com/ceres/v1/accounts",
+              {},
+              { rhsAccountNumber: acct },
+            );
+            const rows: any[] = Array.isArray(ceres?.results)
+              ? ceres.results
+              : Array.isArray(ceres)
+                ? ceres
+                : [];
+            const matches = rows.filter(
+              (row) => row?.id && String(row?.rhsAccountNumber) === acct,
+            );
+            if (!matches.length) return;
+            const surfaces = await Promise.all(
+              matches.map(async (row) => {
+                const id = String(row.id);
+                let aggregatedPositionCount = 0;
+                let costBasisContractCount = 0;
+                try {
+                  const aggregated = await getJson(
+                    "https://api.robinhood.com/ceres/v1/accounts/{id}/aggregated_positions",
+                    { id },
+                  );
+                  aggregatedPositionCount = Array.isArray(aggregated?.results)
+                    ? aggregated.results.length
+                    : 0;
+                } catch {
+                  out.warnings.push("futures aggregated positions unavailable");
+                }
+                try {
+                  const costBasis = await getJson(
+                    "https://api.robinhood.com/ceres/v1/accounts/{id}/pnl_cost_basis",
+                    { id },
+                  );
+                  costBasisContractCount =
+                    costBasis?.contractToInfo && typeof costBasis.contractToInfo === "object"
+                      ? Object.keys(costBasis.contractToInfo).length
+                      : 0;
+                } catch {
+                  out.warnings.push("futures cost basis unavailable");
+                }
+                return {
+                  accountType: String(row.accountType ?? "unknown"),
+                  aggregatedPositionCount,
+                  costBasisContractCount,
+                };
+              }),
+            );
+            out.futures = {
+              accountTypes: [...new Set(surfaces.map((x) => x.accountType))],
+              aggregatedPositionCount: surfaces.reduce(
+                (sum, x) => sum + x.aggregatedPositionCount,
+                0,
+              ),
+              costBasisContractCount: surfaces.reduce(
+                (sum, x) => sum + x.costBasisContractCount,
+                0,
+              ),
+            };
+          } catch {
+            out.warnings.push("futures account resolver unavailable");
+          }
+        })(),
+      ]);
+
+      return out;
+    }),
+  );
+  return { accounts };
+}
+
 const round2 = (value: number): number =>
   Number.isFinite(value) ? Math.round(value * 100) / 100 : Number.NaN;
 

--- a/cli/test/account-pulse.test.ts
+++ b/cli/test/account-pulse.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { readAccountPulse } from "../src/lib.js";
+
+const accounts = {
+  results: [
+    { type: "rhs", account_number: "11112222", account_name: "Taxable" },
+    { type: "ira_roth", account_number: "33334444", account_name: "Roth" },
+    { type: "external", account_number: "99990000", account_name: "External" },
+  ],
+};
+
+function makeDeps(failRecentFor?: string) {
+  const calls: Array<{ url: string; params: Record<string, string>; query: Record<string, string> }> = [];
+  const getJson = async (
+    url: string,
+    params: Record<string, string> = {},
+    query: Record<string, string> = {},
+  ): Promise<unknown> => {
+    calls.push({ url, params, query });
+    if (url.includes("transfer/accounts")) return accounts;
+    if (url.includes("options_buying_power")) return { amount: params.account_number === "11112222" ? "10" : "20" };
+    if (url.endsWith("/options/option_settings/{account_number}/")) {
+      return { trading_on_expiration_state: "enabled" };
+    }
+    if (url.includes("wormhole/bw/orders/recent")) {
+      if (query.accountNumber === failRecentFor) throw new Error("recent endpoint unavailable");
+      return { results: [{ id: `order-${query.accountNumber}` }], failedAssetTypes: [] };
+    }
+    if (url.endsWith("/ceres/v1/accounts")) {
+      return query.rhsAccountNumber === "11112222"
+        ? { results: [{ id: "ceres-1", rhsAccountNumber: "11112222", accountType: "FUTURES" }] }
+        : { results: [] };
+    }
+    if (url.includes("aggregated_positions")) return { results: [{ assetType: "FUTURE" }] };
+    if (url.includes("pnl_cost_basis")) return { contractToInfo: { c1: { direction: "LONG" } } };
+    throw new Error(`unexpected ${url}`);
+  };
+  return { calls, getJson };
+}
+
+describe("readAccountPulse", () => {
+  it("scopes universal reads per owned account and includes optional Ceres futures diagnostics", async () => {
+    const { calls, getJson } = makeDeps();
+    const out = await readAccountPulse({}, { getJson: getJson as never });
+
+    expect(out.accounts).toHaveLength(2);
+    expect(out.accounts.map((x) => x.accountLast4)).toEqual(["2222", "4444"]);
+    expect(out.accounts[0]).toMatchObject({
+      label: "Taxable",
+      optionsBuyingPower: { amount: "10" },
+      recentOrderCount: 1,
+      recentFailedAssetTypes: [],
+      optionSettings: {
+        tradingOnExpirationState: "enabled",
+        tradingOnExpirationEnabled: undefined,
+        shortSharesOnOptionEventsEnabled: undefined,
+        defaultPrice: undefined,
+      },
+      futures: { accountTypes: ["FUTURES"], aggregatedPositionCount: 1, costBasisContractCount: 1 },
+      warnings: [],
+    });
+    expect(out.accounts[1].futures).toBeUndefined();
+
+    const recentCalls = calls.filter((x) => x.url.includes("wormhole/bw/orders/recent"));
+    expect(recentCalls.map((x) => x.query)).toEqual([
+      { accountNumber: "11112222" },
+      { accountNumber: "33334444" },
+    ]);
+    const settingsCalls = calls.filter((x) => x.url.includes("option_settings"));
+    expect(settingsCalls.map((x) => x.params.account_number)).toEqual(["11112222", "33334444"]);
+  });
+
+  it("degrades one failed surface without dropping the account", async () => {
+    const { getJson } = makeDeps("33334444");
+    const out = await readAccountPulse({ accountNumber: "33334444" }, { getJson: getJson as never });
+
+    expect(out.accounts).toHaveLength(1);
+    expect(out.accounts[0].accountLast4).toBe("4444");
+    expect(out.accounts[0].recentOrderCount).toBeUndefined();
+    expect(out.accounts[0].warnings).toEqual(["recent orders unavailable"]);
+  });
+
+  it("rejects an account outside the owned trading graph", async () => {
+    const { getJson } = makeDeps();
+    await expect(readAccountPulse({ accountNumber: "55556666" }, { getJson: getJson as never })).rejects.toThrow(
+      /not one of your trading accounts/,
+    );
+  });
+});

--- a/cli/test/capability-registry.test.ts
+++ b/cli/test/capability-registry.test.ts
@@ -64,8 +64,10 @@ describe("typed capability registry", () => {
     expect(
       capabilitiesForProfile(DEFAULT_MCP_PROFILE).some((entry) => entry.access === "write"),
     ).toBe(true);
-    expect(capabilitiesForProfile("lean")).toHaveLength(15);
-    expect(capabilitiesForProfile("lean").every((entry) => entry.access === "read")).toBe(true);
+    const lean = capabilitiesForProfile("lean");
+    expect(lean).toHaveLength(16);
+    expect(lean.some((entry) => entry.mcp === "robinhood_account_pulse")).toBe(true);
+    expect(lean.every((entry) => entry.access === "read")).toBe(true);
   });
 
   it("validates every named profile and rejects typos instead of advertising zero tools", () => {

--- a/docs/legend-browser-contracts-2026-08-04.md
+++ b/docs/legend-browser-contracts-2026-08-04.md
@@ -1,0 +1,38 @@
+# Authenticated Robinhood Legend contract pass — 2026-08-04
+
+## Evidence
+
+A controlled reload of an authenticated Robinhood Legend page was captured through Chrome DevTools' **Export HAR (sanitized)** action. The raw export was reduced locally and deleted. The retained artifact is:
+
+- `research/captures/robinhood-legend-boot-2026-08-04.routes.json`
+- 8,770 requests reduced to 207 unique method/host/path/query-key/status shapes
+- no headers, cookie objects, query values, request payloads, response bodies, account numbers, or generated asset hashes retained
+
+## Fresh authenticated contracts
+
+The pass live-observed account graph and buying-power reads, Ceres futures subaccounts, aggregated futures positions and P&L cost-basis counts, recent-order summaries, options settings/history/positions/chains/stats, equity/futures/crypto buying power, Gold subscription and sweep interest, alerts, earnings, SSR/shorting context, screeners, streaming token/bootstrap, and multi-span performance-summary requests.
+
+## Product decisions
+
+### `account-pulse`
+
+The promoted read-only composite fans out across the complete `transfer/accounts/` graph and returns:
+
+- account last four + label
+- options buying-power object
+- recent-order count and failed asset-type diagnostics
+- normalized options expiration/short-share settings without the raw account echo
+- optional Ceres futures account types, aggregated-position count, and cost-basis-contract count
+- per-surface warnings instead of whole-command failure
+
+### Ceres classification
+
+`GET /ceres/v1/accounts?rhsAccountNumber=...` resolved `SWAP`, `FUTURES`, and `CFTC_30_7` rows for a supported account and no rows for others. Therefore Ceres is treated as an optional futures subsystem. It is **not** presented as universal brokerage P&L.
+
+### Performance summary remains mapped-only
+
+The browser proved `/portfolios/v2/performance/summary` with query keys `rhsAccountNumber`, `spans`, `metrics`, and sometimes `assetClasses`. Three guessed comma-separated enum sets failed live. No wrapper is shipped until public-bundle/runtime evidence establishes the exact value grammar. Method/path/query-key evidence alone is not a complete request contract.
+
+## Safety
+
+All promoted behavior is read-only. No order review/submission, transfer, enrollment, settings mutation, or money movement is performed.

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -49,6 +49,7 @@ import {
   brokerageGetJson,
   brokerageGetAllResults,
   loadOwnedAccounts,
+  readAccountPulse,
   fetchOptionMarks,
   computePortfolioPnl,
   getUnifiedHistory,
@@ -1196,6 +1197,19 @@ server.registerTool(
       }));
     return jsonResponse({ count: rows.length, accounts: rows });
   },
+);
+
+server.registerTool(
+  "robinhood_account_pulse",
+  {
+    title: "Robinhood Account Pulse",
+    description:
+      "Compact read-only health pulse across all owned accounts (or one): options buying power, recent-order health, normalized options settings, and optional Ceres futures position/cost-basis counts. Returns account last-four labels rather than raw account numbers.",
+    inputSchema: z.object({ account_number: z.string().optional() }),
+    annotations: toolAnnotations(true, "read"),
+  },
+  async ({ account_number }) =>
+    jsonResponse(await readAccountPulse({ accountNumber: account_number })),
 );
 
 server.registerTool(

--- a/mcp/test/protocol.test.ts
+++ b/mcp/test/protocol.test.ts
@@ -245,7 +245,8 @@ describe("MCP profile protocol surfaces", () => {
       const bytes = Buffer.byteLength(JSON.stringify(tools.tools));
       const estimatedTokens = Math.ceil(bytes / 4);
       const instructionBytes = Buffer.byteLength(profileClient.getInstructions() ?? "");
-      expect(tools.tools).toHaveLength(15);
+      expect(tools.tools).toHaveLength(16);
+      expect(tools.tools.some((tool) => tool.name === "robinhood_account_pulse")).toBe(true);
       expect(bytes).toBeLessThanOrEqual(40_000);
       expect(estimatedTokens).toBeLessThanOrEqual(10_000);
       expect(instructionBytes).toBeLessThanOrEqual(800);
@@ -276,7 +277,8 @@ describe("MCP profile protocol surfaces", () => {
           .map((entry) => entry.mcp!)
           .sort(),
       );
-      expect(tools.tools).toHaveLength(85);
+      expect(tools.tools).toHaveLength(86);
+      expect(tools.tools.some((tool) => tool.name === "robinhood_account_pulse")).toBe(true);
       expect(defaultClient.getInstructions()).toMatch(/ROBINHOOD_ALLOW_LIVE_WRITE/);
     } finally {
       await defaultClient.close();

--- a/research/captures/robinhood-legend-boot-2026-08-04.routes.json
+++ b/research/captures/robinhood-legend-boot-2026-08-04.routes.json
@@ -1,0 +1,2186 @@
+{
+  "capturedAt": "2026-08-04",
+  "source": "Chrome DevTools Export HAR (sanitized), authenticated Robinhood Legend; raw deleted after derivation",
+  "privacy": {
+    "urlValuesRetained": false,
+    "headersRetained": false,
+    "cookiesRetained": false,
+    "payloadsRetained": false,
+    "responseBodiesRetained": false
+  },
+  "summary": {
+    "entryCount": 8770,
+    "uniqueContractShapes": 207,
+    "originCount": 16,
+    "sensitiveHeaderNameOccurrencesInRaw": 0,
+    "cookieObjectCountInRaw": 0,
+    "postDataEntryCountInRaw": 291,
+    "responseTextEntryCountInRaw": 2105
+  },
+  "origins": [
+    "https://aggregator.service.usercentrics.eu",
+    "https://api.robinhood.com",
+    "https://api.usercentrics.eu",
+    "https://app.usercentrics.eu",
+    "https://bonfire.robinhood.com",
+    "https://cdn.robinhood.com",
+    "https://googleads.g.doubleclick.net",
+    "https://identi.robinhood.com",
+    "https://nummus.robinhood.com",
+    "https://o62437.ingest.us.sentry.io",
+    "https://robinhood.com",
+    "https://www.google-analytics.com",
+    "https://www.google.com",
+    "https://www.googletagmanager.com",
+    "wss://api-streaming.robinhood.com",
+    "wss://api.robinhood.com"
+  ],
+  "routes": [
+    {
+      "method": "GET",
+      "host": "aggregator.service.usercentrics.eu",
+      "path": "/aggregate/en",
+      "queryKeys": [
+        "templates"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "aggregator.service.usercentrics.eu",
+      "path": "/aggregate/en",
+      "queryKeys": [
+        "templates"
+      ],
+      "status": 204,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api-streaming.robinhood.com",
+      "path": "/wss/connect",
+      "queryKeys": [
+        "topic"
+      ],
+      "status": 101,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/accounts/",
+      "queryKeys": [
+        "default_to_all_accounts",
+        "include_managed",
+        "include_multiple_individual"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/accounts/",
+      "queryKeys": [
+        "default_to_all_accounts",
+        "include_managed",
+        "include_multiple_individual"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/accounts/:id/buying_power_breakdown",
+      "queryKeys": [],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/accounts/:id/buying_power_breakdown",
+      "queryKeys": [],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/accounts/sweeps/interest/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/accounts/sweeps/interest/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/arsenal/v1/futures/products",
+      "queryKeys": [
+        "productIds"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/arsenal/v1/futures/products",
+      "queryKeys": [
+        "productIds"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/beacon/base-indicators",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/beacon/base-indicators",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/beacon/indicator-groups",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/beacon/indicator-groups",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/beacon/scans",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/beacon/scans",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/bw/account/futures",
+      "queryKeys": [
+        "rhsAccountNumber"
+      ],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/bw/account/futures",
+      "queryKeys": [
+        "rhsAccountNumber"
+      ],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/bw/config",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/bw/config",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/bw/performance/config",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/bw/performance/config",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/bw/refresh",
+      "queryKeys": [
+        "appChannel",
+        "downloadedDate",
+        "version"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/bw/refresh",
+      "queryKeys": [
+        "appChannel",
+        "downloadedDate",
+        "version"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/accounts",
+      "queryKeys": [
+        "rhsAccountNumber"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/accounts",
+      "queryKeys": [
+        "rhsAccountNumber"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/accounts/:id/aggregated_positions",
+      "queryKeys": [],
+      "status": 200,
+      "count": 197
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/accounts/:id/aggregated_positions",
+      "queryKeys": [],
+      "status": 200,
+      "count": 197
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/accounts/:id/pnl_cost_basis",
+      "queryKeys": [],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/accounts/:id/pnl_cost_basis",
+      "queryKeys": [],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/futures_account_eligibility/:id",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/ceres/v1/futures_account_eligibility/:id",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/discovery/analytics/ids/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/discovery/analytics/ids/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/discovery/lists/items/",
+      "queryKeys": [
+        "list_id"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/discovery/lists/items/",
+      "queryKeys": [
+        "list_id"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/discovery/lists/v2/:id/items/",
+      "queryKeys": [
+        "owner_type"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/discovery/lists/v2/:id/items/",
+      "queryKeys": [
+        "owner_type"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/futures/:id/futures_buying_power",
+      "queryKeys": [],
+      "status": 301,
+      "count": 69
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/futures/:id/futures_buying_power",
+      "queryKeys": [],
+      "status": 200,
+      "count": 69
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/futures/:id/futures_buying_power/",
+      "queryKeys": [],
+      "status": 0,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/futures/:id/futures_buying_power/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 68
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/futures/:id/futures_buying_power/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 68
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/goku/bw_events",
+      "queryKeys": [],
+      "status": 200,
+      "count": 112
+    },
+    {
+      "method": "POST",
+      "host": "api.robinhood.com",
+      "path": "/goku/bw_events",
+      "queryKeys": [],
+      "status": 201,
+      "count": 112
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/goku/live_frontend_log_events",
+      "queryKeys": [],
+      "status": 200,
+      "count": 155
+    },
+    {
+      "method": "POST",
+      "host": "api.robinhood.com",
+      "path": "/goku/live_frontend_log_events",
+      "queryKeys": [],
+      "status": 201,
+      "count": 152
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/groups",
+      "queryKeys": [],
+      "status": 200,
+      "count": 45
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/groups",
+      "queryKeys": [],
+      "status": 200,
+      "count": 45
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/layouts",
+      "queryKeys": [],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/layouts",
+      "queryKeys": [],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/layouts/:id",
+      "queryKeys": [],
+      "status": 200,
+      "count": 45
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/layouts/:id",
+      "queryKeys": [],
+      "status": 200,
+      "count": 45
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 47
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 48
+    },
+    {
+      "method": "PATCH",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/user/migrations",
+      "queryKeys": [],
+      "status": 200,
+      "count": 13
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/user/migrations",
+      "queryKeys": [],
+      "status": 200,
+      "count": 13
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widget/settings",
+      "queryKeys": [
+        "widgetIds"
+      ],
+      "status": 200,
+      "count": 3
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widget/settings",
+      "queryKeys": [
+        "widgetIds"
+      ],
+      "status": 200,
+      "count": 3
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widget/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "PATCH",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widget/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widget/type/WIDGET_TYPE_CHART/settings",
+      "queryKeys": [
+        "appType"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widget/type/WIDGET_TYPE_CHART/settings",
+      "queryKeys": [
+        "appType"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widgets/charts/comparisons",
+      "queryKeys": [
+        "widgetId"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widgets/charts/comparisons",
+      "queryKeys": [
+        "widgetId"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widgets/charts/drawings",
+      "queryKeys": [
+        "instrumentId",
+        "instrumentType"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widgets/charts/drawings",
+      "queryKeys": [
+        "instrumentId",
+        "instrumentType",
+        "widgetId"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widgets/charts/drawings",
+      "queryKeys": [
+        "instrumentId",
+        "instrumentType"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/bw/widgets/charts/drawings",
+      "queryKeys": [
+        "instrumentId",
+        "instrumentType",
+        "widgetId"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/hippo/ux-flags",
+      "queryKeys": [
+        "flags"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/hippo/ux-flags",
+      "queryKeys": [
+        "flags"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/indexes/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/indexes/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/instruments/",
+      "queryKeys": [
+        "active_instruments_only",
+        "ids"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/instruments/",
+      "queryKeys": [
+        "active_instruments_only",
+        "ids"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/instruments/:id/shorting/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/instruments/:id/shorting/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/kaizen/experiments/:id",
+      "queryKeys": [
+        "appVersion",
+        "names",
+        "platform",
+        "trigger"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/kaizen/experiments/:id",
+      "queryKeys": [
+        "appVersion",
+        "names",
+        "platform",
+        "trigger"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/margin/:id/upgrade_restrictions",
+      "queryKeys": [],
+      "status": 301,
+      "count": 2
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/margin/:id/upgrade_restrictions",
+      "queryKeys": [],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/margin/:id/upgrade_restrictions/",
+      "queryKeys": [],
+      "status": 0,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/margin/:id/upgrade_restrictions/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/margin/:id/upgrade_restrictions/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/earnings/",
+      "queryKeys": [
+        "instrument"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/earnings/",
+      "queryKeys": [
+        "instrument"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/equities/ssr/v1/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/equities/ssr/v1/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/forex/fundamentals/:id/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/forex/fundamentals/:id/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/forex/historicals/",
+      "queryKeys": [
+        "bounds",
+        "ids",
+        "interval",
+        "span"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/forex/historicals/",
+      "queryKeys": [
+        "bounds",
+        "ids",
+        "interval",
+        "span"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/forex/quotes/",
+      "queryKeys": [
+        "ids",
+        "routing_group"
+      ],
+      "status": 200,
+      "count": 197
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/forex/quotes/",
+      "queryKeys": [
+        "ids",
+        "routing_group"
+      ],
+      "status": 200,
+      "count": 197
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/fundamentals/:id/",
+      "queryKeys": [
+        "include_inactive"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/fundamentals/:id/",
+      "queryKeys": [
+        "include_inactive"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/options/",
+      "queryKeys": [
+        "ids",
+        "include_all_sessions"
+      ],
+      "status": 200,
+      "count": 216
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/options/",
+      "queryKeys": [
+        "ids",
+        "include_all_sessions"
+      ],
+      "status": 200,
+      "count": 216
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/options/chains/stats/v1/:id/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 195
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/options/chains/stats/v1/:id/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 195
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/quotes/",
+      "queryKeys": [
+        "bounds",
+        "ids",
+        "include_inactive"
+      ],
+      "status": 200,
+      "count": 1541
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/quotes/",
+      "queryKeys": [
+        "bounds",
+        "ids",
+        "include_inactive"
+      ],
+      "status": 200,
+      "count": 1543
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/streaming/legend/v2/",
+      "queryKeys": [],
+      "status": 101,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/token/v1/",
+      "queryKeys": [
+        "session_id",
+        "session_type"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/marketdata/token/v1/",
+      "queryKeys": [
+        "session_id",
+        "session_type"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/markets/XNYS/hours/2026-08-03/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/markets/XNYS/hours/2026-08-03/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/markets/XNYS/hours/2026-08-04/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/markets/XNYS/hours/2026-08-04/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/markets/XNYS/hours/2026-08-05/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/markets/XNYS/hours/2026-08-05/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/messaging/price-movement/alerts/logs",
+      "queryKeys": [
+        "pageSize"
+      ],
+      "status": 200,
+      "count": 25
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/messaging/price-movement/alerts/logs",
+      "queryKeys": [
+        "pageSize"
+      ],
+      "status": 200,
+      "count": 25
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/messaging/price-movement/alerts/settings",
+      "queryKeys": [
+        "assetClass",
+        "assetId"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/messaging/price-movement/alerts/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 24
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/messaging/price-movement/alerts/settings",
+      "queryKeys": [
+        "assetClass",
+        "assetId"
+      ],
+      "status": 200,
+      "count": 46
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/messaging/price-movement/alerts/settings",
+      "queryKeys": [],
+      "status": 200,
+      "count": 24
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/midlands/notifications/stack/",
+      "queryKeys": [
+        "location"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/midlands/notifications/stack/",
+      "queryKeys": [
+        "location"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/observability/v1/metrics",
+      "queryKeys": [],
+      "status": 200,
+      "count": 3
+    },
+    {
+      "method": "POST",
+      "host": "api.robinhood.com",
+      "path": "/observability/v1/metrics",
+      "queryKeys": [],
+      "status": 200,
+      "count": 3
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/observability/v1/traces",
+      "queryKeys": [],
+      "status": 200,
+      "count": 41
+    },
+    {
+      "method": "POST",
+      "host": "api.robinhood.com",
+      "path": "/observability/v1/traces",
+      "queryKeys": [],
+      "status": 200,
+      "count": 41
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options-product/simulated-returns/interest-rate-intervals",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options-product/simulated-returns/interest-rate-intervals",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options/chains/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options/chains/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options/instruments/",
+      "queryKeys": [
+        "chain_id",
+        "expiration_dates",
+        "page_size",
+        "state"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options/instruments/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options/instruments/",
+      "queryKeys": [
+        "chain_id",
+        "expiration_dates",
+        "page_size",
+        "state"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options/instruments/",
+      "queryKeys": [
+        "ids"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options/option_settings/:id/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options/option_settings/:id/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options/orders/",
+      "queryKeys": [
+        "account_number",
+        "created_at__gte"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options/orders/",
+      "queryKeys": [
+        "account_number",
+        "created_at__gte"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/options/positions/",
+      "queryKeys": [
+        "account_numbers",
+        "nonzero"
+      ],
+      "status": 200,
+      "count": 192
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/options/positions/",
+      "queryKeys": [
+        "account_numbers",
+        "nonzero"
+      ],
+      "status": 200,
+      "count": 193
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/orders/order_checks/presubmit_data/",
+      "queryKeys": [
+        "account_number",
+        "instrument"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/orders/order_checks/presubmit_data/",
+      "queryKeys": [
+        "account_number",
+        "instrument"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/portfolios/v2/performance/summary",
+      "queryKeys": [
+        "metrics",
+        "rhsAccountNumber",
+        "spans"
+      ],
+      "status": 200,
+      "count": 71
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/portfolios/v2/performance/summary",
+      "queryKeys": [
+        "assetClasses",
+        "metrics",
+        "rhsAccountNumber",
+        "spans"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/portfolios/v2/performance/summary",
+      "queryKeys": [
+        "metrics",
+        "rhsAccountNumber",
+        "spans"
+      ],
+      "status": 200,
+      "count": 71
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/portfolios/v2/performance/summary",
+      "queryKeys": [
+        "assetClasses",
+        "metrics",
+        "rhsAccountNumber",
+        "spans"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/positions/",
+      "queryKeys": [
+        "account_number",
+        "nonzero"
+      ],
+      "status": 200,
+      "count": 195
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/positions/",
+      "queryKeys": [
+        "account_number",
+        "nonzero"
+      ],
+      "status": 200,
+      "count": 195
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/subscription/subscriptions/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/subscription/subscriptions/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/user/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/user/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.robinhood.com",
+      "path": "/wormhole/bw/orders/recent",
+      "queryKeys": [
+        "accountNumber"
+      ],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.robinhood.com",
+      "path": "/wormhole/bw/orders/recent",
+      "queryKeys": [
+        "accountNumber"
+      ],
+      "status": 200,
+      "count": 23
+    },
+    {
+      "method": "GET",
+      "host": "api.usercentrics.eu",
+      "path": "/ruleSet/M6Jkl5BTgFMHMJ.json",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.usercentrics.eu",
+      "path": "/ruleSet/M6Jkl5BTgFMHMJ.json",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.usercentrics.eu",
+      "path": "/settings/eRog-on6nfq3j1/latest/en.json",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.usercentrics.eu",
+      "path": "/settings/eRog-on6nfq3j1/latest/en.json",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "api.usercentrics.eu",
+      "path": "/translations/translations-en.json",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "api.usercentrics.eu",
+      "path": "/translations/translations-en.json",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "app.usercentrics.eu",
+      "path": "/browser-sdk/4.59.0/cross-domain-bridge.html",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "app.usercentrics.eu",
+      "path": "/session/1px.png",
+      "queryKeys": [
+        "settingsId"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/accounts/:id/currency_buying_power/USD/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 71
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/accounts/:id/currency_buying_power/USD/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 71
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/accounts/:id/options_buying_power/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 71
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/accounts/:id/options_buying_power/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 71
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/app-comms/batch/surface/info-banner/",
+      "queryKeys": [
+        "account_number",
+        "locations"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/app-comms/batch/surface/info-banner/",
+      "queryKeys": [
+        "account_number",
+        "locations"
+      ],
+      "status": 200,
+      "count": 5
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/app-comms/surface/alert-sheet/",
+      "queryKeys": [
+        "account_number",
+        "location"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/app-comms/surface/alert-sheet/",
+      "queryKeys": [
+        "account_number",
+        "location"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/crypto/cryptobility/:id/",
+      "queryKeys": [
+        "account_id"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/crypto/cryptobility/:id/",
+      "queryKeys": [
+        "account_id"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/options/should_show_options_upgrade_on_sdp/",
+      "queryKeys": [
+        "account_number",
+        "should_include_null_risk_tolerance"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/options/should_show_options_upgrade_on_sdp/",
+      "queryKeys": [
+        "account_number",
+        "should_include_null_risk_tolerance"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/portfolio/performance/:id/",
+      "queryKeys": [
+        "chart_style",
+        "chart_type",
+        "display_span",
+        "include_all_hours",
+        "is_privacy_enabled"
+      ],
+      "status": 200,
+      "count": 44
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/portfolio/performance/:id/",
+      "queryKeys": [
+        "chart_style",
+        "chart_type",
+        "display_span",
+        "include_all_hours",
+        "is_privacy_enabled"
+      ],
+      "status": 503,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/portfolio/performance/:id/",
+      "queryKeys": [
+        "chart_style",
+        "chart_type",
+        "display_span",
+        "include_all_hours",
+        "is_privacy_enabled"
+      ],
+      "status": 200,
+      "count": 45
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/sms/margin/:id/buying_power_impact",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/sms/margin/:id/buying_power_impact",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "bonfire.robinhood.com",
+      "path": "/social/user_profile/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "bonfire.robinhood.com",
+      "path": "/social/user_profile/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "cdn.robinhood.com",
+      "path": "/assets/generated_assets/black-widow/:asset",
+      "queryKeys": [],
+      "status": 200,
+      "count": 131
+    },
+    {
+      "method": "GET",
+      "host": "cdn.robinhood.com",
+      "path": "/assets/generated_assets/black-widow/:asset",
+      "queryKeys": [],
+      "status": 206,
+      "count": 10
+    },
+    {
+      "method": "GET",
+      "host": "cdn.robinhood.com",
+      "path": "/assets/generated_assets/webapp/vendor/user_centrics/3.90.0/:asset",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "googleads.g.doubleclick.net",
+      "path": "/pagead/viewthroughconversion/:id/",
+      "queryKeys": [
+        "async",
+        "auid",
+        "bg",
+        "cv",
+        "data",
+        "dma",
+        "en",
+        "ept",
+        "fmt",
+        "frm",
+        "fst",
+        "gcd",
+        "gtm",
+        "guid",
+        "hn",
+        "npa",
+        "pscdl",
+        "random",
+        "rcb",
+        "rfmt",
+        "tag_exp",
+        "tiba",
+        "u_h",
+        "u_w",
+        "uaa",
+        "uab",
+        "uafvl",
+        "uam",
+        "uamb",
+        "uap",
+        "uapv",
+        "uaw",
+        "url"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "identi.robinhood.com",
+      "path": "/user_info/address/residential/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "identi.robinhood.com",
+      "path": "/user_info/address/residential/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "identi.robinhood.com",
+      "path": "/user_info/agreement_logs/v2/check/cortex_legend_agreement/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "identi.robinhood.com",
+      "path": "/user_info/agreement_logs/v2/check/cortex_legend_agreement/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "nummus.robinhood.com",
+      "path": "/accounts/",
+      "queryKeys": [
+        "default_to_all_accounts"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "nummus.robinhood.com",
+      "path": "/accounts/",
+      "queryKeys": [
+        "default_to_all_accounts"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "nummus.robinhood.com",
+      "path": "/currency_pairs/",
+      "queryKeys": [],
+      "status": 0,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "nummus.robinhood.com",
+      "path": "/currency_pairs/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "OPTIONS",
+      "host": "nummus.robinhood.com",
+      "path": "/currency_pairs/",
+      "queryKeys": [],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "nummus.robinhood.com",
+      "path": "/holdings/",
+      "queryKeys": [
+        "nonzero",
+        "rhs_account_number"
+      ],
+      "status": 200,
+      "count": 190
+    },
+    {
+      "method": "OPTIONS",
+      "host": "nummus.robinhood.com",
+      "path": "/holdings/",
+      "queryKeys": [
+        "nonzero",
+        "rhs_account_number"
+      ],
+      "status": 200,
+      "count": 191
+    },
+    {
+      "method": "POST",
+      "host": "o62437.ingest.us.sentry.io",
+      "path": "/api/:id/envelope/",
+      "queryKeys": [
+        "sentry_client",
+        "sentry_key",
+        "sentry_version"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "POST",
+      "host": "o62437.ingest.us.sentry.io",
+      "path": "/api/:id/security/",
+      "queryKeys": [
+        "sentry_environment",
+        "sentry_key",
+        "sentry_release"
+      ],
+      "status": 200,
+      "count": 3
+    },
+    {
+      "method": "GET",
+      "host": "robinhood.com",
+      "path": "/legend/layout/:id",
+      "queryKeys": [
+        "default_web_client"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "robinhood.com",
+      "path": "/legend/version",
+      "queryKeys": [],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "POST",
+      "host": "www.google-analytics.com",
+      "path": "/g/collect",
+      "queryKeys": [
+        "_eu",
+        "_p",
+        "_s",
+        "are",
+        "cid",
+        "dl",
+        "dma",
+        "dt",
+        "en",
+        "frm",
+        "gcd",
+        "gtm",
+        "ngs",
+        "npa",
+        "pscdl",
+        "rcb",
+        "sct",
+        "seg",
+        "sid",
+        "sr",
+        "tag_exp",
+        "tfd",
+        "tid",
+        "uaa",
+        "uab",
+        "uafvl",
+        "uam",
+        "uamb",
+        "uap",
+        "uapv",
+        "uaw",
+        "ul",
+        "v"
+      ],
+      "status": 204,
+      "count": 1
+    },
+    {
+      "method": "POST",
+      "host": "www.google.com",
+      "path": "/ccm/collect",
+      "queryKeys": [
+        "ae",
+        "apvc",
+        "auid",
+        "dl",
+        "dma",
+        "dt",
+        "en",
+        "ep.ads_data_redaction",
+        "fmt",
+        "frm",
+        "gcd",
+        "gtm",
+        "navt",
+        "npa",
+        "rcb",
+        "rnd",
+        "scrsrc",
+        "tag_exp",
+        "tfd",
+        "tft"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "POST",
+      "host": "www.google.com",
+      "path": "/ccm/collect",
+      "queryKeys": [
+        "apvc",
+        "auid",
+        "dl",
+        "dma",
+        "dt",
+        "en",
+        "fmt",
+        "frm",
+        "gcd",
+        "gtm",
+        "navt",
+        "npa",
+        "rcb",
+        "rnd",
+        "scrsrc",
+        "tag_exp",
+        "tfd",
+        "tft",
+        "tid",
+        "tids"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "POST",
+      "host": "www.google.com",
+      "path": "/ccm/collect",
+      "queryKeys": [
+        "apvc",
+        "auid",
+        "dl",
+        "dma",
+        "dt",
+        "en",
+        "ep.user_data_mode",
+        "fmt",
+        "frm",
+        "gcd",
+        "gtm",
+        "navt",
+        "npa",
+        "rcb",
+        "rnd",
+        "scrsrc",
+        "tag_exp",
+        "tfd",
+        "tft",
+        "tid",
+        "tids"
+      ],
+      "status": 200,
+      "count": 1
+    },
+    {
+      "method": "GET",
+      "host": "www.google.com",
+      "path": "/pagead/1p-user-list/:id/",
+      "queryKeys": [
+        "async",
+        "auid",
+        "bg",
+        "cid",
+        "cv",
+        "data",
+        "dma",
+        "en",
+        "ept",
+        "fmt",
+        "frm",
+        "fst",
+        "gcd",
+        "gtm",
+        "guid",
+        "hn",
+        "ipr",
+        "is_vtc",
+        "npa",
+        "pscdl",
+        "random",
+        "rcb",
+        "rfmt",
+        "rmt_tld",
+        "tag_exp",
+        "tiba",
+        "u_h",
+        "u_w",
+        "uaa",
+        "uab",
+        "uafvl",
+        "uam",
+        "uamb",
+        "uap",
+        "uapv",
+        "uaw",
+        "url"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "POST",
+      "host": "www.google.com",
+      "path": "/rmkt/collect/:id/",
+      "queryKeys": [
+        "async",
+        "auid",
+        "bg",
+        "cv",
+        "data",
+        "dma",
+        "en",
+        "ept",
+        "fmt",
+        "frm",
+        "fst",
+        "gcd",
+        "gcp",
+        "gtm",
+        "guid",
+        "hn",
+        "npa",
+        "pscdl",
+        "random",
+        "rcb",
+        "tag_exp",
+        "tiba",
+        "u_h",
+        "u_w",
+        "uaa",
+        "uab",
+        "uafvl",
+        "uam",
+        "uamb",
+        "uap",
+        "uapv",
+        "uaw",
+        "url"
+      ],
+      "status": 200,
+      "count": 2
+    },
+    {
+      "method": "GET",
+      "host": "www.googletagmanager.com",
+      "path": "/gtag/js",
+      "queryKeys": [
+        "cx",
+        "gtm",
+        "id"
+      ],
+      "status": 200,
+      "count": 4
+    },
+    {
+      "method": "GET",
+      "host": "www.googletagmanager.com",
+      "path": "/gtm.js",
+      "queryKeys": [
+        "id"
+      ],
+      "status": 200,
+      "count": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a privacy-safe authenticated Robinhood Legend contract inventory derived from Chrome's sanitized HAR export
- add shared `readAccountPulse` engine across the complete owned account graph
- expose `account-pulse` in CLI and `robinhood_account_pulse` in MCP/profile manifests
- report per-account options buying power, recent-order health, normalized options settings, and optional Ceres futures position/cost-basis counts
- classify Ceres correctly as an optional futures subsystem rather than universal brokerage P&L
- document that performance-summary remains mapped-only until its exact `spans`/`metrics` value grammar is proven
- add recipes, README coverage, focused engine regressions, and exact MCP manifest assertions

## Browser evidence

- authenticated Robinhood Legend controlled through native Chrome + DevTools
- 8,770 requests reduced to 207 unique route shapes
- retained artifact has no auth headers, cookies, query values, payloads, response bodies, account numbers, or generated asset hashes
- raw 186 MB HAR deleted after verified derivation

## Live proof

Sanitized default-branch-style runtime summary after build:

- account count: 5
- options buying-power surfaces: 5
- recent-order surfaces: 5
- option-settings surfaces: 5
- Ceres futures surfaces: 1
- total warnings: 0
- raw account numbers exposed by pulse: false

## Verification

- `pnpm test` — 469 CLI tests + 16 MCP protocol tests passed (2 platform skips)
- `pnpm run quality` — passed
- `pnpm audit --audit-level high` — no high/critical findings (existing 1 low, 6 moderate)
- `gitleaks detect --no-banner --redact --source .` — no leaks
- `git diff --check` — passed

No order review/submission, transfer, enrollment, settings mutation, or money movement was performed.

- delilah 🌸
