### PR TITLE
feat(options): add read-only order diagnostics

### DIFF
--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -32370,5 +32370,61 @@
     "risk": "sensitive-read",
     "fields": [],
     "fieldsSource": "undocumented"
+  },
+  {
+    "url": "https://api.robinhood.com/options/orders/available_contracts/{account_number}/",
+    "host": "api.robinhood.com",
+    "categories": ["options", "order-diagnostics"],
+    "risk": "sensitive-read",
+    "methods": ["GET"],
+    "source": "public-web-bundle module 452309 (observed request contract; response semantics unverified)",
+    "queryKeys": ["strategy_code", "order_to_replace_id"],
+    "requestTypes": ["XHR"],
+    "fields": ["num_of_contracts"],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
+  },
+  {
+    "url": "https://api.robinhood.com/options/orders/available_shares/{account_number}/",
+    "host": "api.robinhood.com",
+    "categories": ["options", "order-diagnostics"],
+    "risk": "sensitive-read",
+    "methods": ["GET"],
+    "source": "public-web-bundle module 222520 (observed request contract; response semantics unverified)",
+    "queryKeys": ["equity_instrument_id", "order_to_replace_id"],
+    "requestTypes": ["XHR"],
+    "fields": ["num_of_shares"],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
+  },
+  {
+    "url": "https://api.robinhood.com/options/has_recent_rejection/",
+    "host": "api.robinhood.com",
+    "categories": ["options", "order-diagnostics"],
+    "risk": "sensitive-read",
+    "methods": ["GET"],
+    "source": "public-web-bundle module 580605 (observed request contract; response semantics unverified)",
+    "queryKeys": [],
+    "requestTypes": ["XHR"],
+    "fields": ["recent_rejection_exists"],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
+  },
+  {
+    "url": "https://api.robinhood.com/options/exercise_checks/",
+    "host": "api.robinhood.com",
+    "categories": ["options", "order-diagnostics"],
+    "risk": "sensitive-read",
+    "methods": ["GET"],
+    "source": "public-web-bundle module 474280 (observed request contract; response semantics unverified)",
+    "queryKeys": ["account_number", "option_id"],
+    "requestTypes": ["XHR"],
+    "fields": ["exercisable_quantity", "corporate_action_restriction"],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
   }
 ]

--- a/api-map/curl/brokerage-route-templates.sh
+++ b/api-map/curl/brokerage-route-templates.sh
@@ -1109,4 +1109,16 @@
 # sensitive-read GET https://phoenix.robinhood.com/accounts/unified
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://phoenix.robinhood.com/accounts/unified'
 
+# sensitive-read GET https://api.robinhood.com/options/orders/available_contracts/{account_number}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/orders/available_contracts/{account_number}/'
+
+# sensitive-read GET https://api.robinhood.com/options/orders/available_shares/{account_number}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/orders/available_shares/{account_number}/'
+
+# sensitive-read GET https://api.robinhood.com/options/has_recent_rejection/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/has_recent_rejection/'
+
+# sensitive-read GET https://api.robinhood.com/options/exercise_checks/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://api.robinhood.com/options/exercise_checks/'
+
 # Zayd Khan // cold // www.zayd.wtf

--- a/api-map/markdown/brokerage-routes.md
+++ b/api-map/markdown/brokerage-routes.md
@@ -4,8 +4,8 @@ Source: reverse-engineered routes plus sanitized authenticated Chrome/CDP captur
 
 Personal repo semantics: mapped routes can be executed live with caller-owned `ROBINHOOD_BROKERAGE_TOKEN` or `ROBINHOOD_COOKIE`. Pass `--dry-run` when you want a non-sending test plan.
 
-Current count: 368 route templates.
-Risk counts: destructive=9, read=99, sensitive-read=231, write-mutate=11, write-or-sensitive=7, write-safe=11.
+Current count: 372 route templates.
+Risk counts: destructive=9, read=99, sensitive-read=235, write-mutate=11, write-or-sensitive=7, write-safe=11.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -379,5 +379,9 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | destructive | POST | orders | nummus.robinhood.com | wire-writes 2026-05-29 | `https://nummus.robinhood.com/orders/{0}/cancel/` |
 | sensitive-read | GET | account | nummus.robinhood.com | cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://nummus.robinhood.com/portfolios/{uuid}/` |
 | sensitive-read | inferred | account | phoenix.robinhood.com | community-seed | `https://phoenix.robinhood.com/accounts/unified` |
+| sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 452309 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/orders/available_contracts/{account_number}/` |
+| sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 222520 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/orders/available_shares/{account_number}/` |
+| sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 580605 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/has_recent_rejection/` |
+| sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 474280 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/exercise_checks/` |
 
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-exercise-checks.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-exercise-checks.md
@@ -1,0 +1,17 @@
+# GET /options/exercise_checks/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: options, order-diagnostics
+Source: public-web-bundle module 474280 (observed request contract; response semantics unverified)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/exercise_checks/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-has-recent-rejection.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-has-recent-rejection.md
@@ -1,0 +1,17 @@
+# GET /options/has_recent_rejection/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: options, order-diagnostics
+Source: public-web-bundle module 580605 (observed request contract; response semantics unverified)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/has_recent_rejection/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-available-contracts-7baccount-number-7d.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-available-contracts-7baccount-number-7d.md
@@ -1,0 +1,17 @@
+# GET /options/orders/available_contracts/%7Baccount_number%7D/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: options, order-diagnostics
+Source: public-web-bundle module 452309 (observed request contract; response semantics unverified)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/orders/available_contracts/{account_number}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-available-shares-7baccount-number-7d.md
+++ b/api-map/markdown/endpoints/get-api-robinhood-com-options-orders-available-shares-7baccount-number-7d.md
@@ -1,0 +1,17 @@
+# GET /options/orders/available_shares/%7Baccount_number%7D/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: api.robinhood.com
+Categories: options, order-diagnostics
+Source: public-web-bundle module 222520 (observed request contract; response semantics unverified)
+Operation ID: n/a
+
+Route template:
+
+```text
+https://api.robinhood.com/options/orders/available_shares/{account_number}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/robinhood-routes.md
+++ b/api-map/markdown/robinhood-routes.md
@@ -4,10 +4,10 @@ Source: official Robinhood Crypto Trading OpenAPI plus sanitized authenticated C
 
 Crypto operations are official Robinhood-published endpoints and should use Ed25519 signing. Brokerage/account operations are browser-backed route-map entries and use caller-owned brokerage token or browser cookie auth.
 
-Current count: 384 route entries.
+Current count: 388 route entries.
 Official Crypto route entries: 16.
-Brokerage/account route entries: 368.
-Risk counts: destructive=11, read=105, sensitive-read=237, write-mutate=13, write-or-sensitive=7, write-safe=11.
+Brokerage/account route entries: 372.
+Risk counts: destructive=11, read=105, sensitive-read=241, write-mutate=13, write-or-sensitive=7, write-safe=11.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -186,7 +186,9 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | sensitive-read | GET | options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/options/chains/{id}/collateral/` |
 | no | sensitive-read | GET | history-documents, options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/options/corp_actions/` |
 | no | sensitive-read | GET | options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/options/events/` |
+| no | sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 474280 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/exercise_checks/` |
 | no | read | GET | options, trading | api.robinhood.com | cdp-2026-06-04-dram-option-order-flow (observed; per-order fee schedule) | `https://api.robinhood.com/options/fees/` |
+| no | sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 580605 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/has_recent_rejection/` |
 | no | read | GET | instruments, marketdata, options, reference | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2; self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id | `https://api.robinhood.com/options/instruments/` |
 | no | read | GET | options, instruments, reference | api.robinhood.com | self-extension 2026-05-28: list option instruments for a chain/expiry/type -> find strike + option id | `https://api.robinhood.com/options/instruments/?chain_id={chain_id}&expiration_dates={expiration_dates}&state=active&type={type}` |
 | no | read | inferred | marketdata, options | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/options/instruments/{0}/` |
@@ -197,6 +199,8 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | yes | write-mutate | POST | account, options, trading | api.robinhood.com | self-extension 2026-05-28: options order PLACEMENT (POST). Same reason as equity orders; supports legs[] for single/multi-leg. Double-gated. | `https://api.robinhood.com/options/orders/` |
 | no | sensitive-read | GET | options, orders | api.robinhood.com | self-extension 2026-06-11: single OPTIONS order lookup by ID, for the post-cancel/post-send evidence re-read (order-evidence rule). Live-verified 200 against a filled SPXW order. | `https://api.robinhood.com/options/orders/{0}/` |
 | yes | destructive | POST | options, orders | api.robinhood.com | wire-writes 2026-05-29 | `https://api.robinhood.com/options/orders/{0}/cancel/` |
