### PR TITLE
Map IPO request plans and 24-hour equity orders

### DIFF
--- a/api-map/brokerage-routes.json
+++ b/api-map/brokerage-routes.json
@@ -22140,6 +22140,58 @@
     "fieldsSource": "undocumented"
   },
   {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": ["equity", "ipo-access"],
+    "risk": "read",
+    "methods": ["GET"],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": ["ipo-access-order-entry"],
+    "queryKeys": [],
+    "requestTypes": ["XHR"],
+    "fields": ["instrument_id", "title", "subtitle_markdown", "rows", "footer_markdown", "accept_title", "dismiss_title"],
+    "fieldsSource": "verified"
+  },
+  {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": ["equity", "ipo-access"],
+    "risk": "read",
+    "methods": ["GET"],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": ["ipo-access-order-entry"],
+    "queryKeys": [],
+    "requestTypes": ["XHR"],
+    "fields": ["instrument_id", "title", "rows", "disclosure_markdown", "continue_button"],
+    "fieldsSource": "verified"
+  },
+  {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": ["equity", "ipo-access"],
+    "risk": "read",
+    "methods": ["GET"],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": ["ipo-access-order-entry"],
+    "queryKeys": ["endpoint_version"],
+    "requestTypes": ["XHR"],
+    "fields": ["instrument_id", "title", "subtitle_markdown", "sections", "continue_cta_title", "dont_show_again_cta_title"],
+    "fieldsSource": "verified"
+  },
+  {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": ["equity", "ipo-access", "orders"],
+    "risk": "sensitive-read",
+    "methods": ["GET"],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": ["ipo-access-order-entry"],
+    "queryKeys": ["account_number"],
+    "requestTypes": ["XHR"],
+    "fields": ["account_number", "instrument_id", "form_state", "order_entry_view_model", "trade_receipt_view_model", "action_required_view_model", "context"],
+    "fieldsSource": "verified"
+  },
+  {
     "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/",
     "host": "bonfire.robinhood.com",
     "categories": [

--- a/api-map/curl/brokerage-route-templates.sh
+++ b/api-map/curl/brokerage-route-templates.sh
@@ -764,6 +764,18 @@
 # sensitive-read GET https://bonfire.robinhood.com/equities/history/aggregated_borrow_charge
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/equities/history/aggregated_borrow_charge'
 
+# read GET https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/'
+
+# read GET https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/'
+
+# read GET https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/'
+
+# sensitive-read GET https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/
+# curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/'
+
 # read GET https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/
 # curl -sS -X GET -H 'Authorization: Bearer <REDACTED>' 'https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/'
 

--- a/api-map/markdown/brokerage-routes.md
+++ b/api-map/markdown/brokerage-routes.md
@@ -4,8 +4,8 @@ Source: reverse-engineered routes plus sanitized authenticated Chrome/CDP captur
 
 Personal repo semantics: mapped routes can be executed live with caller-owned `ROBINHOOD_BROKERAGE_TOKEN` or `ROBINHOOD_COOKIE`. Pass `--dry-run` when you want a non-sending test plan.
 
-Current count: 372 route templates.
-Risk counts: destructive=9, read=99, sensitive-read=235, write-mutate=11, write-or-sensitive=7, write-safe=11.
+Current count: 376 route templates.
+Risk counts: destructive=9, read=102, sensitive-read=236, write-mutate=11, write-or-sensitive=7, write-safe=11.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -264,6 +264,10 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://bonfire.robinhood.com/education/tour/` |
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/equities/history/{id}` |
 | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://bonfire.robinhood.com/equities/history/aggregated_borrow_charge` |
+| read | GET | equity, ipo-access | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/` |
+| read | GET | equity, ipo-access | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/` |
+| read | GET | equity, ipo-access | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/` |
+| sensitive-read | GET | equity, ipo-access, orders | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/` |
 | read | GET | equity, ipo-access | bonfire.robinhood.com | cdp (observed; RH IPO Access summary viewmodel — Idea A seed; full prospectus/IOI family TBD via interactive capture) | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/` |
 | sensitive-read | GET | orders | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/equity_trading/order_type_selector/buy/` |
 | read | GET | equity, trading | bonfire.robinhood.com | cdp (observed; web order-ticket SELL-side selector viewmodel) | `https://bonfire.robinhood.com/equity_trading/order_type_selector/sell/` |

--- a/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-indication-of-interest-7binstrument-id-7d.md
+++ b/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-indication-of-interest-7binstrument-id-7d.md
@@ -1,0 +1,17 @@
+# GET /equity_trading/ipo_access/viewmodels/indication_of_interest/%7Binstrument_id%7D/
+
+Mutation: no
+Risk: read
+
+Host: bonfire.robinhood.com
+Categories: equity, ipo-access
+Source: web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08
+Operation ID: n/a
+
+Route template:
+
+```text
+https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-notification-disclosure-7binstrument-id-7d.md
+++ b/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-notification-disclosure-7binstrument-id-7d.md
@@ -1,0 +1,17 @@
+# GET /equity_trading/ipo_access/viewmodels/notification_disclosure/%7Binstrument_id%7D/
+
+Mutation: no
+Risk: read
+
+Host: bonfire.robinhood.com
+Categories: equity, ipo-access
+Source: web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08
+Operation ID: n/a
+
+Route template:
+
+```text
+https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-order-entry-splash-7binstrument-id-7d.md
+++ b/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-order-entry-splash-7binstrument-id-7d.md
@@ -1,0 +1,17 @@
+# GET /equity_trading/ipo_access/viewmodels/order_entry_splash/%7Binstrument_id%7D/
+
+Mutation: no
+Risk: read
+
+Host: bonfire.robinhood.com
+Categories: equity, ipo-access
+Source: web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08
+Operation ID: n/a
+
+Route template:
+
+```text
+https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-web-order-entry-7binstrument-id-7d.md
+++ b/api-map/markdown/endpoints/get-bonfire-robinhood-com-equity-trading-ipo-access-viewmodels-web-order-entry-7binstrument-id-7d.md
@@ -1,0 +1,17 @@
+# GET /equity_trading/ipo_access/viewmodels/web_order_entry/%7Binstrument_id%7D/
+
+Mutation: no
+Risk: sensitive-read
+
+Host: bonfire.robinhood.com
+Categories: equity, ipo-access, orders
+Source: web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08
+Operation ID: n/a
+
+Route template:
+
+```text
+https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/
+```
+
+<!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/api-map/markdown/robinhood-routes.md
+++ b/api-map/markdown/robinhood-routes.md
@@ -4,10 +4,10 @@ Source: official Robinhood Crypto Trading OpenAPI plus sanitized authenticated C
 
 Crypto operations are official Robinhood-published endpoints and should use Ed25519 signing. Brokerage/account operations are browser-backed route-map entries and use caller-owned brokerage token or browser cookie auth.
 
-Current count: 388 route entries.
+Current count: 392 route entries.
 Official Crypto route entries: 16.
-Brokerage/account route entries: 372.
-Risk counts: destructive=11, read=105, sensitive-read=241, write-mutate=13, write-or-sensitive=7, write-safe=11.
+Brokerage/account route entries: 376.
+Risk counts: destructive=11, read=108, sensitive-read=242, write-mutate=13, write-or-sensitive=7, write-safe=11.
 
 Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts with `Mutation: yes` or `Mutation: no`.
 
@@ -270,7 +270,11 @@ Per-endpoint files are generated in `api-map/markdown/endpoints/`. Each starts w
 | no | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized; cdp-2026-07-14-authenticated-sanitized-v2 | `https://bonfire.robinhood.com/education/tour/` |
 | no | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/equities/history/{id}` |
 | no | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-07-14-authenticated-sanitized-v2 | `https://bonfire.robinhood.com/equities/history/aggregated_borrow_charge` |
+| no | read | GET | equity, ipo-access | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/` |
+| no | read | GET | equity, ipo-access | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/` |
+| no | read | GET | equity, ipo-access | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/` |
 | no | read | GET | equity, ipo-access | bonfire.robinhood.com | cdp (observed; RH IPO Access summary viewmodel — Idea A seed; full prospectus/IOI family TBD via interactive capture) | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/` |
+| no | sensitive-read | GET | equity, ipo-access, orders | bonfire.robinhood.com | web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08 | `https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/` |
 | no | sensitive-read | GET | orders | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/equity_trading/order_type_selector/buy/` |
 | no | read | GET | equity, trading | bonfire.robinhood.com | cdp (observed; web order-ticket SELL-side selector viewmodel) | `https://bonfire.robinhood.com/equity_trading/order_type_selector/sell/` |
 | no | sensitive-read | GET | unknown | bonfire.robinhood.com | cdp-2026-05-27-stock-account-sanitized | `https://bonfire.robinhood.com/feature-discovery/features/investing_below_card` |

--- a/api-map/openapi/robinhood-brokerage.openapi.json
+++ b/api-map/openapi/robinhood-brokerage.openapi.json
@@ -10901,6 +10901,150 @@
         ]
       }
     },
