### PR TITLE
feat(options): add quality-adjusted leverage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,8 @@ Two read-only convenience commands that join the raw options routes (`aggregate_
 ```bash
 # Every open option position across ALL owned accounts, ranked in DOLLARS:
 # per-contract value, unrealized/day $ P&L, delta shares/$, intrinsic/extrinsic,
-# local option elasticity and expiration break-even — with totals.
+# local option elasticity, extrinsic cost per delta-dollar, implied-move hurdle,
+# gamma/theta convexity rent, and expiration break-even — with totals.
 robinhood-cli options positions
 robinhood-cli options positions --json
 
@@ -400,7 +401,7 @@ TOTAL: value $18825.00 | unrealized $17335.00 | day $375.00
 Best performer: DRAM $50 Call 6/18 at +1334.6%.
 ```
 
-Both are pure reads (no write gate). `--json` emits structured rows for piping into a spreadsheet or an agent. The same `exposureAnalytics` object is included by MCP `robinhood_options_holdings`, `robinhood_options_inspect`, and `robinhood_options_snapshot`. See [`docs/options-exposure-analytics.md`](./docs/options-exposure-analytics.md) for formulas, the intrinsic/extrinsic read order, delta-dollar interpretation, and why a giant OTM elasticity number is not guaranteed leverage.
+Both are pure reads (no write gate). `--json` emits structured rows for piping into a spreadsheet or an agent. The same `exposureAnalytics` object is included by MCP `robinhood_options_holdings`, `robinhood_options_inspect`, and `robinhood_options_snapshot`. See [`docs/options-exposure-analytics.md`](./docs/options-exposure-analytics.md) for formulas, the intrinsic/extrinsic read order, delta-dollar interpretation, roll audit, expected-move hurdle, convexity rent, and why a giant OTM elasticity number is not guaranteed leverage.
 
 ### 6.1 Options strategy planners — Greeks, spreads, quotes, and dry-run bodies
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2187,6 +2187,9 @@ options
         elasticity: Number.isFinite(row.exposureAnalytics.elasticity)
           ? `${row.exposureAnalytics.elasticity.toFixed(2)}x`
           : "—",
+        extrinsic_per_delta: Number.isFinite(row.exposureAnalytics.extrinsicPerDeltaDollar)
+          ? row.exposureAnalytics.extrinsicPerDeltaDollar.toFixed(3)
+          : "—",
         intrinsic: usd(row.exposureAnalytics.intrinsicValueUsd),
         extrinsic: usd(row.exposureAnalytics.extrinsicValueUsd),
         dte: Number.isFinite(row.exposureAnalytics.daysToExpiration)
@@ -2214,6 +2217,16 @@ options
         break_even_move: Number.isFinite(row.exposureAnalytics.underlyingMovePctToMarkBreakEven)
           ? pct(row.exposureAnalytics.underlyingMovePctToMarkBreakEven)
           : "—",
+        expected_move: Number.isFinite(row.exposureAnalytics.expectedMovePctToExpiration)
+          ? pct(row.exposureAnalytics.expectedMovePctToExpiration)
+          : "—",
+        be_vs_expected: Number.isFinite(row.exposureAnalytics.breakEvenToExpectedMoveRatio)
+          ? `${row.exposureAnalytics.breakEvenToExpectedMoveRatio.toFixed(2)}x`
+          : "—",
+        gamma_1pct_usd: usd(row.exposureAnalytics.gammaPnlForOnePctMoveUsd),
+        gamma_theta: Number.isFinite(row.exposureAnalytics.gammaToThetaOnePctMoveRatio)
+          ? `${row.exposureAnalytics.gammaToThetaOnePctMoveRatio.toFixed(2)}x`
+          : "—",
         favorable: row.exposureAnalytics.diagnostics.favorable.join(",") || "—",
         unfavorable: row.exposureAnalytics.diagnostics.unfavorable.join(",") || "—",
         not_evaluated: row.exposureAnalytics.diagnostics.notEvaluated.join(",") || "—",
@@ -2232,6 +2245,7 @@ options
         "delta",
         "delta_usd",
         "elasticity",
+        "extrinsic_per_delta",
         "intrinsic",
         "extrinsic",
         "dte",
@@ -2243,6 +2257,10 @@ options
         "volume",
         "theta_pct_day",
         "break_even_move",
+        "expected_move",
+        "be_vs_expected",
+        "gamma_1pct_usd",
+        "gamma_theta",
         "favorable",
         "unfavorable",
         "not_evaluated",

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -8538,11 +8538,16 @@ export interface OptionExposureAnalytics {
   elasticity: number;
   absoluteElasticity: number;
   premiumPerDeltaDollar: number;
+  extrinsicPerDeltaDollar: number;
   markBreakEvenAtExpiration: number;
   costBasisBreakEvenAtExpiration: number;
   underlyingMovePctToMarkBreakEven: number;
+  expectedMovePctToExpiration: number;
+  breakEvenToExpectedMoveRatio: number;
   thetaUsdPerDay: number;
   thetaPctOfPremiumPerDay: number;
+  gammaPnlForOnePctMoveUsd: number;
+  gammaToThetaOnePctMoveRatio: number;
   gamma: number;
   vega: number;
   impliedVolatility: number;
@@ -8639,6 +8644,29 @@ export function computeOptionExposureAnalytics(
     validSpot && Number.isFinite(markBreakEven)
       ? ((markBreakEven - input.spot) / input.spot) * 100
       : Number.NaN;
+  const expectedMovePctToExpiration =
+    Number.isFinite(impliedVolatility) &&
+    impliedVolatility >= 0 &&
+    Number.isFinite(daysToExpiration) &&
+    daysToExpiration >= 0
+      ? impliedVolatility * Math.sqrt(daysToExpiration / 365) * 100
+      : Number.NaN;
+  const breakEvenToExpectedMoveRatio =
+    Number.isFinite(expectedMovePctToExpiration) &&
+    expectedMovePctToExpiration > 0 &&
+    Number.isFinite(underlyingMovePctToMarkBreakEven)
+      ? Math.abs(underlyingMovePctToMarkBreakEven) / expectedMovePctToExpiration
+      : Number.NaN;
+  const gammaPnlForOnePctMoveUsd =
+    Number.isFinite(gamma) && validSpot
+      ? 0.5 * gamma * Math.pow(input.spot * 0.01, 2) * 100 * contracts * sign
+      : Number.NaN;
+  const gammaToThetaOnePctMoveRatio =
+    Number.isFinite(gammaPnlForOnePctMoveUsd) &&
+    Number.isFinite(thetaUsdPerDay) &&
+    Math.abs(thetaUsdPerDay) > 0
+      ? Math.abs(gammaPnlForOnePctMoveUsd) / Math.abs(thetaUsdPerDay)
+      : Number.NaN;
 
   const diagnostics: OptionExposureDiagnostics = {
     favorable: [],
@@ -8732,11 +8760,20 @@ export function computeOptionExposureAnalytics(
         ? absolutePositionValue / Math.abs(deltaDollars)
         : Number.NaN,
     ),
+    extrinsicPerDeltaDollar: round(
+      Number.isFinite(extrinsic) && Number.isFinite(deltaDollars) && Math.abs(deltaDollars) > 0
+        ? Math.abs(extrinsic * 100 * contracts) / Math.abs(deltaDollars)
+        : Number.NaN,
+    ),
     markBreakEvenAtExpiration: round(markBreakEven),
     costBasisBreakEvenAtExpiration: round(costBasisBreakEven),
     underlyingMovePctToMarkBreakEven: round(underlyingMovePctToMarkBreakEven),
+    expectedMovePctToExpiration: round(expectedMovePctToExpiration),
+    breakEvenToExpectedMoveRatio: round(breakEvenToExpectedMoveRatio),
     thetaUsdPerDay: round(thetaUsdPerDay),
     thetaPctOfPremiumPerDay: round(thetaPctOfPremiumPerDay),
+    gammaPnlForOnePctMoveUsd: round(gammaPnlForOnePctMoveUsd),
+    gammaToThetaOnePctMoveRatio: round(gammaToThetaOnePctMoveRatio),
     gamma: round(gamma),
     vega: round(vega),
     impliedVolatility: round(impliedVolatility),

--- a/cli/test/options-intelligence.test.ts
+++ b/cli/test/options-intelligence.test.ts
@@ -24,7 +24,10 @@ describe("computeOptionExposureAnalytics", () => {
       optionPrice: 50,
       entryPremiumPerShare: 52,
       delta: 0.8,
+      gamma: 0.01,
       theta: -0.1,
+      impliedVolatility: 0.4,
+      daysToExpiration: 365,
       contracts: 2,
     });
 
@@ -38,19 +41,21 @@ describe("computeOptionExposureAnalytics", () => {
     expect(result.elasticity).toBe(1.6);
     expect(result.absoluteElasticity).toBe(1.6);
     expect(result.premiumPerDeltaDollar).toBe(0.625);
+    expect(result.extrinsicPerDeltaDollar).toBe(0.0625);
     expect(result.markBreakEvenAtExpiration).toBe(105);
     expect(result.costBasisBreakEvenAtExpiration).toBe(107);
     expect(result.underlyingMovePctToMarkBreakEven).toBe(5);
+    expect(result.expectedMovePctToExpiration).toBe(40);
+    expect(result.breakEvenToExpectedMoveRatio).toBe(0.125);
     expect(result.thetaUsdPerDay).toBe(-20);
     expect(result.thetaPctOfPremiumPerDay).toBe(-0.2);
+    expect(result.gammaPnlForOnePctMoveUsd).toBe(1);
+    expect(result.gammaToThetaOnePctMoveRatio).toBe(0.05);
     expect(result.diagnostics).toEqual({
       favorable: ["intrinsic_backing_present", "high_delta_response", "low_theta_burn"],
       unfavorable: [],
       notEvaluated: [
-        "days_to_expiration_unavailable",
         "bid_ask_spread_unavailable",
-        "implied_volatility_unavailable",
-        "gamma_unavailable",
         "vega_unavailable",
         "open_interest_unavailable",
         "volume_unavailable",
@@ -80,6 +85,11 @@ describe("computeOptionExposureAnalytics", () => {
 
     expect(result.elasticity).toBe(12.5);
     expect(result.extrinsicPctOfPremium).toBe(100);
+    expect(result.extrinsicPerDeltaDollar).toBe(0.08);
+    expect(result.expectedMovePctToExpiration).toBe(10.533703);
+    expect(result.breakEvenToExpectedMoveRatio).toBe(2.088534);
+    expect(result.gammaPnlForOnePctMoveUsd).toBe(1.5);
+    expect(result.gammaToThetaOnePctMoveRatio).toBe(0.1875);
     expect(result.spreadPctOfMark).toBe(30);
     expect(result.daysToExpiration).toBe(5);
     expect(result.diagnostics.favorable).toEqual(["high_local_elasticity"]);
@@ -159,6 +169,10 @@ describe("computeOptionExposureAnalytics", () => {
       result.volume,
       result.daysToExpiration,
       result.thetaUsdPerDay,
+      result.expectedMovePctToExpiration,
+      result.breakEvenToExpectedMoveRatio,
+      result.gammaPnlForOnePctMoveUsd,
+      result.gammaToThetaOnePctMoveRatio,
     ]) {
       expect(Number.isNaN(value)).toBe(true);
     }
@@ -184,13 +198,14 @@ describe("computeOptionExposureAnalytics", () => {
     );
   });
 
-  it("signs short holdings' value, delta dollars, and theta opposite a long holding", () => {
+  it("signs short holdings' value, delta dollars, theta, and gamma P&L opposite a long holding", () => {
     const result = computeOptionExposureAnalytics({
       type: "call",
       strike: 100,
       spot: 110,
       optionPrice: 12,
       delta: 0.6,
+      gamma: 0.02,
       theta: -0.1,
       contracts: 2,
       positionSide: "short",
@@ -199,6 +214,7 @@ describe("computeOptionExposureAnalytics", () => {
     expect(result.positionValueUsd).toBe(-2_400);
     expect(result.deltaDollars).toBe(-13_200);
     expect(result.thetaUsdPerDay).toBe(20);
+    expect(result.gammaPnlForOnePctMoveUsd).toBe(-2.42);
   });
 
   it("derives holding side from the aggregate-position leg before strategy fallback", () => {

--- a/docs/options-exposure-analytics.md
+++ b/docs/options-exposure-analytics.md
@@ -26,10 +26,15 @@ Let:
 | `elasticity`                     | `deltaDollars / abs(positionValueUsd)`          | Approximate option % move for a 1% underlying move, locally                   |
 | `absoluteElasticity`             | `abs(elasticity)`                               | Direction-agnostic local effective leverage                                   |
 | `premiumPerDeltaDollar`          | `abs(positionValueUsd) / abs(deltaDollars)`     | Premium capital tied up per $1 of local delta exposure                        |
+| `extrinsicPerDeltaDollar`        | `abs(extrinsicValueUsd) / abs(deltaDollars)`    | Decayable premium paid per $1 of local delta exposure                         |
 | `markBreakEvenAtExpiration`      | call: `K+P`; put: `K-P`                         | Expiration break-even if entering at the current mark                         |
 | `costBasisBreakEvenAtExpiration` | call: `K+entry premium`; put: `K-entry premium` | Expiration break-even from the actual average opening premium, when available |
+| `expectedMovePctToExpiration`    | `IV × sqrt(DTE/365) × 100`                      | One-standard-deviation magnitude approximation implied by current IV          |
+| `breakEvenToExpectedMoveRatio`   | `abs(break-even move %) / expected move %`      | Expiration hurdle expressed in current implied-move units                     |
 | `thetaUsdPerDay`                 | `Θ × 100 × N`                                   | Model-implied one-day theta change if other inputs stay fixed                 |
 | `thetaPctOfPremiumPerDay`        | `thetaUsdPerDay / abs(positionValueUsd)`        | Theta burn relative to remaining marked premium                               |
+| `gammaPnlForOnePctMoveUsd`       | `0.5 × Γ × (0.01S)^2 × 100 × N`                 | Gamma-only convexity contribution for a hypothetical 1% spot move             |
+| `gammaToThetaOnePctMoveRatio`    | `abs(gamma 1% P&L) / abs(theta/day)`            | One-percent-move convexity relative to one modeled day of theta                |
 
 ## The important distinction
 
@@ -37,17 +42,61 @@ Let:
 
 For deep-ITM calls, intrinsic value dominates, delta approaches `1`, and elasticity usually falls toward `S / option price`. That is why a deep-ITM call can behave more linearly and share-like while still giving modest capital leverage. Rolling up and out typically sells some accumulated intrinsic/delta and buys more extrinsic/time: it can restore convexity, but it also raises break-even and reintroduces decay.
 
+`extrinsicPerDeltaDollar` separates two contracts that have similar elasticity but very different quality as stock substitutes. Lower values mean less decayable premium is supporting each local dollar of directional exposure. This does **not** make the contract cheap in valuation terms: rates, dividends, borrow, IV skew, exercise style, and execution still matter.
+
+`breakEvenToExpectedMoveRatio` is a hurdle gauge, not a probability or alpha score. `1.0x` means the current-mark expiration break-even is approximately one current-IV expected move away. The approximation assumes IV stays meaningful over the horizon and uses calendar-time square-root scaling; jumps, skew, drift, dividends, rates, changing IV, and early exits all break the simplification.
+
+`gammaToThetaOnePctMoveRatio` asks a narrow question: how much **second-order** gain would a hypothetical 1% move add relative to one modeled day of theta? It excludes the much larger first-order delta P&L and says nothing about direction or move probability. Use it to compare convexity rent, never as a standalone buy signal.
+
 ## Read order
 
 1. **Quote quality:** bid, ask, spread, update timestamp, volume/open interest.
 2. **Absolute exposure:** `deltaShares` and `deltaDollars`.
 3. **Premium composition:** intrinsic vs extrinsic dollars and percentages.
-4. **Local leverage:** elasticity and premium-per-delta-dollar.
+4. **Local leverage:** elasticity, premium-per-delta-dollar, and extrinsic-per-delta-dollar.
 5. **Time risk:** theta dollars/day, theta %/day, and days to expiration.
-6. **Expiration hurdle:** current-mark and cost-basis break-evens.
-7. **Then** gamma, IV/vega, event risk, and the full payoff.
+6. **Expiration hurdle:** current-mark/cost-basis break-evens and break-even versus expected move.
+7. **Convexity rent:** gamma P&L for a 1% move versus daily theta.
+8. **Then** IV/vega, event risk, scenario P&L, and the full payoff.
 
 Never rank contracts by elasticity alone. A nearly worthless OTM contract can have spectacular elasticity and almost no useful probability-weighted exposure.
+
+## Where a real edge could exist
+
+The chain does not reveal alpha by itself. A potentially lucrative angle exists only when a view about **magnitude, direction, timing, or volatility** is better than what the option price already implies—and survives the spread and theta.
+
+### 1. Intrinsic-backed stock replacement
+
+Look for high delta, high intrinsic percentage, low extrinsic-per-delta-dollar, low theta percentage, and executable spreads. This creates more linear exposure with less premium capital than shares. The tradeoff is finite expiry, no dividend ownership, rate/forward effects, and possible loss of the entire premium. Elasticity often looks less exciting precisely because the position is higher quality and more share-like.
+
+### 2. Catalyst convexity
+
+OTM options can make sense when a dated catalyst can produce a move larger/faster than the market-implied distribution. Require a written catalyst date and directional thesis; compare break-even to expected move; inspect IV and likely post-event IV crush; then include spread cost. High elasticity without that event-specific disagreement is usually a cheap-looking lottery ticket.
+
+### 3. Roll audit instead of automatic roll-up
+
+For the old and proposed contracts, compare:
+
+- delta dollars retained or sold
+- intrinsic dollars surrendered
+- new extrinsic dollars purchased
+- theta %/day before and after
+- expiration break-even and break-even/expected-move ratio
+- spread cost on **both** legs
+- gamma/theta ratio before and after
+
+Rolling up and out is not merely “taking profit while staying bullish.” It converts accumulated share-like exposure back into rented convexity. That can be intentional, but the CLI should make the conversion explicit.
+
+### 4. Relative-value screen, not a trade signal
+
+Compare contracts on the same underlying and catalyst window. A contract with slightly lower elasticity may dominate if it has materially higher delta, less extrinsic per delta-dollar, a tighter spread, and a break-even inside fewer implied moves. The result is a shortlist for scenario analysis—not an order recommendation.
+
+## Official educational grounding
+
+- OIC explains delta as the approximate option-price change for a one-point underlying move, all else equal, and notes that delta changes with moneyness, time, and volatility: https://www.optionseducation.org/referencelibrary/faq/option-price-behavior
+- OIC describes deep-ITM options as having larger delta: https://www.optionseducation.org/advancedconcepts/delta
+- OIC's Rule of 16 material grounds square-root-of-time conversion of annualized IV into an expected daily move: https://www.optionseducation.org/news/understanding-the-rule-of-16-in-plain-terms
+- OIC separates intrinsic and time value and warns that exercising a call requires paying cash for the shares: https://www.optionseducation.org/referencelibrary/faq/options-exercise
 
 ## Every-print diagnostics
 

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1794,7 +1794,7 @@ server.registerTool(
   {
     title: "Robinhood Options Holdings",
     description:
-      "Every held option contract across accounts (or one), enriched with exact contract metadata, live mark/spot, intrinsic and extrinsic value, delta shares, delta dollars, option elasticity (local effective leverage), premium per delta-dollar, expiration break-evens, and theta burn. The owned-contract map; read only.",
+      "Every held option contract across accounts (or one), enriched with exact contract metadata, live mark/spot, intrinsic and extrinsic value, delta shares/dollars, local elasticity, extrinsic cost per delta-dollar, IV expected-move hurdle, gamma/theta convexity rent, expiration break-evens, and theta burn. The owned-contract map; read only.",
     inputSchema: z.object({ account_number: accountNumberOptionalSchema }),
     annotations: toolAnnotations(true, "read"),
   },
@@ -1917,7 +1917,7 @@ server.registerTool(
   {
     title: "Robinhood Option Inspect",
     description:
-      "Full detail for ONE owned/known option contract by its UUID: metadata, live Greeks/quote, intrinsic/extrinsic value, delta dollars, option elasticity, break-even and theta analytics, plus fill history. Tolerates the web _L1 leg suffix. Read.",
+      "Full detail for ONE owned/known option contract by its UUID: metadata, live Greeks/quote, intrinsic/extrinsic value, delta dollars, local elasticity, extrinsic cost per delta-dollar, IV expected-move hurdle, gamma/theta convexity rent, break-even and theta analytics, plus fill history. Tolerates the web _L1 leg suffix. Read.",
     inputSchema: z.object({
       option_instrument_id: z
         .string()
@@ -2546,7 +2546,7 @@ server.registerTool(
   {
     title: "Robinhood Options Research Snapshot",
     description:
-      "Research-grade bulk option-chain dataset across one expiration or a bounded all-expiration range. Returns every active contract with bid/ask/mark/mid/last/previous close/spread, delta/gamma/theta/vega/rho, IV, volume, open interest, moneyness, UUID and deep link, plus intrinsic/extrinsic value, delta dollars, local option elasticity, premium-per-delta-dollar, break-even and theta analytics. Includes put/call liquidity ratios and concentration leaders. Shared engine with CLI `options snapshot`; live read only.",
+      "Research-grade bulk option-chain dataset across one expiration or a bounded all-expiration range. Returns every active contract with bid/ask/mark/mid/last/previous close/spread, delta/gamma/theta/vega/rho, IV, volume, open interest, moneyness, UUID and deep link, plus intrinsic/extrinsic value, delta dollars, local elasticity, extrinsic cost per delta-dollar, IV expected-move hurdle, gamma/theta convexity rent, break-even and theta analytics. Includes put/call liquidity ratios and concentration leaders. Shared engine with CLI `options snapshot`; live read only.",
     inputSchema: z.object({
       symbol: symbolSchema,
       expiration: z.union([dateSchema, z.literal("all")]).optional(),


### PR DESCRIPTION
## Summary
- add extrinsic cost per delta-dollar to distinguish share-like leverage from rented premium
- add IV expected-move hurdle and break-even/expected-move ratio
- add gamma P&L for a 1% move and gamma/theta convexity-rent ratio
- print fields in human CLI output and preserve shared CLI/MCP JSON parity
- document roll audits, stock-replacement vs catalyst-convexity use cases, and metric limitations

## Verification
- [x] TDD red confirmed: new field was undefined
- [x] 494 CLI tests passed
- [x] 16 MCP tests passed (2 intentional skips)
- [x] full build passed
- [x] typecheck passed
- [x] quality gate passed
- [x] live authenticated options read returned all five new fields across 22 holdings

- delilah 🌸