+| no | sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 452309 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/orders/available_contracts/{account_number}/` |
+| no | sensitive-read | GET | options, order-diagnostics | api.robinhood.com | public-web-bundle module 222520 (observed request contract; response semantics unverified) | `https://api.robinhood.com/options/orders/available_shares/{account_number}/` |
 | no | read | GET | options, trading | api.robinhood.com | cdp-2026-06-04-dram-option-order-flow; cdp-2026-06-23-googl-native-roll (response live-verified; collateral pre-check, full order passed url-encoded in ?order={json}) | `https://api.robinhood.com/options/orders/collateral/` |
 | no | sensitive-read | inferred | account, options | api.robinhood.com | brokerage-browser-map | `https://api.robinhood.com/options/positions/` |
 | no | sensitive-read | GET | account, options | api.robinhood.com | cdp-2026-05-26-stock-account-sanitized; cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://api.robinhood.com/options/positions/?account_numbers=` |

--- a/api-map/openapi/robinhood-brokerage.openapi.json
+++ b/api-map/openapi/robinhood-brokerage.openapi.json
@@ -96,6 +96,10 @@
       "description": "Options routes from the brokerage route map."
     },
     {
+      "name": "order-diagnostics",
+      "description": "Order Diagnostics routes from the brokerage route map."
+    },
+    {
       "name": "orders",
       "description": "Orders routes from the brokerage route map."
     },
@@ -25193,6 +25197,59 @@
         ]
       }
     },
+    "/options/exercise_checks/": {
+      "get": {
+        "operationId": "brokerage_get_options_exercise_checks",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "option_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/exercise_checks/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 474280 (observed request contract",
+          "response semantics unverified)"
+        ],
+        "x-robinhood-seen-on": []
+      }
+    },
     "/options/fees/": {
       "get": {
         "operationId": "brokerage_get_options_fees",
@@ -25227,6 +25284,40 @@
         "x-robinhood-seen-on": [
           "option-order-ticket"
         ]
+      }
+    },
+    "/options/has_recent_rejection/": {
+      "get": {
+        "operationId": "brokerage_get_options_has_recent_rejection",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/has_recent_rejection/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 580605 (observed request contract",
+          "response semantics unverified)"
+        ],
+        "x-robinhood-seen-on": []
       }
     },
     "/options/instruments/": {
@@ -26106,6 +26197,130 @@
         ],
         "x-robinhood-sources": [
           "wire-writes 2026-05-29"
+        ],
+        "x-robinhood-seen-on": []
+      }
+    },
+    "/options/orders/available_contracts/{account_number}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_available_contracts_account_number",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "order_to_replace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "strategy_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/available_contracts/{account_number}/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 452309 (observed request contract",
+          "response semantics unverified)"
+        ],
+        "x-robinhood-seen-on": []
+      }
+    },
+    "/options/orders/available_shares/{account_number}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_available_shares_account_number",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "equity_instrument_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "order_to_replace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/available_shares/{account_number}/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 222520 (observed request contract",
+          "response semantics unverified)"
         ],
         "x-robinhood-seen-on": []
       }

--- a/api-map/openapi/robinhood-unified.openapi.json
+++ b/api-map/openapi/robinhood-unified.openapi.json
@@ -124,6 +124,10 @@
       "description": "Options routes from the brokerage route map."
     },
     {
+      "name": "order-diagnostics",
+      "description": "Order Diagnostics routes from the brokerage route map."
+    },
+    {
       "name": "orders",
       "description": "Orders routes from the brokerage route map."
     },
@@ -27292,6 +27296,60 @@
         "x-robinhood-source": "brokerage-browser-map"
       }
     },