+    "/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_indication_of_interest_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
+        ]
+      }
+    },
+    "/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_notification_disclosure_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
+        ]
+      }
+    },
+    "/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_order_entry_splash_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "endpoint_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
+        ]
+      }
+    },
     "/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/": {
       "get": {
         "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_summary_ipo_id",
@@ -10945,6 +11089,61 @@
         ],
         "x-robinhood-seen-on": [
           "ipo-access"
+        ]
+      }
+    },
+    "/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_web_order_entry_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access",
+          "orders"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "account_number",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
         ]
       }
     },

--- a/api-map/openapi/robinhood-unified.openapi.json
+++ b/api-map/openapi/robinhood-unified.openapi.json
@@ -12871,6 +12871,153 @@
         "x-robinhood-source": "brokerage-browser-map"
       }
     },
+    "/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_indication_of_interest_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
+        ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_notification_disclosure_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
+        ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_order_entry_splash_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "endpoint_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
+        ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
     "/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/": {
       "get": {
         "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_summary_ipo_id",
@@ -12915,6 +13062,62 @@
         ],
         "x-robinhood-seen-on": [
           "ipo-access"
+        ],
+        "x-robinhood-source": "brokerage-browser-map"
+      }
+    },
+    "/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/": {
+      "get": {
+        "operationId": "brokerage_get_equity_trading_ipo_access_viewmodels_web_order_entry_instrument_id",
+        "summary": "Equity brokerage route",
+        "description": "Personal route map entry. Risk: sensitive-read. Live execution requires ROBINHOOD_BROKERAGE_TOKEN or ROBINHOOD_COOKIE. Use dryRun/--dry-run to avoid sending.",
+        "tags": [
+          "equity",
+          "ipo-access",
+          "orders"
+        ],
+        "parameters": [
+          {
+            "name": "instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Route placeholder instrument_id. Mapped route name; live verification should replace with a semantic parameter name when known."
+          },
+          {
+            "name": "account_number",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Observed query key from route templates or sanitized browser capture; values are intentionally not stored."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response shape not yet live-verified.",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "x-robinhood-risk": "sensitive-read",
+        "x-robinhood-hosts": [
+          "bonfire.robinhood.com"
+        ],
+        "x-robinhood-route-templates": [
+          "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/"
+        ],
+        "x-robinhood-sources": [
+          "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08"
+        ],
+        "x-robinhood-seen-on": [
+          "ipo-access-order-entry"
         ],
         "x-robinhood-source": "brokerage-browser-map"
       }

--- a/api-map/robinhood-routes.json
+++ b/api-map/robinhood-routes.json
@@ -22242,6 +22242,95 @@
     "fieldsSource": "undocumented"
   },
   {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": [
+      "equity",
+      "ipo-access"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": [
+      "ipo-access-order-entry"
+    ],
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "instrument_id",
+      "title",
+      "subtitle_markdown",
+      "rows",
+      "footer_markdown",
+      "accept_title",
+      "dismiss_title"
+    ],
+    "fieldsSource": "verified"
+  },
+  {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": [
+      "equity",
+      "ipo-access"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": [
+      "ipo-access-order-entry"
+    ],
+    "queryKeys": [],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "instrument_id",
+      "title",
+      "rows",
+      "disclosure_markdown",
+      "continue_button"
+    ],
+    "fieldsSource": "verified"
+  },
+  {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": [
+      "equity",
+      "ipo-access"
+    ],
+    "risk": "read",
+    "methods": [
+      "GET"
+    ],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": [
+      "ipo-access-order-entry"
+    ],
+    "queryKeys": [
+      "endpoint_version"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "instrument_id",
+      "title",
+      "subtitle_markdown",
+      "sections",
+      "continue_cta_title",
+      "dont_show_again_cta_title"
+    ],
+    "fieldsSource": "verified"
+  },
+  {
     "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/",
     "host": "bonfire.robinhood.com",
     "categories": [
@@ -22262,6 +22351,39 @@
     ],
     "fields": [],
     "fieldsSource": "undocumented"
+  },
+  {
+    "url": "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/",
+    "host": "bonfire.robinhood.com",
+    "categories": [
+      "equity",
+      "ipo-access",
+      "orders"
+    ],
+    "risk": "sensitive-read",
+    "methods": [
+      "GET"
+    ],
+    "source": "web-bundle-2026.32.5622 plus authenticated live GET 2026-08-08",
+    "seenOn": [
+      "ipo-access-order-entry"
+    ],
+    "queryKeys": [
+      "account_number"
+    ],
+    "requestTypes": [
+      "XHR"
+    ],
+    "fields": [
+      "account_number",
+      "instrument_id",
+      "form_state",
+      "order_entry_view_model",
+      "trade_receipt_view_model",
+      "action_required_view_model",
+      "context"
+    ],
+    "fieldsSource": "verified"
   },
   {
     "url": "https://bonfire.robinhood.com/equity_trading/order_type_selector/buy/",

--- a/cli/src/capabilities.ts
+++ b/cli/src/capabilities.ts
@@ -100,6 +100,7 @@ const LEGACY_MCP_TOOLS = [
   "robinhood_rewards",
   "robinhood_inbox_summary",
   "robinhood_ipo_access",
+  "robinhood_ipo_access_request_plan",
 ] as const;
 
 type LegacyMcpTool = (typeof LEGACY_MCP_TOOLS)[number];
@@ -134,6 +135,7 @@ const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly st
     "robinhood_rewards",
     "robinhood_inbox_summary",
     "robinhood_ipo_access",
+    "robinhood_ipo_access_request_plan",
     "robinhood_history",
     "robinhood_margin",
     "robinhood_options_chain",
@@ -189,6 +191,7 @@ const PROFILE_TOOL_NAMES: Record<Exclude<CapabilityProfile, "full">, readonly st
     "robinhood_rewards",
     "robinhood_inbox_summary",
     "robinhood_ipo_access",
+    "robinhood_ipo_access_request_plan",
     "robinhood_history",
     "robinhood_hotlist",
     "robinhood_income",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -129,6 +129,7 @@ import {
   getStockRewardsSummary,
   getInboxSummary,
   getIpoAccess,
+  getIpoAccessRequestPlan,
 } from "./lib.js";
 import type { OptionStrategyLegTemplate, OptionsStrategyPricingMode } from "./lib.js";
 
@@ -830,13 +831,14 @@ brokerage
   .option("--shares <qty>", "share quantity (whole shares for OTC names)")
   .option("--limit <price>", "explicit limit price; else market with ask collar (OTC forces a limit at the ask)")
   .option("--tif <gfd|gtc>", "time in force (default: gfd for market/OTC, gtc for an explicit limit)")
+  .option("--market-hours <regular|extended|overnight>", "execution session; overnight maps to Robinhood all_day_hours and is dry-run-only until account order-check capture")
   .option("--dry-run", "print plan/body, send nothing")
   .option("--live", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--force", "skip the pending-duplicate-order check")
   .option("--override-cap", "bypass the ROBINHOOD_MAX_ORDER_DOLLARS / ROBINHOOD_MAX_SESSION_DOLLARS notional caps for this order")
   .option("--live-write", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--json", "emit JSON")
-  .action(async (symbol: string, opts: { account: string; dollars?: string; shares?: string; limit?: string; tif?: string; dryRun?: boolean; live?: boolean; force?: boolean; overrideCap?: boolean; liveWrite?: boolean; json?: boolean }) => {
+  .action(async (symbol: string, opts: { account: string; dollars?: string; shares?: string; limit?: string; tif?: string; marketHours?: string; dryRun?: boolean; live?: boolean; force?: boolean; overrideCap?: boolean; liveWrite?: boolean; json?: boolean }) => {
     if (!opts.dollars && !opts.shares) throw new Error("Pass --dollars <amt> or --shares <qty>.");
     if (opts.dollars && opts.shares) throw new Error("Pass only one of --dollars or --shares.");
     if (opts.dollars && !(Number(opts.dollars) > 0)) throw new Error(`--dollars must be a positive number (got "${opts.dollars}").`);
@@ -854,6 +856,7 @@ brokerage
       shares: opts.shares ? Number(opts.shares) : undefined,
       limitPrice: opts.limit ? Number(opts.limit) : undefined,
       timeInForce: parseTif(opts.tif),
+      marketHours: parseMarketHours(opts.marketHours),
       dryRun: Boolean(opts.dryRun),
       liveWrite: Boolean(opts.live ?? opts.liveWrite),
       force: Boolean(opts.force),
@@ -3495,6 +3498,23 @@ function parseTif(v: string | undefined): "gfd" | "gtc" | undefined {
   return t;
 }
 
+function parseMarketHours(v: string | undefined): "regular_hours" | "extended_hours" | "all_day_hours" | undefined {
+  if (v == null) return undefined;
+  const value = String(v).toLowerCase();
+  const aliases: Record<string, "regular_hours" | "extended_hours" | "all_day_hours"> = {
+    regular: "regular_hours",
+    regular_hours: "regular_hours",
+    extended: "extended_hours",
+    extended_hours: "extended_hours",
+    overnight: "all_day_hours",
+    "24-hour": "all_day_hours",
+    all_day_hours: "all_day_hours",
+  };
+  const resolved = aliases[value];
+  if (!resolved) throw new Error(`--market-hours must be regular, extended, or overnight (got "${v}")`);
+  return resolved;
+}
+
 // ── buy: simple market/limit order — one command, no raw JSON needed ──
 program
   .command("buy")
@@ -3506,6 +3526,7 @@ program
   .option("-q, --shares <number>", "Share quantity — alternative to --amount")
   .option("-p, --price <number>", "Limit price (omit for market order)")
   .option("--tif <gfd|gtc>", "time in force (default: gfd for market/OTC, gtc for an explicit limit)")
+  .option("--market-hours <regular|extended|overnight>", "execution session; overnight maps to Robinhood all_day_hours and is dry-run-only until account order-check capture")
   .option("--dry-run", "Force a non-sending preview even when live writes are enabled")
   .option("--live", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--force", "Skip duplicate order check")
@@ -3522,6 +3543,7 @@ program
       shares: opts.shares ? Number(opts.shares) : undefined,
       limitPrice: opts.price ? Number(opts.price) : undefined,
       timeInForce: parseTif(opts.tif),
+      marketHours: parseMarketHours(opts.marketHours),
       dryRun: Boolean(opts.dryRun),
       liveWrite: Boolean(opts.live),
       force: Boolean(opts.force),
@@ -3529,7 +3551,7 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, marketHours: r.marketHours, eligibility: r.eligibility, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
@@ -3551,6 +3573,7 @@ program
   .option("-q, --shares <number>", "Share quantity — alternative to --amount")
   .option("-p, --price <number>", "Limit price (omit for market order)")
   .option("--tif <gfd|gtc>", "time in force (default: gfd for market/OTC, gtc for an explicit limit)")
+  .option("--market-hours <regular|extended|overnight>", "execution session; overnight maps to Robinhood all_day_hours and is dry-run-only until account order-check capture")
   .option("--dry-run", "Force a non-sending preview even when live writes are enabled")
   .option("--live", "optional back-compat no-op; the live-write gate is ROBINHOOD_ALLOW_LIVE_WRITE=1")
   .option("--force", "Skip duplicate order check")
@@ -3566,6 +3589,7 @@ program
       shares: opts.shares ? Number(opts.shares) : undefined,
       limitPrice: opts.price ? Number(opts.price) : undefined,
       timeInForce: parseTif(opts.tif),
+      marketHours: parseMarketHours(opts.marketHours),
       dryRun: Boolean(opts.dryRun),
       liveWrite: Boolean(opts.live),
       force: Boolean(opts.force),
@@ -3573,7 +3597,7 @@ program
     });
 
     if (opts.json) {
-      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
+      printJson({ generatedAt: new Date().toISOString(), symbol: opts.symbol, account: opts.account, shares: r.shares, estimatedPrice: r.estimatedPrice, estimatedTotal: r.estimatedTotal, type: r.type, dollarBased: r.dollarBased, marketHours: r.marketHours, eligibility: r.eligibility, session: r.session, sessionWarning: r.sessionWarning, live: r.live, refId: r.refId, result: r.result });
       return;
     }
 
@@ -4557,6 +4581,26 @@ ipoAccess
     if (!offering) { process.stdout.write(`No IPO Access offering found for ${symbol.toUpperCase()}.\n`); return; }
     printTable([{ symbol: offering.symbol, status: offering.status ?? "—", price: offering.priceUsd === null ? "—" : `$${offering.priceUsd.toFixed(2)}`, deadline: offering.deadline ?? "—", start: offering.startDate ?? "—", list_date: offering.listDate ?? "—", customers: offering.customerCount ?? "—" }], ["symbol", "status", "price", "deadline", "start", "list_date", "customers"]);
     if (r.warnings.length) process.stdout.write(`${r.warnings.map((warning) => `⚠️  ${warning}`).join("\n")}\n`);
+  });
+ipoAccess
+  .command("plan-request <symbol>")
+  .description("Collapse IPO onboarding, disclosures, eligibility, buying power, deadline, and review into one read-only plan. Never submits interest.")
+  .requiredOption("--account <account_number>", "brokerage account number")
+  .option("--json", "emit JSON")
+  .action(async (symbol: string, opts: { account: string; json?: boolean }) => {
+    const plan = await getIpoAccessRequestPlan({ symbol, accountNumber: opts.account });
+    if (opts.json) { printJson(plan); return; }
+    printTable([{
+      symbol: plan.symbol,
+      status: plan.status ?? "—",
+      can_request: plan.canRequest ? "yes" : "no",
+      enrolled: plan.enrollment.enrolled ? "yes" : "no",
+      deadline: plan.deadline.at ?? "—",
+      buying_power: plan.buyingPower.amount ?? "—",
+      existing_order: plan.existingOrder.present ? "yes" : "no",
+    }], ["symbol", "status", "can_request", "enrolled", "deadline", "buying_power", "existing_order"]);
+    if (plan.blockers.length) process.stdout.write(`Blockers: ${plan.blockers.join(", ")}\n`);
+    process.stdout.write(`Submission: ${plan.submission.status} — ${plan.submission.missingInput}\n`);
   });
 
 program.parseAsync(process.argv).catch((error: unknown) => {

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -4459,6 +4459,9 @@ export interface EquityOrderInput {
   /** Explicit time-in-force override. Omit to let the engine pick (gfd for market/OTC, gtc for limit).
    *  gtc is rejected on a fractional dollar-market order (Robinhood requires gfd there). */
   timeInForce?: "gfd" | "gtc";
+  /** Explicit execution session. `all_day_hours` is Robinhood's current 24-hour-market enum.
+   * Non-regular sessions are evidence-gated whole-share limit orders; no implicit promotion. */
+  marketHours?: "regular_hours" | "extended_hours" | "all_day_hours";
   /** Optional (back-compat) — the gate is ROBINHOOD_ALLOW_LIVE_WRITE=1, enforced downstream. */
   liveWrite?: boolean;
   /** Force a non-sending preview even when ROBINHOOD_ALLOW_LIVE_WRITE=1 is set. */
@@ -4490,6 +4493,13 @@ export interface EquityOrderResult {
   otcAutoLimit: boolean;
   /** True when the send used the native `dollar_based_amount` fractional body (dollar-notional market order on a fractional-tradable name) rather than a computed quantity. */
   dollarBased: boolean;
+  marketHours: "regular_hours" | "extended_hours" | "all_day_hours";
+  eligibility: {
+    evaluated: boolean;
+    eligible: boolean | null;
+    source: string;
+    reason: string | null;
+  };
   /** Detected US-equity session at send time (`regular`/`pre_market`/`after_hours`/`closed`); undefined if detection was skipped/failed. */
   session?: MarketSession;
   /** Set when the order will QUEUE rather than fill now (e.g. a fractional/market order placed outside regular hours). */
@@ -4558,6 +4568,51 @@ export async function placeEquityOrder(
     .results?.[0];
   if (!inst) throw new Error(`Symbol ${symbol} not found`);
   const iid = inst.id;
+  const marketHours = input.marketHours ?? "regular_hours";
+  let eligibility: EquityOrderResult["eligibility"] = {
+    evaluated: true,
+    eligible: true,
+    source: "regular-hours-default",
+    reason: null,
+  };
+  if (marketHours !== "regular_hours") {
+    if (input.amount != null)
+      throw new Error(`${symbol}: ${marketHours} orders require an explicit share quantity; dollar/notional sizing is not supported.`);
+    if (input.limitPrice == null)
+      throw new Error(`${symbol}: ${marketHours} execution requires an explicit limit price.`);
+    if (marketHours === "all_day_hours") {
+      if (!Number.isInteger(Number(input.shares)))
+        throw new Error(`${symbol}: 24-hour/all-day orders require whole shares.`);
+      const state = inst.all_day_tradability;
+      eligibility = {
+        evaluated: typeof state === "string",
+        eligible: typeof state === "string" ? state === "tradable" : null,
+        source: "instrument.all_day_tradability",
+        reason:
+          typeof state === "string"
+            ? state === "tradable"
+              ? null
+              : `all_day_tradability=${state}`
+            : "all_day_tradability was absent; eligibility was not evaluated",
+      };
+      if (eligibility.eligible !== true)
+        throw new Error(`${symbol}: ${eligibility.reason}; refusing to build a 24-hour order.`);
+    } else {
+      const state = inst.tradability;
+      eligibility = {
+        evaluated: typeof state === "string",
+        eligible: typeof state === "string" ? state === "tradable" : null,
+        source: "instrument.tradability",
+        reason: typeof state === "string" && state !== "tradable" ? `tradability=${state}` : null,
+      };
+      if (eligibility.eligible === false)
+        throw new Error(`${symbol}: ${eligibility.reason}; refusing extended-hours execution.`);
+    }
+    if (execution.live)
+      throw new Error(
+        `${symbol}: live ${marketHours} submission is blocked until the account-scoped order-check contract is captured. The dry-run body is mapped; account/session kill-switch eligibility is not yet evaluated.`,
+      );
+  }
   const otc =
     Boolean(inst.otc_market_tier) || inst.fractional_tradability === "position_closing_only";
   if (input.amount && inst.fractional_tradability && inst.fractional_tradability !== "tradable") {
@@ -4576,6 +4631,22 @@ export async function placeEquityOrder(
     throw new Error(
       `Invalid or missing quote for ${symbol} (last_trade_price=${q?.last_trade_price ?? "none"})`,
     );
+  if (marketHours === "all_day_hours") {
+    const bid = Number(q?.bid_price);
+    const ask = Number(q?.ask_price);
+    const mid = (bid + ask) / 2;
+    const spreadPct = Number.isFinite(mid) && mid > 0 ? ((ask - bid) / mid) * 100 : Number.NaN;
+    const configured = Number(process.env.ROBINHOOD_MAX_ALL_DAY_SPREAD_PCT ?? "5");
+    const maxSpreadPct = Number.isFinite(configured) && configured > 0 ? configured : 5;
+    if (!Number.isFinite(spreadPct) || bid <= 0 || ask <= bid) {
+      throw new Error(`${symbol}: 24-hour quote has no valid two-sided book; refusing the plan.`);
+    }
+    if (spreadPct > maxSpreadPct) {
+      throw new Error(
+        `${symbol}: 24-hour bid/ask spread is ${spreadPct.toFixed(2)}% (${bid.toFixed(2)} / ${ask.toFixed(2)}), above the ${maxSpreadPct.toFixed(2)}% safety cap. Refusing the plan.`,
+      );
+    }
+  }
 
   // 3. Quantity (Robinhood: 4 decimal places for fractional shares).
   const rawShares = input.amount ? Number(input.amount) / last : Number(input.shares);
@@ -4710,6 +4781,8 @@ export async function placeEquityOrder(
       type: "market",
       otcAutoLimit,
       dollarBased,
+      marketHours,
+      eligibility,
       session,
       sessionWarning: reason,
       live: false,
@@ -4732,6 +4805,7 @@ export async function placeEquityOrder(
     side,
     order_form_version: "7",
     ref_id: refId,
+    market_hours: marketHours,
   };
   let body: Record<string, unknown>;
   if (dollarBased) {
@@ -4740,14 +4814,28 @@ export async function placeEquityOrder(
     body = {
       ...baseBody,
       dollar_based_amount: { amount: Number(input.amount).toFixed(2), currency_code: "USD" },
-      market_hours: "regular_hours",
       position_effect: side === "buy" ? "open" : "close",
       ...(Number.isFinite(bid) && bid > 0 ? { bid_price: bid.toFixed(2) } : {}),
       ...(Number.isFinite(ask) && ask > 0 ? { ask_price: ask.toFixed(2) } : {}),
       ...(q?.updated_at ? { bid_ask_timestamp: String(q.updated_at) } : {}),
     };
   } else {
-    body = { ...baseBody, quantity: String(shares), price };
+    const bid = Number(q?.bid_price);
+    const ask = Number(q?.ask_price);
+    body = {
+      ...baseBody,
+      quantity: String(shares),
+      price,
+      ...(marketHours !== "regular_hours" && Number.isFinite(bid) && bid > 0
+        ? { bid_price: bid.toFixed(2) }
+        : {}),
+      ...(marketHours !== "regular_hours" && Number.isFinite(ask) && ask > 0
+        ? { ask_price: ask.toFixed(2) }
+        : {}),
+      ...(marketHours !== "regular_hours" && q?.updated_at
+        ? { bid_ask_timestamp: String(q.updated_at) }
+        : {}),
+    };
   }
 
   // NOTIONAL CAPS: block an oversized LIVE send. Applies only to a genuine live attempt (intent +
@@ -4830,6 +4918,8 @@ export async function placeEquityOrder(
     type: isMarket ? "market" : "limit",
     otcAutoLimit,
     dollarBased,
+    marketHours,
+    eligibility,
     session,
     sessionWarning,
     live: !result.dryRun,
@@ -11095,6 +11185,189 @@ export async function getIpoAccess(
     eligibility: { eligibleAccounts, restrictedAccounts, restrictionReasons: [...reasons].sort() },
     message: openOfferingCount === 0 ? "No open IPO offerings are currently available." : null,
     warnings,
+  };
+}
+
+export interface IpoAccessRequestPlan {
+  symbol: string;
+  instrumentId: string;
+  status: string | null;
+  formStateId: string | null;
+  canRequest: boolean;
+  blockers: string[];
+  enrollment: { evaluated: true; enrolled: boolean };
+  deadline: { evaluated: boolean; passed: boolean | null; at: string | null };
+  buyingPower: { evaluated: boolean; amount: number | null; currencyCode: string | null };
+  existingOrder: { evaluated: true; present: boolean };
+  education: {
+    title: string | null;
+    subtitleMarkdown: string | null;
+    sections: unknown[];
+    startLabel: string | null;
+    suppressLabel: string | null;
+  };
+  acknowledgement: {
+    required: boolean;
+    title: string | null;
+    rows: unknown[];
+    footerMarkdown: string | null;
+    acceptLabel: string | null;
+    dismissLabel: string | null;
+  };
+  notificationDisclosure: {
+    title: string | null;
+    rows: unknown[];
+    disclosureMarkdown: string | null;
+    continueLabel: string | null;
+  };
+  review: {
+    title: string | null;
+    rows: unknown;
+    orderSummaryMarkdown: string | null;
+    disclaimerMarkdown: string | null;
+  };
+  submission: { evaluated: false; status: "not_evaluated"; missingInput: string };
+}
+
+/**
+ * Collapse Robinhood's IPO Access splash, indication-of-interest, notification disclosure, and
+ * account-scoped entry form into one non-mutating plan. The UX cards are returned as structured
+ * acknowledgement content; they are not mistaken for separate product steps. Submission remains
+ * explicitly not_evaluated until a real submit/update HTTP contract is captured.
+ */
+export async function getIpoAccessRequestPlan(
+  input: { symbol: string; accountNumber: string },
+  deps: { getJson?: typeof brokerageGetJson } = {},
+): Promise<IpoAccessRequestPlan> {
+  const getJson = deps.getJson ?? brokerageGetJson;
+  await assertAccountOwned(input.accountNumber, { getJson, onLookupFailure: "block" });
+  const symbol = input.symbol.trim().toUpperCase();
+  const instrument = (
+    await getJson("https://api.robinhood.com/instruments/?symbol={symbol}", { symbol })
+  ).results?.[0];
+  if (!instrument?.id) throw new Error(`IPO Access instrument ${symbol} not found`);
+  const instrumentId = String(instrument.id);
+  const [splash, entry, acknowledgement, notification] = await Promise.all([
+    getJson(
+      "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/",
+      { instrument_id: instrumentId },
+      { endpoint_version: "2021-10-13" },
+    ),
+    getJson(
+      "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/",
+      { instrument_id: instrumentId },
+      { account_number: input.accountNumber },
+    ),
+    getJson(
+      "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/",
+      { instrument_id: instrumentId },
+    ),
+    getJson(
+      "https://bonfire.robinhood.com/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/",
+      { instrument_id: instrumentId },
+    ),
+  ]);
+  const context = entry?.context ?? {};
+  const buyingPowerAmount = Number(context?.available_buying_power?.amount);
+  const deadlineAt =
+    typeof context?.ipo_access_cob_deadline === "string"
+      ? context.ipo_access_cob_deadline
+      : typeof instrument.ipo_access_cob_deadline === "string"
+        ? instrument.ipo_access_cob_deadline
+        : null;
+  const deadlinePassed =
+    typeof context?.has_cob_deadline_passed === "boolean"
+      ? context.has_cob_deadline_passed
+      : deadlineAt
+        ? Date.parse(deadlineAt) <= Date.now()
+        : null;
+  const enrolled = context?.user_is_enrolled === true;
+  const blockers: string[] = [];
+  if (!enrolled) blockers.push("ipo_access_not_enrolled");
+  if (deadlinePassed === true) blockers.push("cob_deadline_passed");
+  if (typeof entry?.ipoa_new_orders_blocked_details === "string" && entry.ipoa_new_orders_blocked_details)
+    blockers.push(entry.ipoa_new_orders_blocked_details);
+  if (entry?.action_required_view_model) blockers.push("action_required");
+  return {
+    symbol: String(instrument.symbol ?? symbol),
+    instrumentId,
+    status:
+      typeof (context?.phase ?? instrument.ipo_access_status) === "string"
+        ? String(context?.phase ?? instrument.ipo_access_status)
+        : null,
+    formStateId:
+      typeof entry?.form_state?.form_state_id === "string" ? entry.form_state.form_state_id : null,
+    canRequest: blockers.length === 0,
+    blockers,
+    enrollment: { evaluated: true, enrolled },
+    deadline: { evaluated: deadlinePassed !== null, passed: deadlinePassed, at: deadlineAt },
+    buyingPower: {
+      evaluated: Number.isFinite(buyingPowerAmount),
+      amount: Number.isFinite(buyingPowerAmount) ? buyingPowerAmount : null,
+      currencyCode:
+        typeof context?.available_buying_power?.currency_code === "string"
+          ? context.available_buying_power.currency_code
+          : null,
+    },
+    existingOrder: { evaluated: true, present: Boolean(context?.existing_order) },
+    education: {
+      title: typeof splash?.title === "string" ? splash.title : null,
+      subtitleMarkdown:
+        typeof splash?.subtitle_markdown === "string" ? splash.subtitle_markdown : null,
+      sections: Array.isArray(splash?.sections) ? splash.sections : [],
+      startLabel:
+        typeof splash?.continue_cta_title === "string" ? splash.continue_cta_title : null,
+      suppressLabel:
+        typeof splash?.dont_show_again_cta_title === "string"
+          ? splash.dont_show_again_cta_title
+          : null,
+    },
+    acknowledgement: {
+      required: Boolean(acknowledgement?.accept_title),
+      title: typeof acknowledgement?.title === "string" ? acknowledgement.title : null,
+      rows: Array.isArray(acknowledgement?.rows) ? acknowledgement.rows : [],
+      footerMarkdown:
+        typeof acknowledgement?.footer_markdown === "string"
+          ? acknowledgement.footer_markdown
+          : null,
+      acceptLabel:
+        typeof acknowledgement?.accept_title === "string" ? acknowledgement.accept_title : null,
+      dismissLabel:
+        typeof acknowledgement?.dismiss_title === "string" ? acknowledgement.dismiss_title : null,
+    },
+    notificationDisclosure: {
+      title: typeof notification?.title === "string" ? notification.title : null,
+      rows: Array.isArray(notification?.rows) ? notification.rows : [],
+      disclosureMarkdown:
+        typeof notification?.disclosure_markdown === "string"
+          ? notification.disclosure_markdown
+          : null,
+      continueLabel:
+        typeof notification?.continue_button?.title === "string"
+          ? notification.continue_button.title
+          : null,
+    },
+    review: {
+      title:
+        typeof entry?.order_entry_view_model?.title === "string"
+          ? entry.order_entry_view_model.title
+          : null,
+      rows: entry?.order_entry_view_model?.rows ?? null,
+      orderSummaryMarkdown:
+        typeof entry?.order_entry_view_model?.order_summary?.description_markdown === "string"
+          ? entry.order_entry_view_model.order_summary.description_markdown
+          : null,
+      disclaimerMarkdown:
+        typeof entry?.order_entry_view_model?.disclaimer?.label_markdown === "string"
+          ? entry.order_entry_view_model.disclaimer.label_markdown
+          : null,
+    },
+    submission: {
+      evaluated: false,
+      status: "not_evaluated",
+      missingInput:
+        "The IPO submit/update/cancel HTTP method, URL, and request body have not been captured from a live review action; no order was built or sent.",
+    },
   };
 }
 

--- a/cli/test/equity-order.test.ts
+++ b/cli/test/equity-order.test.ts
@@ -213,6 +213,55 @@ describe("placeEquityOrder — validation & guards", () => {
     await expect(placeEquityOrder({ symbol: "AAPL", accountNumber: "A1", side: "sell", amount: 50 }, missing.deps))
       .rejects.toThrow(/Invalid or missing quote/);
   });
+  it("builds a true 24-hour whole-share limit body and rejects ineligible variants", async () => {
+    const eligible = {
+      id: "iid-nbil",
+      symbol: "NBIL",
+      fractional_tradability: "tradable",
+      all_day_tradability: "tradable",
+      twenty_four_seven_tradability: "untradable",
+    };
+    const ok = makeDeps({
+      instrument: eligible,
+      quote: {
+        last_trade_price: "20.50",
+        bid_price: "20.50",
+        ask_price: "20.64",
+        updated_at: "2026-08-08T06:00:00Z",
+        instrument_id: "iid-nbil",
+      },
+      session: "closed",
+    });
+    const result = await placeEquityOrder(
+      { symbol: "NBIL", accountNumber: "A1", side: "sell", shares: 1, limitPrice: 20.55, marketHours: "all_day_hours" },
+      ok.deps,
+    );
+    expect(ok.calls.writes[0].body).toMatchObject({
+      symbol: "NBIL",
+      side: "sell",
+      quantity: "1",
+      type: "limit",
+      price: "20.55",
+      market_hours: "all_day_hours",
+      time_in_force: "gtc",
+      order_form_version: "7",
+      bid_price: "20.50",
+      ask_price: "20.64",
+      bid_ask_timestamp: "2026-08-08T06:00:00Z",
+    });
+    expect(result).toMatchObject({ marketHours: "all_day_hours", eligibility: { evaluated: true, eligible: true } });
+
+    const wide = makeDeps({ instrument: eligible, quote: { last_trade_price: "19.67", bid_price: "18.90", ask_price: "21.00", instrument_id: "iid-nbil" } });
+    await expect(placeEquityOrder({ symbol: "NBIL", accountNumber: "A1", side: "sell", shares: 1, limitPrice: 20.55, marketHours: "all_day_hours" }, wide.deps)).rejects.toThrow(/spread is 10\.53%.*above the 5\.00% safety cap/i);
+    expect(wide.calls.writes).toHaveLength(0);
+
+    const fractional = makeDeps({ instrument: eligible });
+    await expect(placeEquityOrder({ symbol: "NBIL", accountNumber: "A1", side: "sell", shares: 1.5, limitPrice: 20.55, marketHours: "all_day_hours" }, fractional.deps)).rejects.toThrow(/whole shares/i);
+    const noLimit = makeDeps({ instrument: eligible });
+    await expect(placeEquityOrder({ symbol: "NBIL", accountNumber: "A1", side: "sell", shares: 1, marketHours: "all_day_hours" }, noLimit.deps)).rejects.toThrow(/limit/i);
+    const blocked = makeDeps({ instrument: { ...eligible, all_day_tradability: "untradable" } });
+    await expect(placeEquityOrder({ symbol: "NBIL", accountNumber: "A1", side: "sell", shares: 1, limitPrice: 20.55, marketHours: "all_day_hours" }, blocked.deps)).rejects.toThrow(/all_day_tradability=untradable/);
+  });
 });
 
 describe("placeEquityOrder — owned-account guard (WSF-02: the #1 money-loss defense)", () => {

--- a/cli/test/finance-reads.test.ts
+++ b/cli/test/finance-reads.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getInboxSummary,
   getIpoAccess,
+  getIpoAccessRequestPlan,
   getStockRewardsSummary,
   getSweepInterest,
   listGoldFees,
@@ -95,6 +96,76 @@ describe("finance read summaries", () => {
     expect(calls.some((url) => url.includes("discovery/lists/items"))).toBe(false);
     expect(result.offerings[0]).toMatchObject({ symbol: "JMKE", ipoId: "ipo-1", status: "open", priceUsd: 23, customerCount: 12 });
     expect(result.eligibility).toEqual({ eligibleAccounts: 0, restrictedAccounts: 1, restrictionReasons: ["account_ineligible"] });
+  });
+
+  it("collapses IPO onboarding cards into one explicit request plan without pretending the submit write is mapped", async () => {
+    const calls: string[] = [];
+    const result = await getIpoAccessRequestPlan(
+      { symbol: "rvii", accountNumber: "A1" },
+      {
+        getJson: async (url: string, _pathParams?: Record<string, string>, query?: Record<string, string>) => {
+          calls.push(`${url}?${new URLSearchParams(query ?? {}).toString()}`);
+          if (url.includes("transfer/accounts")) return { results: [{ account_number: "A1", type: "rhs" }] };
+          if (url.includes("instruments/?symbol"))
+            return {
+              results: [
+                {
+                  id: "ipo-1",
+                  symbol: "RVII",
+                  ipo_access_status: "price_finalized",
+                  ipo_access_cob_deadline: "2026-08-13T00:00:00Z",
+                },
+              ],
+            };
+          if (url.includes("order_entry_splash"))
+            return {
+              title: "IPO Access",
+              subtitle_markdown: "Learn before requesting",
+              continue_cta_title: "Start request",
+              dont_show_again_cta_title: "Don't show again",
+              sections: [],
+            };
+          if (url.includes("web_order_entry"))
+            return {
+              ipoa_new_orders_blocked_details: "",
+              form_state: { form_state_id: "price_finalized2525" },
+              order_entry_view_model: {
+                title: "Request to buy RVII",
+                buying_power_description: "$50.00 Buying Power Available",
+                rows: { quantity_row: { label: "Number of shares" }, price_row: { value: "$25.00" } },
+                order_summary: { description_markdown: "conditional offer to buy" },
+                disclaimer: { label_markdown: "deadline" },
+              },
+              context: {
+                phase: "price_finalized",
+                user_is_enrolled: true,
+                has_cob_deadline_passed: false,
+                available_buying_power: { amount: "50.00", currency_code: "USD" },
+                existing_order: null,
+              },
+            };
+          if (url.includes("indication_of_interest"))
+            return { title: "Before you request", rows: [{ title_markdown: "Risk" }], footer_markdown: "Terms", accept_title: "I agree", dismiss_title: "Cancel" };
+          if (url.includes("notification_disclosure"))
+            return { title: "Notifications", rows: [], disclosure_markdown: "Notice", continue_button: { title: "Continue" } };
+          throw new Error(`unexpected ${url}`);
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      symbol: "RVII",
+      status: "price_finalized",
+      canRequest: true,
+      enrollment: { evaluated: true, enrolled: true },
+      deadline: { evaluated: true, passed: false, at: "2026-08-13T00:00:00Z" },
+      buyingPower: { evaluated: true, amount: 50, currencyCode: "USD" },
+      education: { startLabel: "Start request", suppressLabel: "Don't show again" },
+      acknowledgement: { required: true, acceptLabel: "I agree", dismissLabel: "Cancel" },
+      submission: { evaluated: false, status: "not_evaluated" },
+    });
+    expect(calls.some((url) => url.includes("account_number=A1"))).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("A1");
   });
 });
 

--- a/docs/ipo-access-and-24-hour-contract-map-2026-08-08.md
+++ b/docs/ipo-access-and-24-hour-contract-map-2026-08-08.md
@@ -1,0 +1,165 @@
+# IPO Access + 24-Hour Equity Contract Map
+
+Captured 2026-08-08 from authenticated read-only Robinhood surfaces and static production web assets. No IPO interest or equity order was submitted.
+
+## Evidence
+
+Robinhood web build: `2026.32.5622+fd5ce74d1fc4`
+
+| Artifact | SHA-256 |
+|---|---|
+| `App-1b250e4b96c6a0f7abde.js` | `06cdf614f7653f7d6ef37e73b118076dae750bd74a1896142e4c6c34001e9c98` |
+| `runtime-d4a2977b4ee337bbb05d.js` | `b842033eb09e592b08c8057a61efc18d93bc717a380542fd2a9cb9f1707fb27b` |
+| `96049-1cc241f6c659f3ae3d5f.chunk.js` | `92b1fbb79f04e610c54fd16e9d71c1d0123a1327f9ba23619de0486114fdc7e1` |
+
+Live RVII GETs verified the request-plan viewmodels and returned HTTP 200 on an owned account. Live NBIL instrument/quote reads verified `all_day_tradability: tradable`, ordinary fractional tradability, no extended-hours fractional support, and a current wide two-sided book.
+
+## IPO Access product map
+
+The education carousel is UX around one account-scoped request state. It is not five independent product operations. `ipo-access plan-request` and `robinhood_ipo_access_request_plan` collapse the following into one structured read:
+
+1. Symbol/instrument resolution
+2. Owned-account verification
+3. Education splash and optional “don't show again” label
+4. Indication-of-interest risk acknowledgement and acceptance label
+5. Notification disclosure
+6. Account-scoped order-entry form
+7. Enrollment state
+8. Phase/form-state ID
+9. COB deadline and passed state
+10. Available buying power
+11. Existing request/order presence
+12. New-order blockers and required actions
+13. Review rows, order summary, and disclaimer
+
+### Registered and exercised routes
+
+| Route | Risk | Query |
+|---|---|---|
+| `/equity_trading/ipo_access/viewmodels/order_entry_splash/{instrument_id}/` | read | `endpoint_version=2021-10-13` |
+| `/equity_trading/ipo_access/viewmodels/indication_of_interest/{instrument_id}/` | read | none |
+| `/equity_trading/ipo_access/viewmodels/notification_disclosure/{instrument_id}/` | read | none |
+| `/equity_trading/ipo_access/viewmodels/web_order_entry/{instrument_id}/` | sensitive-read | `account_number` |
+| `/equity_trading/ipo_access/viewmodels/summary/{ipo_id}/` | read | none |
+
+### Additional GET viewmodels found in the production bundle
+
+- IPO announcement
+- allocation learning hub
+- allocation results
+- post-deadline follow-up
+- trade receipt
+- shareable allocation results
+- list card and IPO list viewmodels
+- limit-type explanation
+- web order entry and order-entry splash
+
+These are mapped as product states but are not all invoked by the request-plan wrapper because they belong to later lifecycle phases.
+
+### Current live RVII proof
+
+- phase: `price_finalized`
+- form state: `price_finalized2525`
+- enrolled: true
+- deadline evaluated and not passed
+- buying power evaluated
+- no existing request
+- no request blockers
+
+### IPO write boundary
+
+The submit/update/cancel HTTP method, URL, and request serializer were not captured from a real review action. The wrapper therefore returns:
+
+```json
+{
+  "submission": {
+    "evaluated": false,
+    "status": "not_evaluated",
+    "missingInput": "The IPO submit/update/cancel HTTP method, URL, and request body have not been captured from a live review action; no order was built or sent."
+  }
+}
+```
+
+Do not infer a generic `/orders/` POST from the standard equity serializer. Capture the exact IPO review request before implementing a write.
+
+## Equity execution-session map
+
+Production enum values:
+
+| Product meaning | `market_hours` |
+|---|---|
+| Regular session | `regular_hours` |
+| Pre-market / after-hours | `extended_hours` |
+| Overnight / 24 Hour Market | `all_day_hours` |
+| Distinct legacy/internal enum; not used by this wrapper | `hyper_extended_hours` |
+
+Instrument eligibility fields found in the web build:
+
+- `all_day_tradability`
+- `twenty_four_seven_tradability`
+- `extended_hours_fractional_tradability`
+- ordinary `tradability`
+
+The web build also contains distinct checks for all-day symbol eligibility, all-day session kill-switches, fractional promotion/blocking, invalid time windows, quantity restrictions, price bands, and spreads. A screenshot proves the UI route, not account/session API eligibility.
+
+## Implemented 24-hour dry-run contract
+
+`--market-hours overnight` maps to `market_hours: all_day_hours` in the shared CLI/MCP order engine.
+
+The engine requires:
+
+- explicit share quantity
+- whole shares
+- explicit limit price
+- `instrument.all_day_tradability === "tradable"`
+- valid two-sided bid/ask
+- spread at or below `ROBINHOOD_MAX_ALL_DAY_SPREAD_PCT` (default 5%)
+- owned account
+- forced dry-run while account-scoped order-check remains unmapped
+
+Mapped request fields:
+
+```json
+{
+  "type": "limit",
+  "time_in_force": "gtc",
+  "trigger": "immediate",
+  "market_hours": "all_day_hours",
+  "quantity": "1",
+  "price": "20.55",
+  "bid_price": "20.50",
+  "ask_price": "20.64",
+  "bid_ask_timestamp": "...",
+  "order_form_version": "7",
+  "position_effect": "close"
+}
+```
+
+### NBIL proof and safety result
+
+The requested screenshot contract (`1` share, `$20.55`, `$20.50 / $20.64`) is covered by regression tests and builds the expected body.
+
+The current live NBIL quote at verification was `$18.90 / $21.00`, a 10.53% spread. The live dry-run correctly blocked before producing a ready plan:
+
+```text
+NBIL: 24-hour bid/ask spread is 10.53% (18.90 / 21.00), above the 5.00% safety cap. Refusing the plan.
+```
+
+## Remaining evidence needed before live 24-hour execution
+
+Capture Robinhood's account-scoped order-check/preflight request and response for an all-day ticket, including:
+
+- account eligibility
+- instrument eligibility
+- session open/kill-switch state
+- supported TIF/order type
+- whole/fractional rule
+- limit-price bands
+- bid/ask freshness
+- spread/liquidity warning or block
+- disclosure version/acceptance state
+- review route and final serializer
+
+Until then, non-regular live sends fail closed even when `ROBINHOOD_ALLOW_LIVE_WRITE=1` is set.
+
+- delilah 🌸

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1414,7 +1414,9 @@ server.registerTool(
       market_hours: z
         .enum(["regular_hours", "extended_hours", "all_day_hours"])
         .optional()
-        .describe("explicit execution session; all_day_hours is the 24-hour market and remains dry-run-only until account-scoped order-check capture"),
+        .describe(
+          "explicit execution session; all_day_hours is the 24-hour market and remains dry-run-only until account-scoped order-check capture",
+        ),
       dryRun: z.boolean().default(false),
       liveWrite: z.boolean().optional(),
       live: z.boolean().optional(),
@@ -1488,7 +1490,9 @@ server.registerTool(
       market_hours: z
         .enum(["regular_hours", "extended_hours", "all_day_hours"])
         .optional()
-        .describe("explicit execution session; all_day_hours is the 24-hour market and remains dry-run-only until account-scoped order-check capture"),
+        .describe(
+          "explicit execution session; all_day_hours is the 24-hour market and remains dry-run-only until account-scoped order-check capture",
+        ),
       dryRun: z.boolean().default(false),
       liveWrite: z.boolean().optional(),
       live: z.boolean().optional(),

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -121,6 +121,7 @@ import {
   getStockRewardsSummary,
   getInboxSummary,
   getIpoAccess,
+  getIpoAccessRequestPlan,
   type BrokerageRoute,
 } from "@zaydiscold/robinhood-cli/lib";
 
@@ -1410,6 +1411,10 @@ server.registerTool(
         .describe(
           "time in force; omit to let the engine pick (gfd market/OTC, gtc limit). gtc is rejected on a fractional dollar-market order",
         ),
+      market_hours: z
+        .enum(["regular_hours", "extended_hours", "all_day_hours"])
+        .optional()
+        .describe("explicit execution session; all_day_hours is the 24-hour market and remains dry-run-only until account-scoped order-check capture"),
       dryRun: z.boolean().default(false),
       liveWrite: z.boolean().optional(),
       live: z.boolean().optional(),
@@ -1435,6 +1440,7 @@ server.registerTool(
     force,
     overrideCap,
     time_in_force,
+    market_hours,
   }) => {
     try {
       await assertAccountOwned(account_number);
@@ -1446,6 +1452,7 @@ server.registerTool(
         shares,
         limitPrice,
         timeInForce: time_in_force,
+        marketHours: market_hours,
         dryRun,
         liveWrite: resolveLiveFlag(liveWrite, live),
         force: Boolean(force),
@@ -1478,6 +1485,10 @@ server.registerTool(
         .describe(
           "time in force; omit to let the engine pick (gfd market/OTC, gtc limit). gtc is rejected on a fractional dollar-market order",
         ),
+      market_hours: z
+        .enum(["regular_hours", "extended_hours", "all_day_hours"])
+        .optional()
+        .describe("explicit execution session; all_day_hours is the 24-hour market and remains dry-run-only until account-scoped order-check capture"),
       dryRun: z.boolean().default(false),
       liveWrite: z.boolean().optional(),
       live: z.boolean().optional(),
@@ -1503,6 +1514,7 @@ server.registerTool(
     force,
     overrideCap,
     time_in_force,
+    market_hours,
   }) => {
     try {
       await assertAccountOwned(account_number);
@@ -1514,6 +1526,7 @@ server.registerTool(
         shares,
         limitPrice,
         timeInForce: time_in_force,
+        marketHours: market_hours,
         dryRun,
         liveWrite: resolveLiveFlag(liveWrite, live),
         force: Boolean(force),
@@ -3759,6 +3772,20 @@ registerCapabilityTool(
     annotations: toolAnnotations(true, "read"),
   },
   async ({ symbol }: { symbol?: string }) => jsonResponse(await getIpoAccess({ symbol })),
+);
+
+registerCapabilityTool(
+  "ipo_access_request_plan",
+  {
+    title: "Robinhood IPO Access Request Plan",
+    description:
+      "Collapse IPO education, indication-of-interest acknowledgement, notification disclosure, account eligibility, buying power, deadline, existing-order state, and review fields into one read-only plan. Never submits, updates, or cancels interest; returns explicit not_evaluated submission state until the write contract is captured.",
+    inputSchema: z.object({ symbol: symbolSchema, account_number: accountNumberSchema }),
+    outputSchema: z.object({}).catchall(z.unknown()),
+    annotations: toolAnnotations(true, "sensitive-read"),
+  },
+  async ({ symbol, account_number }: { symbol: string; account_number: string }) =>
+    jsonResponse(await getIpoAccessRequestPlan({ symbol, accountNumber: account_number })),
 );
 
 // ── MCP Prompts: reusable operating templates ────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- collapse Robinhood IPO education, acknowledgement, disclosure, eligibility, deadline, buying power, existing-order state, and review fields into one read-only CLI/MCP request plan
- register the four live-verified IPO viewmodel routes
- add explicit regular / extended / all-day market-hour enums to the shared equity engine and CLI/MCP schemas
- map `all_day_hours` whole-share limit dry-runs with instrument eligibility, two-sided-book validation, and a configurable 5% spread cap
- fail closed on live non-regular submissions until the account-scoped order-check/review contract is captured
- document production bundle hashes, route/state evidence, exact gaps, and live RVII/NBIL proofs

## Verification
- `npm test`: CLI 477/477; MCP 16 passed, 2 intentionally skipped; auth-session 2/2
- semantic cross-product ship gate: 21 pass / 0 warn / 0 fail
- live RVII request-plan read: price_finalized2525, enrolled, deadline not passed, buying power evaluated, no existing request, no blockers
- live NBIL overnight dry-run: correctly blocked 10.53% spread above 5% cap
- no orders or IPO requests submitted

- delilah 🌸