### PR TITLE
feat(options): add delta-dollar and elasticity analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,8 @@ Two read-only convenience commands that join the raw options routes (`aggregate_
 
 ```bash
 # Every open option position across ALL owned accounts, ranked in DOLLARS:
-# per-contract value, unrealized $ P&L, day $ change, account, return %, delta — with totals.
+# per-contract value, unrealized/day $ P&L, delta shares/$, intrinsic/extrinsic,
+# local option elasticity and expiration break-even — with totals.
 robinhood-cli options positions
 robinhood-cli options positions --json
 
@@ -399,7 +400,7 @@ TOTAL: value $18825.00 | unrealized $17335.00 | day $375.00
 Best performer: DRAM $50 Call 6/18 at +1334.6%.
 ```
 
-Both are pure reads (no write gate). `--json` emits structured rows for piping into a spreadsheet or an agent.
+Both are pure reads (no write gate). `--json` emits structured rows for piping into a spreadsheet or an agent. The same `exposureAnalytics` object is included by MCP `robinhood_options_holdings`, `robinhood_options_inspect`, and `robinhood_options_snapshot`. See [`docs/options-exposure-analytics.md`](./docs/options-exposure-analytics.md) for formulas, the intrinsic/extrinsic read order, delta-dollar interpretation, and why a giant OTM elasticity number is not guaranteed leverage.
 
 ### 6.1 Options strategy planners — Greeks, spreads, quotes, and dry-run bodies
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -97,6 +97,7 @@ import {
   readOptionsOrderDiagnostics,
   loadOptionsStrategyWorkflows,
   loadRobinhoodRoutes,
+  computeOptionExposureAnalytics,
   optionReturnPct,
   parseParamAssignments,
   percentChange,
@@ -2079,14 +2080,57 @@ options
       return;
     }
     const marks = await fetchOptionMarks(open.map((position) => position.optionId));
+    const metaEntries = await Promise.all(
+      open.map(async (position) => {
+        try {
+          return [
+            position.optionId,
+            await brokerageGetJson(OPTION_INSTRUMENT_URL, { "0": position.optionId }),
+          ] as const;
+        } catch {
+          return [position.optionId, {}] as const;
+        }
+      }),
+    );
+    const metadata = new Map(metaEntries);
+    const symbols = [...new Set(open.map((position) => position.symbol).filter(Boolean))];
+    const equityEntries = await Promise.all(
+      symbols.map(async (symbol) => {
+        try {
+          const instrument = (
+            await brokerageGetJson(INSTRUMENTS_SYMBOL_URL, { symbol })
+          ).results?.[0];
+          return [symbol, String(instrument?.id ?? "")] as const;
+        } catch {
+          return [symbol, ""] as const;
+        }
+      }),
+    );
+    const equityIds = new Map(equityEntries);
+    const equityQuotes = await fetchQuotes([...new Set([...equityIds.values()].filter(Boolean))]);
     const rows = open
       .map((position) => {
         const m = marks.get(position.optionId) ?? {};
-        const mark = num(m.adjusted_mark_price);
+        const meta = metadata.get(position.optionId) ?? {};
+        const mark = num(m.adjusted_mark_price ?? m.mark_price);
         const prev = num(m.previous_close_price);
         const delta = num(m.delta);
         const valueUsd = Number.isFinite(mark) ? mark * 100 * position.quantity : Number.NaN;
         const entryPer = position.averageOpenPrice / 100;
+        const equityQuote = equityQuotes.get(equityIds.get(position.symbol) ?? "") ?? {};
+        const spot = finiteNumber(
+          equityQuote.last_extended_hours_trade_price ?? equityQuote.last_trade_price,
+        );
+        const analytics = computeOptionExposureAnalytics({
+          type: meta.type === "put" ? "put" : "call",
+          strike: finiteNumber(meta.strike_price),
+          spot,
+          optionPrice: mark,
+          entryPremiumPerShare: entryPer,
+          delta,
+          theta: finiteNumber(m.theta),
+          contracts: position.quantity,
+        });
         return {
           contract: position.name,
           acct: position.accountNumber ? `…${position.accountNumber.slice(-4)}` : "—",
@@ -2102,6 +2146,7 @@ options
               : Number.NaN,
           returnPct: optionReturnPct(position.averageOpenPrice, mark),
           delta,
+          analytics,
         };
       })
       // Dollars, not percents: rank by unrealized $ P&L so a $6 lot can't outrank a $1,600 call.
@@ -2126,6 +2171,12 @@ options
         day_usd: usd(row.dayUsd),
         return: pct(row.returnPct),
         delta: Number.isFinite(row.delta) ? row.delta.toFixed(2) : "—",
+        delta_usd: usd(row.analytics.deltaDollars),
+        elasticity: Number.isFinite(row.analytics.elasticity)
+          ? `${row.analytics.elasticity.toFixed(2)}x`
+          : "—",
+        intrinsic: usd(row.analytics.intrinsicValueUsd),
+        extrinsic: usd(row.analytics.extrinsicValueUsd),
       })),
       [
         "contract",
@@ -2138,6 +2189,10 @@ options
         "day_usd",
         "return",
         "delta",
+        "delta_usd",
+        "elasticity",
+        "intrinsic",
+        "extrinsic",
       ],
     );
     const sum = (xs: number[]) => xs.filter(Number.isFinite).reduce((s, x) => s + x, 0);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2097,9 +2097,8 @@ options
     const equityEntries = await Promise.all(
       symbols.map(async (symbol) => {
         try {
-          const instrument = (
-            await brokerageGetJson(INSTRUMENTS_SYMBOL_URL, { symbol })
-          ).results?.[0];
+          const instrument = (await brokerageGetJson(INSTRUMENTS_SYMBOL_URL, { symbol }))
+            .results?.[0];
           return [symbol, String(instrument?.id ?? "")] as const;
         } catch {
           return [symbol, ""] as const;
@@ -2121,7 +2120,7 @@ options
         const spot = finiteNumber(
           equityQuote.last_extended_hours_trade_price ?? equityQuote.last_trade_price,
         );
-        const analytics = computeOptionExposureAnalytics({
+        const exposureAnalytics = computeOptionExposureAnalytics({
           type: meta.type === "put" ? "put" : "call",
           strike: finiteNumber(meta.strike_price),
           spot,
@@ -2146,7 +2145,7 @@ options
               : Number.NaN,
           returnPct: optionReturnPct(position.averageOpenPrice, mark),
           delta,
-          analytics,
+          exposureAnalytics,
         };
       })
       // Dollars, not percents: rank by unrealized $ P&L so a $6 lot can't outrank a $1,600 call.
@@ -2171,12 +2170,12 @@ options
         day_usd: usd(row.dayUsd),
         return: pct(row.returnPct),
         delta: Number.isFinite(row.delta) ? row.delta.toFixed(2) : "—",
-        delta_usd: usd(row.analytics.deltaDollars),
-        elasticity: Number.isFinite(row.analytics.elasticity)
-          ? `${row.analytics.elasticity.toFixed(2)}x`
+        delta_usd: usd(row.exposureAnalytics.deltaDollars),
+        elasticity: Number.isFinite(row.exposureAnalytics.elasticity)
+          ? `${row.exposureAnalytics.elasticity.toFixed(2)}x`
           : "—",
-        intrinsic: usd(row.analytics.intrinsicValueUsd),
-        extrinsic: usd(row.analytics.extrinsicValueUsd),
+        intrinsic: usd(row.exposureAnalytics.intrinsicValueUsd),
+        extrinsic: usd(row.exposureAnalytics.extrinsicValueUsd),
       })),
       [
         "contract",

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -8470,6 +8470,134 @@ export function optionReturnPct(averageOpenPrice: number, adjustedMarkPrice: num
   return ((currentValue - averageOpenPrice) / averageOpenPrice) * 100;
 }
 
+export interface OptionExposureAnalyticsInput {
+  type: "call" | "put";
+  strike: number;
+  spot: number;
+  optionPrice: number;
+  entryPremiumPerShare?: number;
+  delta: number;
+  theta?: number;
+  contracts?: number;
+  positionSide?: "long" | "short";
+}
+
+export interface OptionExposureAnalytics {
+  intrinsicValuePerShare: number;
+  extrinsicValuePerShare: number;
+  intrinsicValueUsd: number;
+  extrinsicValueUsd: number;
+  intrinsicPctOfPremium: number;
+  extrinsicPctOfPremium: number;
+  positionValueUsd: number;
+  deltaShares: number;
+  deltaDollars: number;
+  elasticity: number;
+  absoluteElasticity: number;
+  premiumPerDeltaDollar: number;
+  markBreakEvenAtExpiration: number;
+  costBasisBreakEvenAtExpiration: number;
+  underlyingMovePctToMarkBreakEven: number;
+  thetaUsdPerDay: number;
+  thetaPctOfPremiumPerDay: number;
+  warnings: string[];
+}
+
+/**
+ * Local, first-order option exposure diagnostics.
+ *
+ * `elasticity = deltaDollars / |positionValueUsd|` estimates the option's percentage move for a
+ * 1% underlying move if delta and volatility were unchanged. It is not a forecast: gamma changes
+ * delta, while IV, theta, rates, spreads, and discrete jumps move the option independently.
+ * Intrinsic/extrinsic values use the current mark; the optional cost-basis break-even uses the
+ * actual entry premium instead. Missing or stale inputs return explicit NaN fields plus warnings.
+ */
+export function computeOptionExposureAnalytics(
+  input: OptionExposureAnalyticsInput,
+): OptionExposureAnalytics {
+  const round = (value: number, digits = 6): number =>
+    Number.isFinite(value) ? Number(value.toFixed(digits)) : Number.NaN;
+  const contracts = Number.isFinite(input.contracts) && Number(input.contracts) > 0
+    ? Number(input.contracts)
+    : 1;
+  const sign = input.positionSide === "short" ? -1 : 1;
+  const validSpot = Number.isFinite(input.spot) && input.spot > 0;
+  const validStrike = Number.isFinite(input.strike) && input.strike >= 0;
+  const validPrice = Number.isFinite(input.optionPrice) && input.optionPrice > 0;
+  const validDelta = Number.isFinite(input.delta);
+  const warnings: string[] = [];
+  if (!validSpot) warnings.push("spot_unavailable");
+  if (!validStrike) warnings.push("strike_unavailable");
+  if (!validPrice) warnings.push("option_price_unavailable");
+  if (!validDelta) warnings.push("delta_unavailable");
+
+  const intrinsic = validSpot && validStrike
+    ? input.type === "call"
+      ? Math.max(0, input.spot - input.strike)
+      : Math.max(0, input.strike - input.spot)
+    : Number.NaN;
+  const extrinsic = validPrice && Number.isFinite(intrinsic)
+    ? input.optionPrice - intrinsic
+    : Number.NaN;
+  if (Number.isFinite(extrinsic) && extrinsic < -0.01) warnings.push("negative_extrinsic_quote_violation");
+  const positionValueUsd = validPrice ? input.optionPrice * 100 * contracts * sign : Number.NaN;
+  const deltaShares = validDelta ? input.delta * 100 * contracts * sign : Number.NaN;
+  const deltaDollars = validSpot && Number.isFinite(deltaShares)
+    ? deltaShares * input.spot
+    : Number.NaN;
+  const absolutePositionValue = Math.abs(positionValueUsd);
+  const elasticity = absolutePositionValue > 0 && Number.isFinite(deltaDollars)
+    ? deltaDollars / absolutePositionValue
+    : Number.NaN;
+  const entryPremium = Number(input.entryPremiumPerShare);
+  const validEntryPremium = Number.isFinite(entryPremium) && entryPremium >= 0;
+  const markBreakEven = validPrice && validStrike
+    ? input.type === "call"
+      ? input.strike + input.optionPrice
+      : input.strike - input.optionPrice
+    : Number.NaN;
+  const costBasisBreakEven = validEntryPremium && validStrike
+    ? input.type === "call"
+      ? input.strike + entryPremium
+      : input.strike - entryPremium
+    : Number.NaN;
+  const theta = Number(input.theta);
+  const thetaUsdPerDay = Number.isFinite(theta) ? theta * 100 * contracts * sign : Number.NaN;
+
+  return {
+    intrinsicValuePerShare: round(intrinsic),
+    extrinsicValuePerShare: round(extrinsic),
+    intrinsicValueUsd: round(Number.isFinite(intrinsic) ? intrinsic * 100 * contracts * sign : Number.NaN),
+    extrinsicValueUsd: round(Number.isFinite(extrinsic) ? extrinsic * 100 * contracts * sign : Number.NaN),
+    intrinsicPctOfPremium: round(validPrice && Number.isFinite(intrinsic) ? (intrinsic / input.optionPrice) * 100 : Number.NaN),
+    extrinsicPctOfPremium: round(validPrice && Number.isFinite(extrinsic) ? (extrinsic / input.optionPrice) * 100 : Number.NaN),
+    positionValueUsd: round(positionValueUsd),
+    deltaShares: round(deltaShares),
+    deltaDollars: round(deltaDollars),
+    elasticity: round(elasticity),
+    absoluteElasticity: round(Math.abs(elasticity)),
+    premiumPerDeltaDollar: round(
+      Number.isFinite(deltaDollars) && Math.abs(deltaDollars) > 0
+        ? absolutePositionValue / Math.abs(deltaDollars)
+        : Number.NaN,
+    ),
+    markBreakEvenAtExpiration: round(markBreakEven),
+    costBasisBreakEvenAtExpiration: round(costBasisBreakEven),
+    underlyingMovePctToMarkBreakEven: round(
+      validSpot && Number.isFinite(markBreakEven)
+        ? ((markBreakEven - input.spot) / input.spot) * 100
+        : Number.NaN,
+    ),
+    thetaUsdPerDay: round(thetaUsdPerDay),
+    thetaPctOfPremiumPerDay: round(
+      absolutePositionValue > 0 && Number.isFinite(thetaUsdPerDay)
+        ? (thetaUsdPerDay / absolutePositionValue) * 100
+        : Number.NaN,
+    ),
+    warnings,
+  };
+}
+
 /**
  * Generic percent change from a base to a current value: (current - base) / base * 100.
  * Used for equity P/L (avg buy vs last) and day change (prev close vs last). Returns
@@ -10395,6 +10523,7 @@ export interface OptionsSnapshotContract {
   volume: number;
   openInterest: number;
   updatedAt: string;
+  exposureAnalytics: OptionExposureAnalytics;
 }
 
 export interface OptionsSnapshotSummary {
@@ -10580,6 +10709,14 @@ export async function computeOptionsSnapshot(
       volume: Number(mark.volume),
       openInterest: Number(mark.open_interest),
       updatedAt: String(mark.updated_at ?? mark.last_trade_price_source ?? ""),
+      exposureAnalytics: computeOptionExposureAnalytics({
+        type: side,
+        strike,
+        spot,
+        optionPrice: adjustedMark,
+        delta: Number(mark.delta),
+        theta: Number(mark.theta),
+      }),
     };
   });
   contracts.sort((a, b) =>

--- a/cli/test/options-intelligence.test.ts
+++ b/cli/test/options-intelligence.test.ts
@@ -1,5 +1,76 @@
 import { describe, expect, it } from "vitest";
-import { computeOptionsHistory, computeChainStats, computeOptionsSnapshot } from "../src/lib.js";
+import {
+  computeOptionExposureAnalytics,
+  computeOptionsHistory,
+  computeChainStats,
+  computeOptionsSnapshot,
+} from "../src/lib.js";
+
+describe("computeOptionExposureAnalytics", () => {
+  it("separates intrinsic and extrinsic value and reports delta-dollar capital elasticity", () => {
+    const result = computeOptionExposureAnalytics({
+      type: "call",
+      strike: 55,
+      spot: 100,
+      optionPrice: 50,
+      entryPremiumPerShare: 52,
+      delta: 0.8,
+      theta: -0.1,
+      contracts: 2,
+    });
+
+    expect(result.intrinsicValuePerShare).toBe(45);
+    expect(result.extrinsicValuePerShare).toBe(5);
+    expect(result.intrinsicPctOfPremium).toBe(90);
+    expect(result.extrinsicPctOfPremium).toBe(10);
+    expect(result.positionValueUsd).toBe(10_000);
+    expect(result.deltaShares).toBe(160);
+    expect(result.deltaDollars).toBe(16_000);
+    expect(result.elasticity).toBe(1.6);
+    expect(result.absoluteElasticity).toBe(1.6);
+    expect(result.premiumPerDeltaDollar).toBe(0.625);
+    expect(result.markBreakEvenAtExpiration).toBe(105);
+    expect(result.costBasisBreakEvenAtExpiration).toBe(107);
+    expect(result.underlyingMovePctToMarkBreakEven).toBe(5);
+    expect(result.thetaUsdPerDay).toBe(-20);
+    expect(result.thetaPctOfPremiumPerDay).toBe(-0.2);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("keeps put direction signed while exposing absolute leverage", () => {
+    const result = computeOptionExposureAnalytics({
+      type: "put",
+      strike: 110,
+      spot: 100,
+      optionPrice: 15,
+      delta: -0.6,
+    });
+
+    expect(result.intrinsicValuePerShare).toBe(10);
+    expect(result.extrinsicValuePerShare).toBe(5);
+    expect(result.deltaDollars).toBe(-6_000);
+    expect(result.elasticity).toBe(-4);
+    expect(result.absoluteElasticity).toBe(4);
+    expect(result.markBreakEvenAtExpiration).toBe(95);
+    expect(result.underlyingMovePctToMarkBreakEven).toBe(-5);
+  });
+
+  it("returns explicit not-evaluated warnings instead of fake leverage on stale inputs", () => {
+    const result = computeOptionExposureAnalytics({
+      type: "call",
+      strike: 100,
+      spot: 0,
+      optionPrice: 0,
+      delta: Number.NaN,
+    });
+
+    expect(Number.isNaN(result.deltaDollars)).toBe(true);
+    expect(Number.isNaN(result.elasticity)).toBe(true);
+    expect(result.warnings).toContain("spot_unavailable");
+    expect(result.warnings).toContain("option_price_unavailable");
+    expect(result.warnings).toContain("delta_unavailable");
+  });
+});
 
 // ── Options Contract Historicals ──
 // Test the shared engine behind `options history` CLI + `robinhood_options_history` MCP.
@@ -369,6 +440,15 @@ describe("computeOptionsSnapshot", () => {
       volume: 50,
       openInterest: 200,
       moneyness: "ITM",
+      exposureAnalytics: expect.objectContaining({
+        intrinsicValuePerShare: 1,
+        extrinsicValuePerShare: 4.1,
+        positionValueUsd: 510,
+        deltaShares: 52,
+        deltaDollars: 5252,
+        elasticity: expect.closeTo(10.298039, 5),
+        markBreakEvenAtExpiration: 105.1,
+      }),
     });
   });
 

--- a/docs/options-exposure-analytics.md
+++ b/docs/options-exposure-analytics.md
@@ -1,0 +1,54 @@
+# Option exposure analytics
+
+`options positions`, `options snapshot`, `robinhood_options_holdings`, and `robinhood_options_inspect` expose the same local first-order diagnostics for each contract. They are live-read analytics, not forecasts or order recommendations.
+
+## Fields and formulas
+
+Let:
+
+- `S` = underlying spot
+- `K` = strike
+- `P` = current option mark per share
+- `Δ` = option delta
+- `Θ` = option theta per share per day
+- `N` = contracts
+- multiplier = 100 shares per standard equity-option contract
+
+| Field | Formula | Meaning |
+|---|---|---|
+| `intrinsicValuePerShare` | call: `max(S-K, 0)`; put: `max(K-S, 0)` | Exercise value now |
+| `extrinsicValuePerShare` | `P - intrinsic` | Time + volatility + rate value still embedded in the mark |
+| `intrinsicPctOfPremium` | `intrinsic / P` | How share-like the current premium is |
+| `extrinsicPctOfPremium` | `extrinsic / P` | How much of the mark can decay to zero even without an adverse intrinsic move |
+| `positionValueUsd` | `P × 100 × N` | Current marked premium value |
+| `deltaShares` | `Δ × 100 × N` | Share-equivalent local directional exposure |
+| `deltaDollars` | `Δ × 100 × N × S` | Dollar-equivalent local directional exposure |
+| `elasticity` | `deltaDollars / abs(positionValueUsd)` | Approximate option % move for a 1% underlying move, locally |
+| `absoluteElasticity` | `abs(elasticity)` | Direction-agnostic local effective leverage |
+| `premiumPerDeltaDollar` | `abs(positionValueUsd) / abs(deltaDollars)` | Premium capital tied up per $1 of local delta exposure |
+| `markBreakEvenAtExpiration` | call: `K+P`; put: `K-P` | Expiration break-even if entering at the current mark |
+| `costBasisBreakEvenAtExpiration` | call: `K+entry premium`; put: `K-entry premium` | Expiration break-even from the actual average opening premium, when available |
+| `thetaUsdPerDay` | `Θ × 100 × N` | Model-implied one-day theta change if other inputs stay fixed |
+| `thetaPctOfPremiumPerDay` | `thetaUsdPerDay / abs(positionValueUsd)` | Theta burn relative to remaining marked premium |
+
+## The important distinction
+
+**Elasticity is local sensitivity, not guaranteed leverage.** An elasticity of `12x` means the current delta implies roughly a 12% option-price move for a 1% underlying move *at this instant*, if delta, IV, time, rates, and spreads do not change. OTM options can show enormous elasticity because their premium denominator is tiny while their absolute `deltaDollars` remains small. Gamma changes delta; IV can overwhelm the delta move; theta keeps running; wide or stale marks can make every ratio misleading.
+
+For deep-ITM calls, intrinsic value dominates, delta approaches `1`, and elasticity usually falls toward `S / option price`. That is why a deep-ITM call can behave more linearly and share-like while still giving modest capital leverage. Rolling up and out typically sells some accumulated intrinsic/delta and buys more extrinsic/time: it can restore convexity, but it also raises break-even and reintroduces decay.
+
+## Read order
+
+1. **Quote quality:** bid, ask, spread, update timestamp, volume/open interest.
+2. **Absolute exposure:** `deltaShares` and `deltaDollars`.
+3. **Premium composition:** intrinsic vs extrinsic dollars and percentages.
+4. **Local leverage:** elasticity and premium-per-delta-dollar.
+5. **Time risk:** theta dollars/day, theta %/day, and days to expiration.
+6. **Expiration hurdle:** current-mark and cost-basis break-evens.
+7. **Then** gamma, IV/vega, event risk, and the full payoff.
+
+Never rank contracts by elasticity alone. A nearly worthless OTM contract can have spectacular elasticity and almost no useful probability-weighted exposure.
+
+## Data-quality behavior
+
+Missing/nonpositive spot, mark, or delta produces `NaN` fields plus explicit warnings such as `spot_unavailable`, `option_price_unavailable`, and `delta_unavailable`. A materially negative extrinsic value raises `negative_extrinsic_quote_violation`, which usually means stale or crossed inputs rather than free money.

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1840,9 +1840,9 @@ server.registerTool(
     );
     const quotes = await fetchQuotes([...new Set([...equityIds.values()].filter(Boolean))]);
     const holdings = all.map((row) => {
-      const meta: any = metadata.get(row.optionInstrumentId) ?? {};
-      const mark: any = marks.get(row.optionInstrumentId) ?? {};
-      const quote: any = quotes.get(equityIds.get(row.symbol) ?? "") ?? {};
+      const meta = metadata.get(row.optionInstrumentId) ?? {};
+      const mark = marks.get(row.optionInstrumentId) ?? {};
+      const quote = quotes.get(equityIds.get(row.symbol) ?? "") ?? {};
       const optionPrice = finiteNumber(mark.adjusted_mark_price ?? mark.mark_price);
       const spot = finiteNumber(
         quote.last_extended_hours_trade_price ?? quote.last_trade_price,

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -52,6 +52,8 @@ import {
   loadOwnedAccounts,
   readAccountPulse,
   fetchOptionMarks,
+  fetchQuotes,
+  computeOptionExposureAnalytics,
   computePortfolioPnl,
   getUnifiedHistory,
   computeDividends,
@@ -1759,7 +1761,7 @@ server.registerTool(
   {
     title: "Robinhood Options Holdings",
     description:
-      "Every held option contract across accounts (or one), each with its option_instrument_id (UUID) + contract link, symbol, qty, average_open_price. The owned-contract map.",
+      "Every held option contract across accounts (or one), enriched with exact contract metadata, live mark/spot, intrinsic and extrinsic value, delta shares, delta dollars, option elasticity (local effective leverage), premium per delta-dollar, expiration break-evens, and theta burn. The owned-contract map; read only.",
     inputSchema: z.object({ account_number: accountNumberOptionalSchema }),
     annotations: toolAnnotations(true, "read"),
   },
@@ -1801,7 +1803,71 @@ server.registerTool(
         });
       }
     }
-    return jsonResponse({ count: all.length, holdings: all });
+    const ids = [...new Set(all.map((row) => row.optionInstrumentId).filter(Boolean))];
+    const marks = await fetchOptionMarks(ids);
+    const metadata = new Map(
+      await Promise.all(
+        ids.map(async (id) => {
+          try {
+            return [
+              id,
+              await brokerageGetJson("https://api.robinhood.com/options/instruments/{0}/", {
+                "0": id,
+              }),
+            ] as const;
+          } catch {
+            return [id, {}] as const;
+          }
+        }),
+      ),
+    );
+    const symbols = [...new Set(all.map((row) => String(row.symbol ?? "")).filter(Boolean))];
+    const equityIds = new Map(
+      await Promise.all(
+        symbols.map(async (symbol) => {
+          try {
+            const instrument = (
+              await brokerageGetJson("https://api.robinhood.com/instruments/?symbol={symbol}", {
+                symbol,
+              })
+            ).results?.[0];
+            return [symbol, String(instrument?.id ?? "")] as const;
+          } catch {
+            return [symbol, ""] as const;
+          }
+        }),
+      ),
+    );
+    const quotes = await fetchQuotes([...new Set([...equityIds.values()].filter(Boolean))]);
+    const holdings = all.map((row) => {
+      const meta: any = metadata.get(row.optionInstrumentId) ?? {};
+      const mark: any = marks.get(row.optionInstrumentId) ?? {};
+      const quote: any = quotes.get(equityIds.get(row.symbol) ?? "") ?? {};
+      const optionPrice = finiteNumber(mark.adjusted_mark_price ?? mark.mark_price);
+      const spot = finiteNumber(
+        quote.last_extended_hours_trade_price ?? quote.last_trade_price,
+      );
+      return {
+        ...row,
+        strike: finiteNumber(meta.strike_price),
+        type: meta.type === "put" ? "put" : "call",
+        expiration: String(meta.expiration_date ?? ""),
+        spot,
+        mark: optionPrice,
+        delta: finiteNumber(mark.delta),
+        exposureAnalytics: computeOptionExposureAnalytics({
+          type: meta.type === "put" ? "put" : "call",
+          strike: finiteNumber(meta.strike_price),
+          spot,
+          optionPrice,
+          entryPremiumPerShare: finiteNumber(row.averageOpenPrice) / 100,
+          delta: finiteNumber(mark.delta),
+          theta: finiteNumber(mark.theta),
+          contracts: finiteNumber(row.quantity),
+        }),
+      };
+    });
+    return jsonResponse({ count: holdings.length, holdings });
   },
 );
 
@@ -1810,7 +1876,7 @@ server.registerTool(
   {
     title: "Robinhood Option Inspect",
     description:
-      "Full detail for ONE owned/known option contract by its UUID: metadata, live Greeks/quote, and fill history (side/effect/qty/price/date). Tolerates the web _L1 leg suffix. Read.",
+      "Full detail for ONE owned/known option contract by its UUID: metadata, live Greeks/quote, intrinsic/extrinsic value, delta dollars, option elasticity, break-even and theta analytics, plus fill history. Tolerates the web _L1 leg suffix. Read.",
     inputSchema: z.object({
       option_instrument_id: z
         .string()
@@ -1832,6 +1898,19 @@ server.registerTool(
           ids: id,
         })
       ).results?.[0] ?? {};
+    const equityInstrument = (
+      await brokerageGetJson("https://api.robinhood.com/instruments/?symbol={symbol}", {
+        symbol: String(meta.chain_symbol ?? ""),
+      })
+    ).results?.[0];
+    const equityQuotes = equityInstrument?.id
+      ? await fetchQuotes([String(equityInstrument.id)])
+      : new Map();
+    const equityQuote = equityQuotes.get(String(equityInstrument?.id ?? "")) ?? {};
+    const spot = finiteNumber(
+      equityQuote.last_extended_hours_trade_price ?? equityQuote.last_trade_price,
+    );
+    const optionPrice = finiteNumber(mark.adjusted_mark_price ?? mark.mark_price);
     const fills: any[] = [];
     if (meta.chain_id) {
       const orders =
@@ -1878,6 +1957,15 @@ server.registerTool(
         vega: n(mark.vega),
         rho: n(mark.rho),
       },
+      spot,
+      exposureAnalytics: computeOptionExposureAnalytics({
+        type: meta.type === "put" ? "put" : "call",
+        strike: finiteNumber(meta.strike_price),
+        spot,
+        optionPrice,
+        delta: finiteNumber(mark.delta),
+        theta: finiteNumber(mark.theta),
+      }),
       openInterest: n(mark.open_interest),
       volume: n(mark.volume),
       fills,
@@ -2407,7 +2495,7 @@ server.registerTool(
   {
     title: "Robinhood Options Research Snapshot",
     description:
-      "Research-grade bulk option-chain dataset across one expiration or a bounded all-expiration range. Returns every active contract with bid/ask/mark/mid/last/previous close/spread, delta/gamma/theta/vega/rho, IV, volume, open interest, moneyness, UUID and deep link, plus put/call liquidity ratios and concentration leaders. Shared engine with CLI `options snapshot`; live read only.",
+      "Research-grade bulk option-chain dataset across one expiration or a bounded all-expiration range. Returns every active contract with bid/ask/mark/mid/last/previous close/spread, delta/gamma/theta/vega/rho, IV, volume, open interest, moneyness, UUID and deep link, plus intrinsic/extrinsic value, delta dollars, local option elasticity, premium-per-delta-dollar, break-even and theta analytics. Includes put/call liquidity ratios and concentration leaders. Shared engine with CLI `options snapshot`; live read only.",
     inputSchema: z.object({
       symbol: symbolSchema,
       expiration: z.union([dateSchema, z.literal("all")]).optional(),

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1844,9 +1844,7 @@ server.registerTool(
       const mark = marks.get(row.optionInstrumentId) ?? {};
       const quote = quotes.get(equityIds.get(row.symbol) ?? "") ?? {};
       const optionPrice = finiteNumber(mark.adjusted_mark_price ?? mark.mark_price);
-      const spot = finiteNumber(
-        quote.last_extended_hours_trade_price ?? quote.last_trade_price,
-      );
+      const spot = finiteNumber(quote.last_extended_hours_trade_price ?? quote.last_trade_price);
       return {
         ...row,
         strike: finiteNumber(meta.strike_price),

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "type": "module",
   "author": "Zayd Khan // cold (www.zayd.wtf)",
   "packageManager": "pnpm@10.12.1",
+  "pnpm": {
+    "overrides": {
+      "nanoid@<3.3.18": "3.3.18"
+    }
+  },
   "scripts": {
     "build": "corepack pnpm --filter @zaydiscold/robinhood-cli build && corepack pnpm --filter @zaydiscold/robinhood-cli-mcp build",
     "sanitize:cdp": "node scripts/sanitize-cdp-capture.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,16 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  esbuild: 0.28.1
-  vite: 8.1.4
-  hono: 4.12.34
-  '@hono/node-server': 2.0.10
-  postcss: 8.5.23
-  body-parser: 2.3.0
-  fast-uri: 3.1.5
-  ip-address: 10.3.1
-  brace-expansion: 5.0.9
-  nanoid: 3.3.17
+  nanoid@<3.3.18: 3.3.18
 
 importers:
 
@@ -297,11 +288,11 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@2.0.10':
-    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
-    engines: {node: '>=20'}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -769,7 +760,7 @@ packages:
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 8.1.4
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1325,8 +1316,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1600,7 +1591,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.3.0
-      esbuild: 0.28.1
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -1652,7 +1643,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: 8.1.4
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1867,7 +1858,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@2.0.10(hono@4.12.34)':
+  '@hono/node-server@1.19.17(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
 
@@ -1898,7 +1889,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.12.34)
+      '@hono/node-server': 1.19.17(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2840,7 +2831,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -2944,7 +2935,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary
- add shared intrinsic/extrinsic, delta-share, delta-dollar, elasticity, premium-per-delta-dollar, break-even, and theta diagnostics
- expose analytics in CLI positions and MCP holdings/inspect/snapshot reads
- document formulas, interpretation order, and stale-data warnings

## Verification
- `pnpm test` — 505 tests passed, 2 skipped
- live CLI smoke — 22/22 held contracts returned finite analytics
- live MCP smoke after restart — holdings returned the new `exposureAnalytics` object

- delilah 🌸