+    "/options/exercise_checks/": {
+      "get": {
+        "operationId": "brokerage_get_options_exercise_checks",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "option_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/exercise_checks/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 474280 (observed request contract",
+          "response semantics unverified)"
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
     "/options/fees/": {
       "get": {
         "operationId": "brokerage_get_options_fees",
@@ -27326,6 +27384,41 @@
         "x-robinhood-seen-on": [
           "option-order-ticket"
         ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/options/has_recent_rejection/": {
+      "get": {
+        "operationId": "brokerage_get_options_has_recent_rejection",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/has_recent_rejection/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 580605 (observed request contract",
+          "response semantics unverified)"
+        ],
+        "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"
       }
     },
@@ -28214,6 +28307,132 @@
         ],
         "x-robinhood-sources": [
           "wire-writes 2026-05-29"
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/options/orders/available_contracts/{account_number}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_available_contracts_account_number",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "order_to_replace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "strategy_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/available_contracts/{account_number}/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 452309 (observed request contract",
+          "response semantics unverified)"
+        ],
+        "x-robinhood-seen-on": [],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/options/orders/available_shares/{account_number}/": {
+      "get": {
+        "operationId": "brokerage_get_options_orders_available_shares_account_number",
+        "summary": "Options brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "options",
+          "order-diagnostics"
+        ],
+        "parameters": [
+          {
+            "name": "account_number",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder account_number. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "equity_instrument_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          },
+          {
+            "name": "order_to_replace_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "api.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://api.robinhood.com/options/orders/available_shares/{account_number}/"
+        ],
+        "x-robinhood-sources": [
+          "public-web-bundle module 222520 (observed request contract",
+          "response semantics unverified)"
         ],
         "x-robinhood-seen-on": [],
         "x-robinhood-source": "brokerage-browser-map"

--- a/api-map/recipes.json
+++ b/api-map/recipes.json
@@ -626,6 +626,22 @@
       "mcpTool": "robinhood_hotlist",
       "risk": "read",
       "notes": "Reads repo-root hotlist.md (one `TICKER — thesis` per line; example-marked lines ignored) and quotes every ticker live: last, day $ and %, thesis. Operators maintain the file; agents read it alongside ball-knowledge.md."
+    },
+    {
+      "id": "options-diagnostics",
+      "intent": "Read-only options availability, recent rejection, rollable quantity, or exercise checks",
+      "triggers": [
+        "options diagnostics",
+        "available contracts",
+        "available shares",
+        "recent option rejection",
+        "rollable quantity",
+        "exercise checks"
+      ],
+      "command": "options diagnostics --account <N> [--strategy-code <CODE>] [--equity-instrument-id <UUID>] [--option-id <UUID>] [--order-to-replace-id <UUID>] [--json]",
+      "mcpTool": "robinhood_options_diagnostics",
+      "risk": "sensitive-read",
+      "notes": "Strictly read-only availability/rejection/exercise diagnostics; endpoint-specific missing inputs SKIP locally. availableContracts, availableShares, recentRejection, and exerciseChecks are public-bundle observed-contract evidence; maximumRollableQuantity is live-verified. Never reviews or submits an order."
     }
   ]
 }

--- a/api-map/robinhood-routes.json
+++ b/api-map/robinhood-routes.json
@@ -15835,6 +15835,33 @@
     ]
   },
   {
+    "url": "https://api.robinhood.com/options/exercise_checks/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "order-diagnostics"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "public-web-bundle module 474280 (observed request contract; response semantics unverified)",
+    "queryKeys": [
+      "account_number",
+      "option_id"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "exercisable_quantity",
+      "corporate_action_restriction"
+    ],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
+  },
+  {
     "url": "https://api.robinhood.com/options/fees/",
     "host": "api.robinhood.com",
     "categories": [
@@ -15866,6 +15893,29 @@
     ],
     "fieldsSource": "verified",
     "fieldsShape": "object"
+  },
+  {
+    "url": "https://api.robinhood.com/options/has_recent_rejection/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "order-diagnostics"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "public-web-bundle module 580605 (observed request contract; response semantics unverified)",
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "recent_rejection_exists"
+    ],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
   },
   {
     "url": "https://api.robinhood.com/options/instruments/",
@@ -16588,6 +16638,58 @@
     "source": "wire-writes 2026-05-29",
     "fields": [],
     "fieldsSource": "undocumented"
+  },
+  {
+    "url": "https://api.robinhood.com/options/orders/available_contracts/{account_number}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "order-diagnostics"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "public-web-bundle module 452309 (observed request contract; response semantics unverified)",
+    "queryKeys": [
+      "strategy_code",
+      "order_to_replace_id"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "num_of_contracts"
+    ],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
+  },
+  {
+    "url": "https://api.robinhood.com/options/orders/available_shares/{account_number}/",
+    "host": "api.robinhood.com",
+    "categories": [
+      "options",
+      "order-diagnostics"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "public-web-bundle module 222520 (observed request contract; response semantics unverified)",
+    "queryKeys": [
+      "equity_instrument_id",
+      "order_to_replace_id"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "num_of_shares"
+    ],
+    "fieldsSource": "inferred",
+    "fieldsShape": "object",
+    "verificationStatus": "inferred"
   },
   {
     "url": "https://api.robinhood.com/options/orders/collateral/",

--- a/cli/src/capabilities.ts
+++ b/cli/src/capabilities.ts
@@ -61,6 +61,7 @@ const LEGACY_MCP_TOOLS = [
   "robinhood_options_holdings",
   "robinhood_options_inspect",
   "robinhood_options_order_flow",
+  "robinhood_options_diagnostics",
   "robinhood_options_roll_plan",
   "robinhood_options_strategy_plan",
   "robinhood_options_strategy_quote",
@@ -146,6 +147,7 @@ const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly st
     "robinhood_options_holdings",
     "robinhood_options_inspect",
     "robinhood_options_order_flow",
+    "robinhood_options_diagnostics",
     "robinhood_options_roll_plan",
     "robinhood_options_strategy_plan",
     "robinhood_options_strategy_quote",
@@ -204,6 +206,7 @@ const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly st
     "robinhood_options_holdings",
     "robinhood_options_inspect",
     "robinhood_options_order_flow",
+    "robinhood_options_diagnostics",
     "robinhood_options_roll_plan",
     "robinhood_options_strategy_plan",
     "robinhood_options_strategy_quote",
@@ -333,6 +336,7 @@ function profilesForMcp(mcp: string): CapabilityProfile[] {
 function legacyDefinition(mcp: LegacyMcpTool): CapabilityDefinition {
   return {
     id: mcp.replace(/^robinhood_/, ""),
+    cli: mcp === "robinhood_options_diagnostics" ? "options diagnostics" : undefined,
     mcp,
     access: WRITE_TOOL_NAMES.has(mcp) ? "write" : "read",
     profiles: profilesForMcp(mcp),

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -93,6 +93,7 @@ import {
   loadRecipes,
   filterRecipes,
   readOptionsOrderFlow,
+  readOptionsOrderDiagnostics,
   loadOptionsStrategyWorkflows,
   loadRobinhoodRoutes,
   optionReturnPct,
@@ -1606,6 +1607,48 @@ options
       process.stdout.write(`Supplemental chain collateral: ${JSON.stringify(flow.chainCollateral).slice(0, 200)}\n`);
     for (const w of flow.warnings) process.stderr.write(`warning: ${w}\n`);
     process.stdout.write(`\nRead-only context only: this command never reviews or submits the prospective order.\n`);
+  });
+
+options
+  .command("diagnostics")
+  .description("Read-only options availability, rejection, rollable-quantity, and exercise diagnostics; never reviews or submits an order")
+  .option("--account <account_number>", "account for account-scoped diagnostics")
+  .option("--strategy-code <strategy_code>", "strategy code for available-contracts and maximum-rollable-quantity")
+  .option("--equity-instrument-id <uuid>", "equity instrument UUID for available-shares")
+  .option("--option-id <uuid>", "option instrument UUID for exercise checks")
+  .option("--order-to-replace-id <uuid>", "optional replacement-order UUID for availability reads")
+  .option("--json", "emit JSON")
+  .action(async (opts: {
+    account?: string;
+    strategyCode?: string;
+    equityInstrumentId?: string;
+    optionId?: string;
+    orderToReplaceId?: string;
+    json?: boolean;
+  }) => {
+    const diagnostics = await readOptionsOrderDiagnostics({
+      accountNumber: opts.account,
+      strategyCode: opts.strategyCode,
+      equityInstrumentId: opts.equityInstrumentId,
+      optionId: opts.optionId,
+      orderToReplaceId: opts.orderToReplaceId,
+    });
+    if (opts.json) {
+      printJson(diagnostics);
+      return;
+    }
+    if (diagnostics.availableContracts !== undefined)
+      process.stdout.write(`Available contracts: ${diagnostics.availableContracts}\n`);
+    if (diagnostics.availableShares !== undefined)
+      process.stdout.write(`Available shares: ${diagnostics.availableShares}\n`);
+    if (diagnostics.rollable)
+      process.stdout.write(`Maximum rollable quantity: ${diagnostics.rollable.availableQuantity} (pending close ${diagnostics.rollable.pendingClosingQuantity}; total ${diagnostics.rollable.totalQuantity})\n`);
+    if (diagnostics.recentRejectionExists !== undefined)
+      process.stdout.write(`Recent rejection exists: ${diagnostics.recentRejectionExists}\n`);
+    if (diagnostics.exerciseChecks)
+      process.stdout.write(`Exercisable quantity: ${diagnostics.exerciseChecks.exercisableQuantity}\n`);
+    for (const warning of diagnostics.warnings) process.stderr.write(`warning: ${warning}\n`);
+    process.stdout.write("\nRead-only diagnostics only: this command never reviews or submits an order. Bundle-derived fields are observed-contract; rollable quantity is live-verified.\n");
   });
 
 options

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -3095,7 +3095,7 @@ export async function computePortfolioPnl(
         optionPositions: [],
         warnings: [] as string[],
       };
-    try {
+      try {
         const p = await getJson("https://api.robinhood.com/portfolios/{account_number}/", {
           account_number: acct,
         });
@@ -3105,28 +3105,28 @@ export async function computePortfolioPnl(
           rawPrev = n(p.equity_previous_close);
         const prevClose =
           Number.isFinite(adjPrev) && (adjPrev !== 0 || equity === 0)
-        ? adjPrev
+            ? adjPrev
             : Number.isFinite(rawPrev) && (rawPrev !== 0 || equity === 0)
               ? rawPrev
               : Number.NaN;
-      a.equity = equity;
-      a.currentEquity = Number.isFinite(ext) ? ext : equity;
-      a.afterHours = Number.isFinite(ext) && Number.isFinite(equity) ? ext - equity : Number.NaN;
+        a.equity = equity;
+        a.currentEquity = Number.isFinite(ext) ? ext : equity;
+        a.afterHours = Number.isFinite(ext) && Number.isFinite(equity) ? ext - equity : Number.NaN;
         a.reportedDay =
           Number.isFinite(equity) && Number.isFinite(prevClose) ? equity - prevClose : Number.NaN;
       } catch (e: any) {
         a.warnings.push(`portfolio read failed (${acct}): ${(e as Error).message.slice(0, 50)}`);
       }
-    try {
+      try {
         const bp = await getJson(
           "https://api.robinhood.com/accounts/{num}/buying_power_breakdown",
           { num: acct },
         );
-      a.buyingPower = n(bp.buying_power);
+        a.buyingPower = n(bp.buying_power);
       } catch {
         a.warnings.push(`buying power read failed (${acct})`);
       }
-    try {
+      try {
         const eq = await getAll(
           "https://api.robinhood.com/positions/",
           {},
@@ -3138,7 +3138,7 @@ export async function computePortfolioPnl(
       } catch {
         a.warnings.push(`equity positions read failed (${acct})`);
       }
-    try {
+      try {
         const od = await getAll(
           "https://api.robinhood.com/options/aggregate_positions/?account_numbers=",
           {},
@@ -3152,7 +3152,7 @@ export async function computePortfolioPnl(
             oid: x.legs?.[0]?.option_id,
             qty: n(x.quantity),
             underlyingType: x.underlying_type ?? null,
-  }));
+          }));
       } catch {
         a.warnings.push(`option positions read failed (${acct})`);
       }
@@ -3343,10 +3343,10 @@ export async function computePortfolioPnl(
   const mispricedAfterHoursPositions = drivers.filter((d) => !Number.isFinite(d.ahUsd)).length;
   const mispricedPositions =
     window === "day"
-    ? mispricedDayPositions
-    : window === "after-hours"
-      ? mispricedAfterHoursPositions
-      : drivers.filter((d) => !Number.isFinite(d.dayUsd) || !Number.isFinite(d.ahUsd)).length;
+      ? mispricedDayPositions
+      : window === "after-hours"
+        ? mispricedAfterHoursPositions
+        : drivers.filter((d) => !Number.isFinite(d.dayUsd) || !Number.isFinite(d.ahUsd)).length;
   for (const a of perAccount) {
     const accountDrivers = drivers.filter((d) => d.acct === a.acct);
     a.day = accountDrivers.some((d) => !Number.isFinite(d.dayUsd))
@@ -3355,9 +3355,9 @@ export async function computePortfolioPnl(
   }
   const failedReads = perAccount.filter(
     (a) =>
-    !Number.isFinite(a.currentEquity) ||
-    (accountNeedsDay && !Number.isFinite(a.day)) ||
-    (accountNeedsAfterHours && !Number.isFinite(a.afterHours)),
+      !Number.isFinite(a.currentEquity) ||
+      (accountNeedsDay && !Number.isFinite(a.day)) ||
+      (accountNeedsAfterHours && !Number.isFinite(a.afterHours)),
   ).length;
   const driverDaySum = drivers.reduce((s, d) => s + (Number.isFinite(d.dayUsd) ? d.dayUsd : 0), 0);
   const driverAfterHoursSum = drivers.reduce(
@@ -3377,8 +3377,8 @@ export async function computePortfolioPnl(
   };
   const residual =
     Number.isFinite(reportedAccountDayDelta) && mispricedDayPositions === 0
-    ? reportedAccountDayDelta - driverDaySum
-    : Number.NaN;
+      ? reportedAccountDayDelta - driverDaySum
+      : Number.NaN;
   // After-hours is meaningful only in an extended session; intraday/closed it's ~0. Flag so callers don't
   // read a regular-session "$0 after-hours / no AH losers" as a failed or flat session.
   const afterHoursActive = perAccount.some(
@@ -3459,8 +3459,8 @@ export async function computePortfolioPnl(
       driverAfterHoursChangeUsd: driverAfterHoursSum,
       afterHoursResidualUsd:
         Number.isFinite(totals.afterHours) && mispricedAfterHoursPositions === 0
-        ? totals.afterHours - driverAfterHoursSum
-        : Number.NaN,
+          ? totals.afterHours - driverAfterHoursSum
+          : Number.NaN,
       mispricedPositions,
       mispricedDayPositions,
       mispricedAfterHoursPositions,
@@ -3502,6 +3502,8 @@ export interface OptionsOrderFlow {
   collateral?: any;
   /** Supplemental chain-level context; never a substitute for order-specific collateral. */
   chainCollateral?: unknown;
+  /** Explicit ledger for calculations that could not be evaluated because required input was absent. */
+  notEvaluated: Array<{ surface: string; reason: string }>;
   warnings: string[];
 }
 export async function readOptionsOrderFlow(
@@ -3514,7 +3516,11 @@ export async function readOptionsOrderFlow(
   deps: { getJson?: typeof brokerageGetJson } = {},
 ): Promise<OptionsOrderFlow> {
   const getJson = deps.getJson ?? brokerageGetJson;
-  const out: OptionsOrderFlow = { accountNumber: opts.accountNumber, warnings: [] };
+  const out: OptionsOrderFlow = {
+    accountNumber: opts.accountNumber,
+    notEvaluated: [],
+    warnings: [],
+  };
   if (opts.accountNumber) {
     try {
       out.buyingPower = await getJson(
@@ -3525,7 +3531,10 @@ export async function readOptionsOrderFlow(
       out.warnings.push(`options buying power read failed: ${(e as Error).message.slice(0, 60)}`);
     }
   } else {
-    out.warnings.push("no --account given: options buying power is per-account and was skipped.");
+    out.notEvaluated.push({ surface: "buyingPower", reason: "accountNumber is required" });
+    out.warnings.push(
+      "options buying power not evaluated: accountNumber is required for this per-account surface.",
+    );
   }
   if (opts.legs) {
     try {
@@ -3538,7 +3547,8 @@ export async function readOptionsOrderFlow(
       out.warnings.push(`options fees read failed: ${(e as Error).message.slice(0, 60)}`);
     }
   } else {
-    out.warnings.push("no prospective legs given: order-specific options fees were skipped.");
+    out.notEvaluated.push({ surface: "fees", reason: "prospective legs are required" });
+    out.warnings.push("order-specific options fees not evaluated: prospective legs are required.");
   }
   if (opts.order) {
     try {
@@ -3551,7 +3561,13 @@ export async function readOptionsOrderFlow(
       out.warnings.push(`options collateral read failed: ${(e as Error).message.slice(0, 60)}`);
     }
   } else {
-    out.warnings.push("no prospective order given: order-specific options collateral was skipped.");
+    out.notEvaluated.push({
+      surface: "collateral",
+      reason: "a complete prospective order is required",
+    });
+    out.warnings.push(
+      "order-specific options collateral not evaluated: a complete prospective order is required.",
+    );
   }
   if (opts.chainId) {
     try {
@@ -3560,14 +3576,188 @@ export async function readOptionsOrderFlow(
         { id: opts.chainId },
       );
     } catch (e: unknown) {
-      out.warnings.push(`chain collateral context read failed: ${(e as Error).message.slice(0, 60)}`);
+      out.warnings.push(
+        `chain collateral context read failed: ${(e as Error).message.slice(0, 60)}`,
+      );
     }
   }
   return out;
 }
 
 /**
- * Generic env-gated brokerage write, shared by the CLI and the MCP server. Pass the EXACT templated
+ * Read-only options order diagnostics. Each endpoint is input-gated locally so this function never
+ * emits a malformed/naked request. Bundle-derived contracts remain observed-contract until a
+ * sanitized authenticated response confirms semantics; maximum rollable quantity is live-verified.
+ * This intentionally excludes review/submission and all other POST order surfaces.
+ */
+export interface OptionsOrderDiagnostics {
+  accountNumber?: string;
+  availableContracts?: number;
+  availableShares?: number;
+  rollable?: {
+    availableQuantity: number;
+    pendingClosingQuantity: number;
+    totalQuantity: number;
+    strategyCode: string;
+  };
+  recentRejectionExists?: boolean;
+  exerciseChecks?: {
+    exercisableQuantity: number;
+    corporateActionRestriction: unknown;
+    raw: unknown;
+  };
+  notEvaluated: Array<{ surface: string; reason: string }>;
+  warnings: string[];
+  evidence: {
+    availableContracts: "observed-contract";
+    availableShares: "observed-contract";
+    recentRejection: "live-verified";
+    exerciseChecks: "observed-contract";
+    maximumRollableQuantity: "live-verified";
+  };
+}
+
+function diagnosticsNumber(value: unknown): number {
+  const result = Number(value);
+  return Number.isFinite(result) ? result : Number.NaN;
+}
+
+export async function readOptionsOrderDiagnostics(
+  opts: {
+    accountNumber?: string;
+    strategyCode?: string;
+    equityInstrumentId?: string;
+    optionId?: string;
+    orderToReplaceId?: string;
+  } = {},
+  deps: { getJson?: typeof brokerageGetJson } = {},
+): Promise<OptionsOrderDiagnostics> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  const out: OptionsOrderDiagnostics = {
+    accountNumber: opts.accountNumber,
+    notEvaluated: [],
+    warnings: [],
+    evidence: {
+      availableContracts: "observed-contract",
+      availableShares: "observed-contract",
+      recentRejection: "live-verified",
+      exerciseChecks: "observed-contract",
+      maximumRollableQuantity: "live-verified",
+    },
+  };
+  if (opts.accountNumber && opts.strategyCode) {
+    const replacement: Record<string, string> = opts.orderToReplaceId
+      ? { order_to_replace_id: opts.orderToReplaceId }
+      : {};
+    try {
+      const value = await getJson(
+        "https://api.robinhood.com/options/orders/available_contracts/{account_number}/",
+        { account_number: opts.accountNumber },
+        { strategy_code: opts.strategyCode, ...replacement },
+      );
+      const normalized = diagnosticsNumber(value?.num_of_contracts);
+      if (Number.isFinite(normalized)) out.availableContracts = normalized;
+      else out.warnings.push("available contracts response omitted a numeric num_of_contracts.");
+    } catch (e: unknown) {
+      out.warnings.push(`available contracts read failed: ${(e as Error).message.slice(0, 60)}`);
+    }
+    try {
+      const value = await getJson(
+        "https://api.robinhood.com/options/maximum_rollable_quantity/{strategy_code}/",
+        { strategy_code: opts.strategyCode },
+        { account_number: opts.accountNumber },
+      );
+      const availableQuantity = diagnosticsNumber(value?.available_quantity);
+      const pendingClosingQuantity = diagnosticsNumber(value?.pending_closing_quantity);
+      const totalQuantity = diagnosticsNumber(value?.total_quantity);
+      if ([availableQuantity, pendingClosingQuantity, totalQuantity].every(Number.isFinite)) {
+        out.rollable = {
+          availableQuantity,
+          pendingClosingQuantity,
+          totalQuantity,
+          strategyCode: opts.strategyCode,
+        };
+      } else
+        out.warnings.push(
+          "maximum rollable quantity response omitted one or more numeric quantity fields.",
+        );
+    } catch (e: unknown) {
+      out.warnings.push(
+        `maximum rollable quantity read failed: ${(e as Error).message.slice(0, 60)}`,
+      );
+    }
+  } else {
+    out.notEvaluated.push({
+      surface: "availableContractsAndRollableQuantity",
+      reason: "accountNumber and strategyCode are required",
+    });
+    out.warnings.push(
+      "available contracts and rollable quantity not evaluated: both account and strategy code are required.",
+    );
+  }
+  if (opts.accountNumber && opts.equityInstrumentId) {
+    try {
+      const replacement: Record<string, string> = opts.orderToReplaceId
+        ? { order_to_replace_id: opts.orderToReplaceId }
+        : {};
+      const value = await getJson(
+        "https://api.robinhood.com/options/orders/available_shares/{account_number}/",
+        { account_number: opts.accountNumber },
+        { equity_instrument_id: opts.equityInstrumentId, ...replacement },
+      );
+      const normalized = diagnosticsNumber(value?.num_of_shares);
+      if (Number.isFinite(normalized)) out.availableShares = normalized;
+      else out.warnings.push("available shares response omitted a numeric num_of_shares.");
+    } catch (e: unknown) {
+      out.warnings.push(`available shares read failed: ${(e as Error).message.slice(0, 60)}`);
+    }
+  } else {
+    out.notEvaluated.push({
+      surface: "availableShares",
+      reason: "accountNumber and equityInstrumentId are required",
+    });
+    out.warnings.push(
+      "available shares not evaluated: both account and equity instrument ID are required.",
+    );
+  }
+  try {
+    const value = await getJson("https://api.robinhood.com/options/has_recent_rejection/");
+    if (typeof value?.recent_rejection_exists === "boolean")
+      out.recentRejectionExists = value.recent_rejection_exists;
+    else out.warnings.push("recent rejection response omitted boolean recent_rejection_exists.");
+  } catch (e: unknown) {
+    out.warnings.push(`recent rejection read failed: ${(e as Error).message.slice(0, 60)}`);
+  }
+  if (opts.accountNumber && opts.optionId) {
+    try {
+      const value = await getJson(
+        "https://api.robinhood.com/options/exercise_checks/",
+        {},
+        { account_number: opts.accountNumber, option_id: opts.optionId },
+      );
+      const exercisableQuantity = diagnosticsNumber(value?.exercisable_quantity);
+      if (Number.isFinite(exercisableQuantity)) {
+        out.exerciseChecks = {
+          exercisableQuantity,
+          corporateActionRestriction: value?.corporate_action_restriction,
+          raw: value,
+        };
+      } else out.warnings.push("exercise checks response omitted a numeric exercisable_quantity.");
+    } catch (e: unknown) {
+      out.warnings.push(`exercise checks read failed: ${(e as Error).message.slice(0, 60)}`);
+    }
+  } else {
+    out.notEvaluated.push({
+      surface: "exerciseChecks",
+      reason: "accountNumber and optionId are required",
+    });
+    out.warnings.push("exercise checks not evaluated: both account and option ID are required.");
+  }
+  return out;
+}
+
+/**
+ * Generic env-gated brokerage write, shared by the CLI and the MCP server.
  * URL (with {placeholders}) so the resolver matches one route and the ambiguity guard can't fire. The
  * gate engages on write verbs even if a route's risk is mis-classified (verb floor). Dry-run by default;
  * a live send needs ROBINHOOD_ALLOW_LIVE_WRITE=1 (the single switch; liveWrite:true optional). Hoisted here so the write path
@@ -6403,9 +6593,7 @@ export async function readAccountPulse(
               : Array.isArray(ceres)
                 ? ceres
                 : [];
-            const matches = rows.filter(
-              (row) => row?.id && String(row?.rhsAccountNumber) === acct,
-            );
+            const matches = rows.filter((row) => row?.id && String(row?.rhsAccountNumber) === acct);
             if (!matches.length) return;
             const surfaces = await Promise.all(
               matches.map(async (row) => {
@@ -6842,7 +7030,8 @@ export async function listDocuments(
     )
     .sort((a: DocumentRecord, b: DocumentRecord) => b.date.localeCompare(a.date));
   const total = documents.length;
-  const limit = Number.isFinite(opts.limit) && Number(opts.limit) > 0 ? Math.floor(Number(opts.limit)) : total;
+  const limit =
+    Number.isFinite(opts.limit) && Number(opts.limit) > 0 ? Math.floor(Number(opts.limit)) : total;
   const boundedDocuments = documents.slice(0, limit);
   const byType: Record<string, number> = {};
   for (const d of boundedDocuments) byType[d.type] = (byType[d.type] ?? 0) + 1;
@@ -10203,13 +10392,15 @@ export async function getSweepInterest(
     if (apyPct !== null) {
       return {
         accountNumber: opts.accountNumber ?? null,
-        rates: [{
-          balanceTier: "Gold cash sweep",
-          apyPct,
-          interestRatePct: null,
-          effectiveDate: null,
-          source: "gold-sweep-splash",
-        }],
+        rates: [
+          {
+            balanceTier: "Gold cash sweep",
+            apyPct,
+            interestRatePct: null,
+            effectiveDate: null,
+            source: "gold-sweep-splash",
+          },
+        ],
         warnings,
       };
     }
@@ -10232,11 +10423,13 @@ export async function getSweepInterest(
 
   const raw = Array.isArray(data?.results)
     ? data.results
-    : data?.interest_rates ?? data?.rates ?? (Array.isArray(data) ? data : [data]);
+    : (data?.interest_rates ?? data?.rates ?? (Array.isArray(data) ? data : [data]));
   const rates: SweepInterestRecord[] = raw
     .filter((record: any) => record && typeof record === "object")
     .map((record: any) => ({
-      balanceTier: String(record?.balance_tier ?? record?.tier ?? record?.label ?? "Account cash sweep"),
+      balanceTier: String(
+        record?.balance_tier ?? record?.tier ?? record?.label ?? "Account cash sweep",
+      ),
       apyPct: finiteSweepNumber(
         record?.apy ?? record?.apy_pct ?? record?.annual_percentage_yield ?? record?.interest_rate,
       ),
@@ -10266,8 +10459,13 @@ export async function listGoldFees(
   opts: { accountNumber?: string; offset?: number; limit?: number } = {},
   deps: { getAll?: typeof brokerageGetAllResults } = {},
 ): Promise<{
-  count: number; total: number; offset: number; limit: number;
-  hasMore: boolean; fees: GoldFeeRecord[]; warnings: string[];
+  count: number;
+  total: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
+  fees: GoldFeeRecord[];
+  warnings: string[];
 }> {
   const getAll = deps.getAll ?? brokerageGetAllResults;
   const limit = opts.limit && opts.limit >= 1 ? opts.limit : 100;
@@ -10278,17 +10476,14 @@ export async function listGoldFees(
   try {
     const q: Record<string, string> = {};
     if (opts.accountNumber) q.account_number = opts.accountNumber;
-    raw = await getAll(
-      "https://bonfire.robinhood.com/gold/get_subscription_fee_list/",
-      {}, q,
-    );
+    raw = await getAll("https://bonfire.robinhood.com/gold/get_subscription_fee_list/", {}, q);
   } catch (e: any) {
     warnings.push(`gold fee read failed: ${(e as Error).message.slice(0, 80)}`);
     return { count: 0, total: 0, offset: 0, limit, hasMore: false, fees: [], warnings };
   }
 
-  const n = (v: unknown): number => (Number(v) || Number.NaN);
-  const all: any[] = Array.isArray(raw) ? raw : raw?.results ?? [];
+  const n = (v: unknown): number => Number(v) || Number.NaN;
+  const all: any[] = Array.isArray(raw) ? raw : (raw?.results ?? []);
 
   const fees: GoldFeeRecord[] = all
     .filter((f: any) => f && typeof f === "object")
@@ -10300,19 +10495,27 @@ export async function listGoldFees(
       billedAt: f?.billed_at ?? f?.date ?? null,
       periodStart: f?.period_start ?? f?.billing_period_start ?? null,
       periodEnd: f?.period_end ?? f?.billing_period_end ?? null,
-      accountNumber: String(
-        f?.account_number ??
-          (typeof f?.account === "string"
-            ? f.account.match(/\/accounts\/([^/]+)\/?/)?.[1] : "") ?? ""
-      ) || null,
+      accountNumber:
+        String(
+          f?.account_number ??
+            (typeof f?.account === "string"
+              ? f.account.match(/\/accounts\/([^/]+)\/?/)?.[1]
+              : "") ??
+            "",
+        ) || null,
     }));
 
   const total = fees.length;
   const page = fees.slice(offset, offset + limit);
 
   return {
-    count: page.length, total, offset, limit,
-    hasMore: offset + limit < total, fees: page, warnings,
+    count: page.length,
+    total,
+    offset,
+    limit,
+    hasMore: offset + limit < total,
+    fees: page,
+    warnings,
   };
 }
 
@@ -10322,7 +10525,14 @@ export interface StockRewardSummary {
   total: number;
   sectionCounts: Record<string, number>;
   typeCounts: Record<string, number>;
-  rewards: Array<{ id: string | null; itemType: string; rewardType: string | null; status: string | null; quantity: number | null; currencyCode: string | null }>;
+  rewards: Array<{
+    id: string | null;
+    itemType: string;
+    rewardType: string | null;
+    status: string | null;
+    quantity: number | null;
+    currencyCode: string | null;
+  }>;
 }
 
 /** Summarize stock rewards without copying referral objects, names, or contact details. */
@@ -10332,30 +10542,44 @@ export async function getStockRewardsSummary(
 ): Promise<StockRewardSummary> {
   const getJson = deps.getJson ?? brokerageGetJson;
   const data = await getJson("https://bonfire.robinhood.com/rewards/reward/stocks/");
-  const sections: unknown[] = Array.isArray(data) ? data : Array.isArray(data?.results) ? data.results : [];
+  const sections: unknown[] = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.results)
+      ? data.results
+      : [];
   const sectionCounts: Record<string, number> = {};
   const typeCounts: Record<string, number> = {};
   const rewards: StockRewardSummary["rewards"] = [];
   for (const section of sections) {
-    const row = section && typeof section === "object" ? section as Record<string, unknown> : {};
+    const row = section && typeof section === "object" ? (section as Record<string, unknown>) : {};
     const name = typeof row.section_name === "string" ? row.section_name : "Unknown";
     const items = Array.isArray(row.items) ? row.items : [];
     sectionCounts[name] = (sectionCounts[name] ?? 0) + items.length;
     for (const item of items) {
-      const record = item && typeof item === "object" ? item as Record<string, unknown> : {};
+      const record = item && typeof item === "object" ? (item as Record<string, unknown>) : {};
       const itemType = typeof record.type === "string" ? record.type : "unknown";
       typeCounts[itemType] = (typeCounts[itemType] ?? 0) + 1;
-      const dataRecord = record.data && typeof record.data === "object" ? record.data as Record<string, unknown> : {};
-      const reward = dataRecord.reward && typeof dataRecord.reward === "object" ? dataRecord.reward as Record<string, unknown> : {};
+      const dataRecord =
+        record.data && typeof record.data === "object"
+          ? (record.data as Record<string, unknown>)
+          : {};
+      const reward =
+        dataRecord.reward && typeof dataRecord.reward === "object"
+          ? (dataRecord.reward as Record<string, unknown>)
+          : {};
       const rawQuantity = reward.reward_qty ?? reward.quantity;
       const quantity = Number(rawQuantity);
       rewards.push({
         id: typeof reward.id === "string" ? reward.id : null,
         itemType,
         rewardType: typeof reward.reward_type === "string" ? reward.reward_type : null,
-        status: typeof (reward.state ?? reward.status) === "string" ? String(reward.state ?? reward.status) : null,
+        status:
+          typeof (reward.state ?? reward.status) === "string"
+            ? String(reward.state ?? reward.status)
+            : null,
         quantity: Number.isFinite(quantity) ? quantity : null,
-        currencyCode: typeof reward.asset_currency_code === "string" ? reward.asset_currency_code : null,
+        currencyCode:
+          typeof reward.asset_currency_code === "string" ? reward.asset_currency_code : null,
       });
     }
   }
@@ -10384,20 +10608,26 @@ export async function getInboxSummary(
     getJson("https://api.robinhood.com/inbox/threads/"),
   ]);
   const rows: unknown[] = Array.isArray(threads?.results) ? threads.results : [];
-  let unread = 0, critical = 0, muted = 0;
+  let unread = 0,
+    critical = 0,
+    muted = 0;
   let latestActivity: string | null = null;
   for (const thread of rows) {
-    const row = thread && typeof thread === "object" ? thread as Record<string, unknown> : {};
+    const row = thread && typeof thread === "object" ? (thread as Record<string, unknown>) : {};
     if (row.is_read === false) unread++;
     if (row.is_critical === true) critical++;
     if (row.is_muted === true) muted++;
     const activity = row.last_message_sent_at ?? row.updated_at;
-    if (typeof activity === "string" && (!latestActivity || activity > latestActivity)) latestActivity = activity;
+    if (typeof activity === "string" && (!latestActivity || activity > latestActivity))
+      latestActivity = activity;
   }
   const total = Number(threads?.count);
   return {
     total: Number.isFinite(total) ? total : rows.length,
-    unread, critical, muted, latestActivity,
+    unread,
+    critical,
+    muted,
+    latestActivity,
     hasNext: Boolean(threads?.next),
     hasBadge: Boolean(badge?.shouldBadge),
     hasCriticalBadge: Boolean(badge?.shouldCriticalBadge),
@@ -10423,12 +10653,26 @@ export interface IpoAccessOffering {
 export async function getIpoAccess(
   opts: { symbol?: string } = {},
   deps: { getJson?: typeof brokerageGetJson } = {},
-): Promise<{ offerings: IpoAccessOffering[]; openOfferingCount: number; eligibility: { eligibleAccounts: number; restrictedAccounts: number; restrictionReasons: string[] }; message: string | null; warnings: string[] }> {
+): Promise<{
+  offerings: IpoAccessOffering[];
+  openOfferingCount: number;
+  eligibility: {
+    eligibleAccounts: number;
+    restrictedAccounts: number;
+    restrictionReasons: string[];
+  };
+  message: string | null;
+  warnings: string[];
+}> {
   const getJson = deps.getJson ?? brokerageGetJson;
   const symbols: string[] = [];
   if (opts.symbol) symbols.push(opts.symbol.trim().toUpperCase());
   else {
-    const list = await getJson("https://api.robinhood.com/discovery/lists/items/", {}, { list_id: IPO_ACCESS_LIST_ID, owner_type: "robinhood" });
+    const list = await getJson(
+      "https://api.robinhood.com/discovery/lists/items/",
+      {},
+      { list_id: IPO_ACCESS_LIST_ID, owner_type: "robinhood" },
+    );
     for (const item of Array.isArray(list?.results) ? list.results : []) {
       if (typeof item?.symbol === "string") symbols.push(item.symbol.toUpperCase());
     }
@@ -10436,44 +10680,78 @@ export async function getIpoAccess(
   const offerings: IpoAccessOffering[] = [];
   const warnings: string[] = [];
   for (const symbol of [...new Set(symbols)]) {
-    const instrument = (await getJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol })).results?.[0];
+    const instrument = (
+      await getJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol })
+    ).results?.[0];
     if (!instrument?.id) continue;
     let summary: any = {};
     // Listing historical/public offerings should not fan out into a feature-gated
     // detail call per symbol. A direct show and an actually open offering do need it.
     if (opts.symbol || instrument.ipo_access_status === "open") {
       try {
-        summary = await getJson("https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/", { ipo_id: instrument.id });
+        summary = await getJson(
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/",
+          { ipo_id: instrument.id },
+        );
       } catch (error) {
         // The offering's public instrument fields remain useful if a feature-gated/retired
         // summary viewmodel is unavailable. Do not turn a read-only list into a hard failure.
-        warnings.push(`IPO summary unavailable for ${String(instrument.symbol ?? symbol)}: ${error instanceof Error ? error.message.slice(0, 80) : "unknown error"}`);
+        warnings.push(
+          `IPO summary unavailable for ${String(instrument.symbol ?? symbol)}: ${error instanceof Error ? error.message.slice(0, 80) : "unknown error"}`,
+        );
       }
     }
     const price = summary?.ipo_price ?? summary?.price?.amount ?? summary?.price;
-    const customerCount = summary?.customer_count ?? summary?.participation?.customers ?? summary?.participation_stats?.customers;
+    const customerCount =
+      summary?.customer_count ??
+      summary?.participation?.customers ??
+      summary?.participation_stats?.customers;
     offerings.push({
-      symbol: String(instrument.symbol ?? symbol), ipoId: String(instrument.id), name: typeof instrument.name === "string" ? instrument.name : null,
-      status: typeof (instrument.ipo_access_status ?? summary?.status) === "string" ? String(instrument.ipo_access_status ?? summary?.status) : null,
-      deadline: typeof instrument.ipo_access_cob_deadline === "string" ? instrument.ipo_access_cob_deadline : null,
+      symbol: String(instrument.symbol ?? symbol),
+      ipoId: String(instrument.id),
+      name: typeof instrument.name === "string" ? instrument.name : null,
+      status:
+        typeof (instrument.ipo_access_status ?? summary?.status) === "string"
+          ? String(instrument.ipo_access_status ?? summary?.status)
+          : null,
+      deadline:
+        typeof instrument.ipo_access_cob_deadline === "string"
+          ? instrument.ipo_access_cob_deadline
+          : null,
       startDate: typeof instrument.ipoa_start_date === "string" ? instrument.ipoa_start_date : null,
       listDate: typeof instrument.list_date === "string" ? instrument.list_date : null,
       priceUsd: Number.isFinite(Number(price)) ? Number(price) : null,
       s1Url: typeof instrument.ipo_s1_url === "string" ? instrument.ipo_s1_url : null,
-      roadshowUrl: typeof instrument.ipo_roadshow_url === "string" ? instrument.ipo_roadshow_url : null,
+      roadshowUrl:
+        typeof instrument.ipo_roadshow_url === "string" ? instrument.ipo_roadshow_url : null,
       customerCount: Number.isFinite(Number(customerCount)) ? Number(customerCount) : null,
     });
   }
   const accountsData = await getJson("https://api.robinhood.com/accounts/");
-  const accounts: unknown[] = Array.isArray(accountsData?.results) ? accountsData.results : Array.isArray(accountsData) ? accountsData : [];
-  const reasons = new Set<string>(); let eligibleAccounts = 0; let restrictedAccounts = 0;
+  const accounts: unknown[] = Array.isArray(accountsData?.results)
+    ? accountsData.results
+    : Array.isArray(accountsData)
+      ? accountsData
+      : [];
+  const reasons = new Set<string>();
+  let eligibleAccounts = 0;
+  let restrictedAccounts = 0;
   for (const account of accounts) {
-    const row = account && typeof account === "object" ? account as Record<string, unknown> : {};
-    if (row.ipo_access_restricted === true) { restrictedAccounts++; if (typeof row.ipo_access_restricted_reason === "string") reasons.add(row.ipo_access_restricted_reason); }
-    else eligibleAccounts++;
+    const row = account && typeof account === "object" ? (account as Record<string, unknown>) : {};
+    if (row.ipo_access_restricted === true) {
+      restrictedAccounts++;
+      if (typeof row.ipo_access_restricted_reason === "string")
+        reasons.add(row.ipo_access_restricted_reason);
+    } else eligibleAccounts++;
   }
   const openOfferingCount = offerings.filter((offering) => offering.status === "open").length;
-  return { offerings, openOfferingCount, eligibility: { eligibleAccounts, restrictedAccounts, restrictionReasons: [...reasons].sort() }, message: openOfferingCount === 0 ? "No open IPO offerings are currently available." : null, warnings };
+  return {
+    offerings,
+    openOfferingCount,
+    eligibility: { eligibleAccounts, restrictedAccounts, restrictionReasons: [...reasons].sort() },
+    message: openOfferingCount === 0 ? "No open IPO offerings are currently available." : null,
+    warnings,
+  };
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/cli/test/options-order-diagnostics.test.ts
+++ b/cli/test/options-order-diagnostics.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { readOptionsOrderDiagnostics } from "../src/lib.js";
+
+type Call = { url: string; params: Record<string, string>; query: Record<string, string> };
+
+function deps(fixture: Record<string, unknown>, throwOn: string[] = []) {
+  const calls: Call[] = [];
+  const getJson = async (
+    url: string,
+    params: Record<string, string> = {},
+    query: Record<string, string> = {},
+  ) => {
+    calls.push({ url, params, query });
+    const key = url.includes("available_contracts")
+      ? "contracts"
+      : url.includes("available_shares")
+        ? "shares"
+        : url.includes("maximum_rollable_quantity")
+          ? "rollable"
+          : url.includes("has_recent_rejection")
+            ? "rejection"
+            : url.includes("exercise_checks")
+              ? "exercise"
+              : "unexpected";
+    if (throwOn.includes(key)) throw new Error(`${key} unavailable`);
+    if (key === "unexpected") throw new Error(`unexpected ${url}`);
+    return fixture[key];
+  };
+  return { getJson, calls };
+}
+
+const fixture = {
+  contracts: { num_of_contracts: "3" },
+  shares: { num_of_shares: "125" },
+  rollable: {
+    available_quantity: "2",
+    pending_closing_quantity: "1",
+    total_quantity: "3",
+  },
+  rejection: { recent_rejection_exists: false },
+  exercise: { exercisable_quantity: "4", corporate_action_restriction: null, extra: "retained" },
+};
+
+describe("readOptionsOrderDiagnostics", () => {
+  it("uses only documented, input-gated read routes and normalizes known scalar fields", async () => {
+    const d = deps(fixture);
+    const result = await readOptionsOrderDiagnostics(
+      {
+        accountNumber: "111",
+        strategyCode: "option-1_L1",
+        equityInstrumentId: "equity-1",
+        optionId: "option-1",
+        orderToReplaceId: "order-1",
+      },
+      d,
+    );
+
+    expect(d.calls).toEqual([
+      {
+        url: "https://api.robinhood.com/options/orders/available_contracts/{account_number}/",
+        params: { account_number: "111" },
+        query: { strategy_code: "option-1_L1", order_to_replace_id: "order-1" },
+      },
+      {
+        url: "https://api.robinhood.com/options/maximum_rollable_quantity/{strategy_code}/",
+        params: { strategy_code: "option-1_L1" },
+        query: { account_number: "111" },
+      },
+      {
+        url: "https://api.robinhood.com/options/orders/available_shares/{account_number}/",
+        params: { account_number: "111" },
+        query: { equity_instrument_id: "equity-1", order_to_replace_id: "order-1" },
+      },
+      {
+        url: "https://api.robinhood.com/options/has_recent_rejection/",
+        params: {},
+        query: {},
+      },
+      {
+        url: "https://api.robinhood.com/options/exercise_checks/",
+        params: {},
+        query: { account_number: "111", option_id: "option-1" },
+      },
+    ]);
+    expect(result).toMatchObject({
+      accountNumber: "111",
+      availableContracts: 3,
+      availableShares: 125,
+      rollable: {
+        availableQuantity: 2,
+        pendingClosingQuantity: 1,
+        totalQuantity: 3,
+        strategyCode: "option-1_L1",
+      },
+      recentRejectionExists: false,
+      exerciseChecks: {
+        exercisableQuantity: 4,
+        corporateActionRestriction: null,
+        raw: fixture.exercise,
+      },
+      warnings: [],
+      evidence: {
+        availableContracts: "observed-contract",
+        availableShares: "observed-contract",
+        recentRejection: "live-verified",
+        exerciseChecks: "observed-contract",
+        maximumRollableQuantity: "live-verified",
+      },
+    });
+  });
+
+  it("reports explicit not-evaluated states when prerequisite inputs are missing", async () => {
+    const d = deps(fixture);
+    const result = await readOptionsOrderDiagnostics({}, d);
+
+    expect(d.calls).toEqual([
+      { url: "https://api.robinhood.com/options/has_recent_rejection/", params: {}, query: {} },
+    ]);
+    expect(result.availableContracts).toBeUndefined();
+    expect(result.availableShares).toBeUndefined();
+    expect(result.rollable).toBeUndefined();
+    expect(result.exerciseChecks).toBeUndefined();
+    expect(result.notEvaluated).toEqual([
+      {
+        surface: "availableContractsAndRollableQuantity",
+        reason: "accountNumber and strategyCode are required",
+      },
+      {
+        surface: "availableShares",
+        reason: "accountNumber and equityInstrumentId are required",
+      },
+      {
+        surface: "exerciseChecks",
+        reason: "accountNumber and optionId are required",
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toMatch(/skipp/i);
+    expect(result.warnings.join(" ")).toMatch(/available contracts.*account.*strategy/i);
+    expect(result.warnings.join(" ")).toMatch(/available shares.*account.*equity/i);
+    expect(result.warnings.join(" ")).toMatch(/rollable.*account.*strategy/i);
+    expect(result.warnings.join(" ")).toMatch(/exercise.*account.*option/i);
+  });
+
+  it("keeps independent results when a sub-read fails", async () => {
+    const d = deps(fixture, ["shares", "exercise"]);
+    const result = await readOptionsOrderDiagnostics(
+      {
+        accountNumber: "111",
+        strategyCode: "option-1_L1",
+        equityInstrumentId: "equity-1",
+        optionId: "option-1",
+      },
+      d,
+    );
+
+    expect(result.availableContracts).toBe(3);
+    expect(result.rollable?.availableQuantity).toBe(2);
+    expect(result.recentRejectionExists).toBe(false);
+    expect(result.availableShares).toBeUndefined();
+    expect(result.exerciseChecks).toBeUndefined();
+    expect(result.warnings.join(" ")).toMatch(
+      /available shares read failed.*exercise checks read failed/i,
+    );
+  });
+});

--- a/cli/test/options-order-flow.test.ts
+++ b/cli/test/options-order-flow.test.ts
@@ -4,8 +4,18 @@ import { readOptionsOrderFlow } from "../src/lib.js";
 // Options order-flow reads are strictly non-ordering. Fee and collateral models require
 // prospective-order context serialized as JSON inside query fields; a naked GET is malformed.
 
-function deps(fix: { bp?: any; fees?: any; collateral?: any; chainCollateral?: any; throwOn?: string[] }) {
-  const calls: Array<{ url: string; params: Record<string, string>; query: Record<string, string> }> = [];
+function deps(fix: {
+  bp?: any;
+  fees?: any;
+  collateral?: any;
+  chainCollateral?: any;
+  throwOn?: string[];
+}) {
+  const calls: Array<{
+    url: string;
+    params: Record<string, string>;
+    query: Record<string, string>;
+  }> = [];
   const getJson = async (
     url: string,
     params: Record<string, string> = {},
@@ -13,9 +23,18 @@ function deps(fix: { bp?: any; fees?: any; collateral?: any; chainCollateral?: a
   ) => {
     calls.push({ url, params, query });
     const fail = (k: string) => fix.throwOn?.includes(k);
-    if (url.includes("options_buying_power")) { if (fail("bp")) throw new Error("503"); return fix.bp; }
-    if (url.includes("options/fees")) { if (fail("fees")) throw new Error("503"); return fix.fees; }
-    if (url.includes("options/orders/collateral")) { if (fail("collateral")) throw new Error("503"); return fix.collateral; }
+    if (url.includes("options_buying_power")) {
+      if (fail("bp")) throw new Error("503");
+      return fix.bp;
+    }
+    if (url.includes("options/fees")) {
+      if (fail("fees")) throw new Error("503");
+      return fix.fees;
+    }
+    if (url.includes("options/orders/collateral")) {
+      if (fail("collateral")) throw new Error("503");
+      return fix.collateral;
+    }
     if (url.includes("options/chains/") && url.includes("collateral")) {
       if (fail("chainCollateral")) throw new Error("503");
       return fix.chainCollateral;
@@ -72,13 +91,18 @@ describe("readOptionsOrderFlow", () => {
     expect(JSON.parse(collateralCall?.query.order ?? "null")).toEqual(order);
   });
 
-  it("skips malformed fee/collateral requests when prospective inputs are absent", async () => {
+  it("reports explicit not-evaluated results instead of sending malformed requests", async () => {
     const d = deps(base);
     const r = await readOptionsOrderFlow({ accountNumber: "111" }, d);
     expect(d.calls.some((c) => c.url.includes("options/fees"))).toBe(false);
     expect(d.calls.some((c) => c.url.includes("options/orders/collateral"))).toBe(false);
     expect(r.fees).toBeUndefined();
     expect(r.collateral).toBeUndefined();
+    expect(r.notEvaluated).toEqual([
+      { surface: "fees", reason: "prospective legs are required" },
+      { surface: "collateral", reason: "a complete prospective order is required" },
+    ]);
+    expect(JSON.stringify(r)).not.toMatch(/skipp/i);
     expect(r.warnings.some((w) => /prospective legs/.test(w))).toBe(true);
     expect(r.warnings.some((w) => /prospective order/.test(w))).toBe(true);
   });

--- a/docs/options-diagnostics-contract-2026-08-04.md
+++ b/docs/options-diagnostics-contract-2026-08-04.md
@@ -1,0 +1,31 @@
+# Read-only options diagnostics contract
+
+`options diagnostics` and `robinhood_options_diagnostics` share `readOptionsOrderDiagnostics`.
+
+## Scope and safety
+
+This capability performs only independently input-gated **GET** reads. It does not call option order review, marketability, creation, replacement, cancellation, or submission endpoints.
+
+| Diagnostic | Required input | Route | Evidence |
+|---|---|---|---|
+| Available contracts | `accountNumber`, `strategyCode` | `options/orders/available_contracts/{account_number}/` | observed-contract (public bundle) |
+| Maximum rollable quantity | `accountNumber`, `strategyCode` | `options/maximum_rollable_quantity/{strategy_code}/` | live-verified |
+| Available shares | `accountNumber`, `equityInstrumentId` | `options/orders/available_shares/{account_number}/` | observed-contract (public bundle) |
+| Recent rejection | none | `options/has_recent_rejection/` | live-verified (sanitized authenticated structural proof) |
+| Exercise checks | `accountNumber`, `optionId` | `options/exercise_checks/` | observed-contract (public bundle) |
+
+`orderToReplaceId` is passed only to the two availability routes where the observed request contract permits it. Missing prerequisites result in local warnings and no request; a failed sub-read leaves independent diagnostics intact.
+
+## Evidence classifications
+
+“Observed-contract” means the path/query model and named response fields were observed in Robinhood’s public web bundle; it does **not** claim authenticated response semantics. `maximum_rollable_quantity` and `has_recent_rejection` are separately labeled `live-verified` from sanitized authenticated structural evidence. Do not promote the remaining bundle-derived capabilities without sanitized authenticated structural proof.
+
+## Usage
+
+```text
+options diagnostics --account <N> --strategy-code <CODE> --equity-instrument-id <UUID> --option-id <UUID> --json
+```
+
+For replacement-aware availability reads, append `--order-to-replace-id <UUID>`. Account and instrument identifiers are sensitive; keep live outputs private or use synthetic values in tests.
+
+- delilah 🌸

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -89,6 +89,7 @@ import {
   loadRecipes,
   filterRecipes,
   readOptionsOrderFlow,
+  readOptionsOrderDiagnostics,
   selectNearStrikes,
   classifyMoneyness,
   finiteNumber,
@@ -417,6 +418,33 @@ server.registerTool(
   },
   async ({ accountNumber, chainId, legs, order }) =>
     jsonResponse(await readOptionsOrderFlow({ accountNumber, chainId, legs, order })),
+);
+
+server.registerTool(
+  "robinhood_options_diagnostics",
+  {
+    title: "Robinhood Options Diagnostics",
+    description:
+      "Read-only options availability, rejection, rollable-quantity, and exercise diagnostics. Endpoint-specific prerequisites are skipped locally with warnings. Available-contracts, available-shares, rejection, and exercise fields are observed-contract; maximum rollable quantity is live-verified. Never reviews or submits an order.",
+    annotations: toolAnnotations(true, "sensitive-read"),
+    inputSchema: z.object({
+      accountNumber: accountNumberOptionalSchema,
+      strategyCode: z.string().min(1).optional(),
+      equityInstrumentId: uuidOptionalSchema,
+      optionId: uuidOptionalSchema,
+      orderToReplaceId: uuidOptionalSchema,
+    }),
+  },
+  async ({ accountNumber, strategyCode, equityInstrumentId, optionId, orderToReplaceId }) =>
+    jsonResponse(
+      await readOptionsOrderDiagnostics({
+        accountNumber,
+        strategyCode,
+        equityInstrumentId,
+        optionId,
+        orderToReplaceId,
+      }),
+    ),
 );
 
 server.registerTool(

--- a/mcp/test/protocol.test.ts
+++ b/mcp/test/protocol.test.ts
@@ -277,7 +277,7 @@ describe("MCP profile protocol surfaces", () => {
           .map((entry) => entry.mcp!)
           .sort(),
       );
-      expect(tools.tools).toHaveLength(86);
+      expect(tools.tools).toHaveLength(capabilitiesForProfile("full").length);
       expect(tools.tools.some((tool) => tool.name === "robinhood_account_pulse")).toBe(true);
       expect(defaultClient.getInstructions()).toMatch(/ROBINHOOD_ALLOW_LIVE_WRITE/);
     } finally {


### PR DESCRIPTION
## Summary
- add read-only options availability, rollability, recent-rejection, and exercise diagnostics
- wire shared engine → CLI → MCP → capability profiles → route maps → recipes/docs
- classify maximum rollable quantity and recent rejection as live-verified; retain bundle-derived surfaces as observed-contract
- replace silent skipped fee/collateral/diagnostic calculations with explicit `notEvaluated` entries
- never review, create, submit, or mutate an order

## Verification
- 472 CLI tests passed
- 16 MCP protocol tests passed (2 intentionally skipped)
- quality, build, typecheck, API-map sanitizer, portability, diff check, and gitleaks passed
- authenticated sanitized proof: 5 accounts discoverable; recent-rejection returned boolean; 3 missing-input surfaces explicit; no skip wording

- delilah 🌸