### PR TITLE
docs: codify Robinhood release regressions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -780,4 +780,32 @@ anything a generator produced, and we may spin up separate repos to keep buildin
 rather than conforming back to the generator. The map is the product; Printing Press just gave us a good
 place to start.
 
+## 17. Recent release regressions and focused gate
+
+These checks are intentionally specific to failures observed in this repository; they complement rather than duplicate the full quality matrix.
+
+### Source/dist parity
+
+The MCP previously served stale `dist` after source changes. Build both packages before runtime or registration checks and exercise the built packages. Never validate source while serving stale dist.
+
+### Public portability
+
+A tracked research document exposed a private machine name. `pnpm test:portability` must continue scanning the complete tracked public tree for private usernames, hostnames, paths, account identifiers, tokens, cookies, and capture secrets. Fix findings; do not narrow or whitelist the scan to make it green.
+
+### Dependency audit
+
+CI found vulnerable transitive versions of `nanoid`, `hono`, `@hono/node-server`, `postcss`, and `body-parser`. Patched workspace overrides and the lockfile are intentional. The focused gate audits at `low`, so any low/moderate/high/critical advisory blocks release. Do not raise the threshold to hide findings.
+
+### Live semantics
+
+Auth presence is not product proof. Live acceptance requires verified accounts, a real quote, portfolio values, MCP registration, and a write plan with `live=false`. Never perform a live trade to test a release gate.
+
+Run after dependency, lockfile, build-output, public-doc/capture, MCP-registration, or packaging changes:
+
+```bash
+pnpm regression:recent
+```
+
+It composes the existing build and portability checks with a zero-advisory audit. Before release, also run the full quality/test matrix and external live ship gate.
+
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "auth:refresh": "bash scripts/refresh-auth.sh",
     "version:refresh": "node scripts/scrape-web-app-version.mjs",
     "quality": "corepack pnpm lint && corepack pnpm format:check && corepack pnpm deadcode && corepack pnpm test:api-map && corepack pnpm test:skill && corepack pnpm test:portability",
+    "regression:recent": "corepack pnpm build && corepack pnpm test:portability && corepack pnpm@11.13.1 --pm-on-fail=ignore audit --audit-level low",
     "test:portability": "node scripts/check-public-portability.mjs",
     "lint": "node scripts/check-eslint-ratchet.mjs",
     "lint:report": "eslint cli/src mcp/src",


### PR DESCRIPTION
## Summary
- preserve the full existing AGENTS.md and append stale-dist, portability, and dependency-audit history
- add one `regression:recent` command that builds both packages, scans the tracked tree, and audits at low severity
- require dry-run semantic live proof, never a trade

## Verification
- CLI + MCP build: pass
- portability: 598 tracked files
- dependency audit: zero known vulnerabilities
- no output warnings on the final focused gate

- delilah 🌸