### PR TITLE
fix(options): preserve unavailable diagnostics

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -118,6 +118,7 @@ import {
   fetchRecurringSchedules,
   setRecurringState,
   finiteNumber,
+  optionPositionSide,
   optionMoney,
   repositoryRoot,
   appendPortfolioSnapshot,
@@ -1736,6 +1737,7 @@ interface OpenOptionPosition {
   name: string;
   averageOpenPrice: number;
   quantity: number;
+  positionSide?: "long" | "short";
   optionId: string;
   accountNumber: string;
 }
@@ -1782,6 +1784,7 @@ async function loadOpenOptionPositions(): Promise<OpenOptionPosition[]> {
       name: `${position.symbol} ${detail}`,
       averageOpenPrice: num(position.average_open_price),
       quantity,
+      positionSide: optionPositionSide(position),
       optionId,
       accountNumber: String(position.account_number ?? ""),
     });
@@ -2138,6 +2141,7 @@ options
           volume: finiteNumber(m.volume),
           daysToExpiration: calendarDaysUntil(String(meta.expiration_date ?? "")),
           contracts: position.quantity,
+          positionSide: position.positionSide,
         });
         return {
           contract: position.name,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -8484,9 +8484,19 @@ export function calendarDaysUntil(expiration: string, asOf: string | Date = new 
   if (!/^\d{4}-\d{2}-\d{2}$/.test(asOfDate)) return Number.NaN;
   const toUtc = (value: string) => {
     const [year, month, day] = value.split("-").map(Number);
-    return Date.UTC(year, month - 1, day);
+    const timestamp = Date.UTC(year, month - 1, day);
+    const parsed = new Date(timestamp);
+    return parsed.getUTCFullYear() === year &&
+      parsed.getUTCMonth() === month - 1 &&
+      parsed.getUTCDate() === day
+      ? timestamp
+      : Number.NaN;
   };
-  return Math.round((toUtc(expiration) - toUtc(asOfDate)) / 86_400_000);
+  const expirationUtc = toUtc(expiration);
+  const asOfUtc = toUtc(asOfDate);
+  return Number.isFinite(expirationUtc) && Number.isFinite(asOfUtc)
+    ? Math.round((expirationUtc - asOfUtc) / 86_400_000)
+    : Number.NaN;
 }
 
 export interface OptionExposureAnalyticsInput {
@@ -8607,24 +8617,24 @@ export function computeOptionExposureAnalytics(
         ? input.strike + entryPremium
         : input.strike - entryPremium
       : Number.NaN;
-  const theta = Number(input.theta);
+  const theta = finiteNumber(input.theta);
   const thetaUsdPerDay = Number.isFinite(theta) ? theta * 100 * contracts * sign : Number.NaN;
   const thetaPctOfPremiumPerDay =
     absolutePositionValue > 0 && Number.isFinite(thetaUsdPerDay)
       ? (thetaUsdPerDay / absolutePositionValue) * 100
       : Number.NaN;
-  const gamma = Number(input.gamma);
-  const vega = Number(input.vega);
-  const impliedVolatility = Number(input.impliedVolatility);
-  const bid = Number(input.bid);
-  const ask = Number(input.ask);
+  const gamma = finiteNumber(input.gamma);
+  const vega = finiteNumber(input.vega);
+  const impliedVolatility = finiteNumber(input.impliedVolatility);
+  const bid = finiteNumber(input.bid);
+  const ask = finiteNumber(input.ask);
   const validBidAsk = Number.isFinite(bid) && bid >= 0 && Number.isFinite(ask) && ask >= bid;
   const spreadUsd = validBidAsk ? ask - bid : Number.NaN;
   const spreadPctOfMark =
     validBidAsk && validPrice ? (spreadUsd / input.optionPrice) * 100 : Number.NaN;
-  const openInterest = Number(input.openInterest);
-  const volume = Number(input.volume);
-  const daysToExpiration = Number(input.daysToExpiration);
+  const openInterest = finiteNumber(input.openInterest);
+  const volume = finiteNumber(input.volume);
+  const daysToExpiration = finiteNumber(input.daysToExpiration);
   const underlyingMovePctToMarkBreakEven =
     validSpot && Number.isFinite(markBreakEven)
       ? ((markBreakEven - input.spot) / input.spot) * 100
@@ -8655,6 +8665,8 @@ export function computeOptionExposureAnalytics(
     } else if (thetaPctOfPremiumPerDay <= -1) {
       diagnostics.unfavorable.push("high_theta_burn");
     }
+  } else {
+    diagnostics.notEvaluated.push("theta_unavailable");
   }
   if (Number.isFinite(elasticity) && Math.abs(elasticity) >= 3) {
     diagnostics.favorable.push("high_local_elasticity");
@@ -8824,8 +8836,26 @@ function finitePrice(value: number | string | null | undefined): number {
 }
 
 export function finiteNumber(value: unknown): number {
+  if (value == null) return Number.NaN;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+/** Determine an aggregate option position's side without guessing from its option type. */
+export function optionPositionSide(position: unknown): "long" | "short" | undefined {
+  const candidate =
+    position && typeof position === "object"
+      ? (position as { legs?: unknown; strategy?: unknown })
+      : {};
+  const firstLeg = Array.isArray(candidate.legs)
+    ? (candidate.legs[0] as { position_type?: unknown } | undefined)
+    : undefined;
+  const legSide = String(firstLeg?.position_type ?? "").toLowerCase();
+  if (legSide === "long" || legSide === "short") return legSide;
+  const strategy = String(candidate.strategy ?? "").toLowerCase();
+  if (strategy.startsWith("long")) return "long";
+  if (strategy.startsWith("short")) return "short";
+  return undefined;
 }
 
 export function quoteLast(quote: any): number {

--- a/cli/test/options-intelligence.test.ts
+++ b/cli/test/options-intelligence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   computeOptionExposureAnalytics,
+  optionPositionSide,
   calendarDaysUntil,
   computeOptionsHistory,
   computeChainStats,
@@ -11,6 +12,7 @@ describe("computeOptionExposureAnalytics", () => {
   it("computes calendar days to expiration from a deterministic as-of", () => {
     expect(calendarDaysUntil("2026-08-20", "2026-08-15T20:00:00-07:00")).toBe(5);
     expect(calendarDaysUntil("2026-08-14", "2026-08-15T20:00:00-07:00")).toBe(-1);
+    expect(Number.isNaN(calendarDaysUntil("2026-02-31", "2026-02-15T20:00:00-08:00"))).toBe(true);
     expect(Number.isNaN(calendarDaysUntil("", "2026-08-15T20:00:00-07:00"))).toBe(true);
   });
 
@@ -127,6 +129,85 @@ describe("computeOptionExposureAnalytics", () => {
     expect(result.warnings).toContain("spot_unavailable");
     expect(result.warnings).toContain("option_price_unavailable");
     expect(result.warnings).toContain("delta_unavailable");
+  });
+
+  it("keeps null market-data fields unavailable instead of classifying them as zero", () => {
+    const result = computeOptionExposureAnalytics({
+      type: "call",
+      strike: 100,
+      spot: 100,
+      optionPrice: 2,
+      delta: 0.5,
+      gamma: null as unknown as number,
+      theta: null as unknown as number,
+      vega: null as unknown as number,
+      impliedVolatility: null as unknown as number,
+      bid: null as unknown as number,
+      ask: null as unknown as number,
+      openInterest: null as unknown as number,
+      volume: null as unknown as number,
+      daysToExpiration: null as unknown as number,
+    });
+
+    for (const value of [
+      result.gamma,
+      result.vega,
+      result.impliedVolatility,
+      result.bid,
+      result.ask,
+      result.openInterest,
+      result.volume,
+      result.daysToExpiration,
+      result.thetaUsdPerDay,
+    ]) {
+      expect(Number.isNaN(value)).toBe(true);
+    }
+    expect(result.diagnostics.notEvaluated).toEqual(
+      expect.arrayContaining([
+        "days_to_expiration_unavailable",
+        "theta_unavailable",
+        "bid_ask_spread_unavailable",
+        "implied_volatility_unavailable",
+        "gamma_unavailable",
+        "vega_unavailable",
+        "open_interest_unavailable",
+        "volume_unavailable",
+      ]),
+    );
+    expect(result.diagnostics.unfavorable).not.toEqual(
+      expect.arrayContaining([
+        "near_expiration",
+        "low_open_interest",
+        "low_volume",
+        "low_theta_burn",
+      ]),
+    );
+  });
+
+  it("signs short holdings' value, delta dollars, and theta opposite a long holding", () => {
+    const result = computeOptionExposureAnalytics({
+      type: "call",
+      strike: 100,
+      spot: 110,
+      optionPrice: 12,
+      delta: 0.6,
+      theta: -0.1,
+      contracts: 2,
+      positionSide: "short",
+    });
+
+    expect(result.positionValueUsd).toBe(-2_400);
+    expect(result.deltaDollars).toBe(-13_200);
+    expect(result.thetaUsdPerDay).toBe(20);
+  });
+
+  it("derives holding side from the aggregate-position leg before strategy fallback", () => {
+    expect(optionPositionSide({ legs: [{ position_type: "short" }], strategy: "long_call" })).toBe(
+      "short",
+    );
+    expect(optionPositionSide({ legs: [{}], strategy: "long_call" })).toBe("long");
+    expect(optionPositionSide({ legs: [{}], strategy: "short_put" })).toBe("short");
+    expect(optionPositionSide({ legs: [{}], strategy: "straddle" })).toBeUndefined();
   });
 });
 

--- a/docs/options-exposure-analytics.md
+++ b/docs/options-exposure-analytics.md
@@ -57,7 +57,7 @@ Current deterministic flags:
 
 - favorable: intrinsic backing present; delta at least `0.70`; absolute theta burn at most `0.5%` of premium/day; or local elasticity at least `3x`
 - unfavorable: no intrinsic backing; delta below `0.35`; theta burn at least `1%` of premium/day; expiration break-even move at least `10%`; expired contract or 14 calendar days or fewer; spread at least `10%` of mark; open interest below `100`; volume below `10`; or high elasticity paired with at least `75%` extrinsic premium
-- not evaluated: each missing DTE, spread, IV, gamma, vega, open-interest, or volume input is named explicitly instead of silently disappearing
+- not evaluated: each missing DTE, theta, spread, IV, gamma, vega, open-interest, or volume input is named explicitly instead of silently disappearing
 
 These thresholds are screeners, not trade rules. The raw values remain in the same payload so operators can audit why each flag fired.
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -97,6 +97,7 @@ import {
   selectNearStrikes,
   classifyMoneyness,
   finiteNumber,
+  optionPositionSide,
   quoteLast,
   optionMoney,
   buildOptionsStrategyPricingSummary,
@@ -1757,6 +1758,37 @@ server.registerTool(
   },
 );
 
+async function ownedOptionPositionSide(optionId: string): Promise<"long" | "short" | undefined> {
+  try {
+    const owned = await loadOwnedAccounts();
+    if (!owned) return undefined;
+    const positionsByAccount = await Promise.all(
+      [...owned.numbers].map(async (accountNumber) =>
+        brokerageGetJson(
+          "https://api.robinhood.com/options/aggregate_positions/?account_numbers=",
+          {},
+          { account_numbers: accountNumber, nonzero: "true" },
+        ),
+      ),
+    );
+    const sides = new Set<"long" | "short">();
+    for (const response of positionsByAccount) {
+      for (const position of response?.results ?? []) {
+        const hasOption = (position?.legs ?? []).some((leg: unknown) => {
+          const optionIdFromLeg =
+            leg && typeof leg === "object" ? (leg as { option_id?: unknown }).option_id : undefined;
+          return String(optionIdFromLeg ?? "") === optionId;
+        });
+        const side = hasOption ? optionPositionSide(position) : undefined;
+        if (side) sides.add(side);
+      }
+    }
+    return sides.size === 1 ? [...sides][0] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 server.registerTool(
   "robinhood_options_holdings",
   {
@@ -1798,6 +1830,7 @@ server.registerTool(
           symbol: p.symbol,
           optionInstrumentId: oid,
           quantity: n(p.quantity),
+          positionSide: optionPositionSide(p),
           averageOpenPrice: n(p.average_open_price),
           strategy: p.strategy,
           link: `https://robinhood.com/options/${oid}?account_number=${acct}`,
@@ -1871,6 +1904,7 @@ server.registerTool(
           volume: finiteNumber(mark.volume),
           daysToExpiration: calendarDaysUntil(String(meta.expiration_date ?? "")),
           contracts: finiteNumber(row.quantity),
+          positionSide: row.positionSide,
         }),
       };
     });
@@ -1918,6 +1952,7 @@ server.registerTool(
       equityQuote.last_extended_hours_trade_price ?? equityQuote.last_trade_price,
     );
     const optionPrice = finiteNumber(mark.adjusted_mark_price ?? mark.mark_price);
+    const positionSide = await ownedOptionPositionSide(id);
     const fills: any[] = [];
     if (meta.chain_id) {
       const orders =
@@ -1980,6 +2015,7 @@ server.registerTool(
         openInterest: finiteNumber(mark.open_interest),
         volume: finiteNumber(mark.volume),
         daysToExpiration: calendarDaysUntil(String(meta.expiration_date ?? "")),
+        positionSide,
       }),
       openInterest: n(mark.open_interest),
       volume: n(mark.volume),


### PR DESCRIPTION
## Summary
- preserve null/missing quote fields as unavailable instead of coercing them to zero
- wire long/short position side through CLI positions, MCP holdings, and MCP inspect
- reject impossible calendar dates and use host-local calendar dates for live DTE
- emit explicit `theta_unavailable` diagnostics

## Regression coverage
- null IV/Greeks/liquidity/DTE no longer generate false zero-based flags
- short holdings sign position value, delta dollars, and theta correctly
- aggregate-position side derivation
- impossible calendar dates return not-evaluated

## Verification
- `pnpm test` — 494 CLI tests + 16 MCP tests passed (2 MCP skips)
- `pnpm quality` — all gates passed
- `pnpm typecheck` — passed

- delilah 🌸