### PR TITLE
fix(auth): select the freshest browser session

### DIFF
--- a/scripts/extract-auth-leveldb.py
+++ b/scripts/extract-auth-leveldb.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Extract the furthest-expiring Robinhood auth object from Chromium LevelDB."""
+import argparse
+import base64
+import glob
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def jwt_exp(token):
+    try:
+        part = token.split(".")[1]
+        part += "=" * ((4 - len(part) % 4) % 4)
+        return int(json.loads(base64.urlsafe_b64decode(part.encode("ascii"))).get("exp") or 0)
+    except (IndexError, ValueError, TypeError, json.JSONDecodeError):
+        return 0
+
+
+def scan(bases):
+    files = []
+    for base in bases:
+        files.extend(glob.glob(os.path.join(str(base), "*", "Local Storage", "leveldb", "*.ldb")))
+        files.extend(glob.glob(os.path.join(str(base), "*", "Local Storage", "leveldb", "*.log")))
+    candidates = []
+    for filename in set(files):
+        try:
+            data = Path(filename).read_bytes()
+            mtime = os.path.getmtime(filename)
+        except OSError:
+            continue
+        for match in re.finditer(rb"access_token", data):
+            start = data.rfind(b"{", max(0, match.start() - 300), match.start())
+            if start < 0:
+                continue
+            depth = 0
+            end = None
+            for index in range(start, min(len(data), start + 12000)):
+                char = data[index : index + 1]
+                if char == b"{":
+                    depth += 1
+                elif char == b"}":
+                    depth -= 1
+                    if depth == 0:
+                        end = index + 1
+                        break
+            if end is None:
+                continue
+            try:
+                obj = json.loads(data[start:end].decode("latin-1"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            if not isinstance(obj, dict) or not obj.get("access_token") or not obj.get("refresh_token"):
+                continue
+            token = str(obj["access_token"])
+            candidates.append((jwt_exp(token), mtime, len(token), Path(filename), token))
+    if not candidates:
+        raise RuntimeError("no Robinhood auth found in Chromium LevelDB")
+    candidates.sort(key=lambda item: item[:3], reverse=True)
+    return candidates[0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", action="append", type=Path, default=[])
+    parser.add_argument("--env", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        exp, _mtime, _length, source, token = scan(args.base)
+    except RuntimeError:
+        print("source=leveldb unavailable=no_auth", file=sys.stderr)
+        raise SystemExit(2) from None
+    args.env.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + token + "\n", encoding="utf-8")
+    try:
+        os.chmod(str(args.env), 0o600)
+    except OSError:
+        pass
+    profile = source.parents[2].name
+    print("source=leveldb:" + profile + " auth_state=yes token_written=yes jwt_exp=" + str(exp))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh-auth.sh
+++ b/scripts/refresh-auth.sh
@@ -75,22 +75,21 @@ export CHROME_BASE
 export BRAVE_BASE
 export EDGE_BASE
 
-# --- CDP-first (live-memory) read -------------------------------------------
-# The disk scan below reads Chrome's on-disk LevelDB, which Chrome flushes
-# LAZILY — so a token that rotated minutes ago (or a fresh login) may not be on
-# disk yet, and the scan finds nothing even though you're logged in. When a
-# debug Chrome is reachable (chrome-debug / --remote-debugging-port=9222) we
-# instead read localStorage["web:auth_state"] straight from the LIVE tab over
-# CDP: authoritative, always current. Populates RH_CDP_JSON for the python
-# below; on any failure we fall through to the disk scan (headless/offline path).
-# Opt out with ROBINHOOD_NO_CDP=1.
-cdp_try() {
-    [ -n "${ROBINHOOD_NO_CDP:-}" ] && return 1
+# --- Collect every available auth source, then choose the furthest expiry ---
+# A stale debug profile can remain reachable while the user has just logged in
+# through normal Chrome or Safari. Never stop at the first valid token: collect
+# private candidate env files, compare JWT exp locally, and write only the winner.
+TARGET_ENV_PATH="$ROBINHOOD_ENV_PATH"
+CANDIDATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/robinhood-auth.XXXXXX")"
+trap 'rm -rf "$CANDIDATE_DIR"' EXIT
+
+cdp_collect() {
+    [ -n "${ROBINHOOD_NO_CDP:-}" ] && return 0
     local helper="$REPO_DIR/scripts/extract-auth-cdp.py"
-    [ -f "$helper" ] || return 1
+    [ -f "$helper" ] || return 0
     "$PYTHON_BIN" -c 'import websockets' >/dev/null 2>&1 || {
-        echo "[refresh-auth] CDP support unavailable: install with '$PYTHON_BIN -m pip install websockets'; trying disk fallback" >&2
-        return 1
+        echo "[refresh-auth] CDP support unavailable; continuing with other sources" >&2
+        return 0
     }
 
     local configured="${ROBINHOOD_CDP_PORTS:-${ROBINHOOD_CDP_PORT:-}}"
@@ -101,14 +100,14 @@ roots = [os.environ.get(k) for k in ("CHROME_BASE", "BRAVE_BASE", "EDGE_BASE")]
 roots += [p for p in os.environ.get("CHROMIUM_BASES", "").split(os.pathsep) if p]
 seen = set()
 for root in filter(None, roots):
-    for path in (os.path.join(root, "DevToolsActivePort"),):
-        try:
-            port = int(open(path, encoding="utf-8").readline().strip())
-        except (OSError, ValueError):
-            continue
-        if port not in seen:
-            seen.add(port)
-            print(port)
+    path = os.path.join(root, "DevToolsActivePort")
+    try:
+        port = int(open(path, encoding="utf-8").readline().strip())
+    except (OSError, ValueError):
+        continue
+    if port not in seen:
+        seen.add(port)
+        print(port)
 PYPORTS
 )
 
@@ -118,156 +117,32 @@ PYPORTS
         case "$port" in *[!0-9]*|'') continue ;; esac
         case "$tried" in *" $port "*) continue ;; esac
         tried="$tried$port "
-        if "$PYTHON_BIN" "$helper" --port "$port" --env "$ROBINHOOD_ENV_PATH"; then
-            return 0
-        fi
+        "$PYTHON_BIN" "$helper" --port "$port" --env "$CANDIDATE_DIR/cdp-$port.env" || true
     done
-    return 1
 }
 
-# Direct CDP is authoritative and already writes the protected .env. Stop here
-# on success. Safari is a macOS-only, stdlib fallback that validates the
-# robinhood.com WebKit origin before reading the exact web:auth_state key.
-if cdp_try; then
-    exit 0
-fi
+cdp_collect
+
 if [ "$(uname -s)" = "Darwin" ] && [ -f "$REPO_DIR/scripts/extract-auth-safari.py" ]; then
-    if "$PYTHON_BIN" "$REPO_DIR/scripts/extract-auth-safari.py" --env "$ROBINHOOD_ENV_PATH"; then
-        exit 0
-    fi
+    "$PYTHON_BIN" "$REPO_DIR/scripts/extract-auth-safari.py" \
+        --env "$CANDIDATE_DIR/safari.env" || true
 fi
 
-# Final fallback: generic on-disk Chromium discovery.
+leveldb_args=()
+[ -n "${CHROME_BASE:-}" ] && leveldb_args+=(--base "$CHROME_BASE")
+[ -n "${BRAVE_BASE:-}" ] && leveldb_args+=(--base "$BRAVE_BASE")
+[ -n "${EDGE_BASE:-}" ] && leveldb_args+=(--base "$EDGE_BASE")
+"$PYTHON_BIN" "$REPO_DIR/scripts/extract-auth-leveldb.py" \
+    "${leveldb_args[@]}" --env "$CANDIDATE_DIR/leveldb.env" || true
 
-# Python prefers RH_CDP_JSON (live) when present; else does the disk scan. It
-# writes .env, chmods it, and prints the status — so the token value never
-# passes through the shell. Heredoc goes straight to python (no nesting inside
-# $(), which trips macOS bash 3.2's paren scanner).
-"$PYTHON_BIN" << 'PYEOF'
-import re, json, glob, os, sys, datetime
-
-env_path = os.environ["ROBINHOOD_ENV_PATH"]
-base = os.environ.get("CHROME_BASE")
-brave = os.environ.get("BRAVE_BASE")
-edge = os.environ.get("EDGE_BASE")
-
-# Live CDP read wins when available — it's the authoritative in-memory token,
-# not the lazily-flushed disk copy. RH_CDP_JSON is the raw web:auth_state JSON.
-cdp_raw = os.environ.get("RH_CDP_JSON")
-cdp_best = None
-if cdp_raw:
-    try:
-        obj = json.loads(cdp_raw)
-        if isinstance(obj, dict) and obj.get("access_token"):
-            cdp_best = obj
-    except Exception:
-        cdp_best = None
-
-# Try Chrome first, then Brave, then Edge
-bases = [b for b in [base, brave, edge] if b]
-if not bases:
-    home = os.path.expanduser("~")
-    if sys.platform == "darwin":
-        base = os.path.join(home, "Library/Application Support/Google/Chrome")
-    elif sys.platform == "win32":
-        base = os.path.join(os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData/Local")),
-                            "Google", "Chrome", "User Data")
-    else:
-        base = os.path.join(home, ".config/google-chrome")
-
-# On Windows, the base IS "User Data" and profiles are direct children.
-# On macOS/Linux, profiles are direct children of the Chrome base.
-# The glob below handles both: "<base>/*/Local Storage/leveldb"
-# Try all browser bases (Chrome, Brave, Edge) in order
-files = []
-for b in bases:
-    for prof in glob.glob(os.path.join(b, "*", "Local Storage", "leveldb")):
-        files += glob.glob(os.path.join(prof, "*.ldb"))
-        files += glob.glob(os.path.join(prof, "*.log"))
-files = sorted(set(files), key=lambda p: os.path.getmtime(p), reverse=True)
-
-candidates = []
-for f in files:
-    try:
-        data = open(f, "rb").read()
-    except OSError:
-        continue
-    for m in re.finditer(rb"access_token", data):
-        start = data.rfind(b"{", max(0, m.start() - 200), m.start())
-        if start == -1:
-            continue
-        depth = 0
-        end = None
-        for i in range(start, min(len(data), start + 8000)):
-            c = data[i:i + 1]
-            if c == b"{":
-                depth += 1
-            elif c == b"}":
-                depth -= 1
-                if depth == 0:
-                    end = i + 1
-                    break
-        if end is None:
-            continue
-        try:
-            obj = json.loads(data[start:end].decode("latin-1"))
-        except Exception:
-            continue
-        if isinstance(obj, dict) and obj.get("access_token") and obj.get("refresh_token"):
-            candidates.append((os.path.getmtime(f), obj))
-
-if cdp_best is not None:
-    best = cdp_best
-    source = "live CDP (localStorage)"
-elif candidates:
-    candidates.sort(key=lambda c: (c[0], len(str(c[1]["access_token"]))), reverse=True)
-    best = candidates[0][1]
-    source = "on-disk localStorage"
-else:
-    sys.stderr.write(
-        "[refresh-auth] no Robinhood auth found via CDP or in any Chrome profile's "
-        "on-disk localStorage. Log in to robinhood.com in Chrome (or start chrome-debug) "
-        "and retry.\n")
-    sys.exit(2)
-
-tok = str(best["access_token"])
-exp = int(best.get("expires_in", 0) or 0)
-ttype = best.get("token_type", "Bearer")
-
-header = (
-    "# Robinhood brokerage auth — " + source + " "
-    + datetime.datetime.utcnow().isoformat() + "Z\n"
-    + "# token_type=" + str(ttype) + " expires_in=" + str(exp)
-    + "s (~%.1fd)\n" % (exp / 86400)
-    + "ROBINHOOD_BROKERAGE_TOKEN=" + tok + "\n"
-)
-# Surgical write: refresh ONLY the token (+ its auto-generated header comments) and
-# PRESERVE every other line (ROBINHOOD_WEB_APP_VERSION, crypto keys, etc.). A full
-# overwrite would clobber sibling keys — the same "refresh one field, destroy others"
-# bug class we're stamping out.
-keep = []
-if os.path.exists(env_path):
-    with open(env_path) as fh:
-        for ln in fh.read().split("\n"):
-            s = ln.strip()
-            if s.startswith("ROBINHOOD_BROKERAGE_TOKEN="):
-                continue
-            if s.startswith("# Robinhood brokerage auth") or s.startswith("# token_type="):
-                continue
-            keep.append(ln)
-while keep and keep[0].strip() == "":
-    keep.pop(0)
-while keep and keep[-1].strip() == "":
-    keep.pop()
-content = header + ("\n".join(keep).rstrip("\n") + "\n" if keep else "")
-with open(env_path, "w") as fh:
-    fh.write(content)
-try:
-    os.chmod(env_path, 0o600)
-except OSError:
-    pass  # chmod on Windows is no-op; ignore
-print("[refresh-auth] wrote %s (OK len=%d type=%s exp_days=%.1f, %d other line(s) preserved)"
-      % (env_path, len(tok), ttype, exp / 86400, len(keep)))
-PYEOF
+shopt -s nullglob
+candidates=("$CANDIDATE_DIR"/*.env)
+shopt -u nullglob
+if [ "${#candidates[@]}" -eq 0 ]; then
+    echo "[refresh-auth] no valid Robinhood auth found via CDP, Safari, or Chromium LevelDB" >&2
+    exit 2
+fi
+"$PYTHON_BIN" "$REPO_DIR/scripts/select-auth-candidate.py" \
+    --target "$TARGET_ENV_PATH" "${candidates[@]}"
 
 # Zayd Khan // cold // www.zayd.wtf

--- a/scripts/select-auth-candidate.py
+++ b/scripts/select-auth-candidate.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Select the longest-lived Robinhood bearer candidate without exposing it."""
+import argparse
+import base64
+import datetime
+import json
+import os
+from pathlib import Path
+
+
+def token_from_env(path):
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("ROBINHOOD_BROKERAGE_TOKEN="):
+            return line.split("=", 1)[1]
+    return None
+
+
+def jwt_exp(token):
+    try:
+        part = token.split(".")[1]
+        part += "=" * ((4 - len(part) % 4) % 4)
+        return int(json.loads(base64.urlsafe_b64decode(part.encode("ascii"))).get("exp") or 0)
+    except (IndexError, ValueError, TypeError, json.JSONDecodeError):
+        return 0
+
+
+def select_freshest(paths):
+    candidates = []
+    for path in paths:
+        token = token_from_env(path)
+        if not token:
+            continue
+        candidates.append((jwt_exp(token), path.stat().st_mtime, len(token), path, token))
+    if not candidates:
+        raise RuntimeError("no valid Robinhood auth candidates")
+    candidates.sort(key=lambda item: item[:3], reverse=True)
+    return candidates[0]
+
+
+def write_target(target, token, source, exp):
+    old = target.read_text(encoding="utf-8") if target.exists() else ""
+    keep = []
+    for line in old.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ROBINHOOD_BROKERAGE_TOKEN="):
+            continue
+        if stripped.startswith("# Robinhood brokerage auth") or stripped.startswith("# token_type="):
+            continue
+        keep.append(line)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    header = (
+        "# Robinhood brokerage auth — freshest verified candidate "
+        + now.isoformat()
+        + "\n# token_type=Bearer jwt_exp="
+        + str(exp)
+        + " source="
+        + source
+        + "\nROBINHOOD_BROKERAGE_TOKEN="
+        + token
+        + "\n"
+    )
+    body = "\n".join(keep).strip("\n")
+    target.write_text(header + (body + "\n" if body else ""), encoding="utf-8")
+    try:
+        os.chmod(str(target), 0o600)
+    except OSError:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", type=Path, required=True)
+    parser.add_argument("candidates", nargs="+", type=Path)
+    args = parser.parse_args()
+    existing = [path for path in args.candidates if path.exists()]
+    exp, _mtime, _length, path, token = select_freshest(existing)
+    source = path.stem
+    write_target(args.target, token, source, exp)
+    now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+    remaining = round((exp - now) / 86400, 2) if exp else "unknown"
+    expires = datetime.datetime.fromtimestamp(exp, datetime.timezone.utc).isoformat() if exp else "unknown"
+    print(
+        "source="
+        + source
+        + " auth_state=yes token_written=yes session_remaining_days="
+        + str(remaining)
+        + " token_expires_utc="
+        + expires
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-auth-session.mjs
+++ b/scripts/test-auth-session.mjs
@@ -1,11 +1,18 @@
 import { spawnSync } from "node:child_process";
 
 const candidates = process.platform === "win32" ? ["python", "py"] : ["python3", "python"];
+const tests = ["scripts/test_auth_session.py", "scripts/test_auth_candidate_selection.py"];
 for (const candidate of candidates) {
-  const args = candidate === "py" ? ["-3", "scripts/test_auth_session.py"] : ["scripts/test_auth_session.py"];
-  const result = spawnSync(candidate, args, { stdio: "inherit" });
-  if (result.error && result.error.code === "ENOENT") continue;
-  process.exit(result.status ?? 1);
+  const probeArgs = candidate === "py" ? ["-3", "--version"] : ["--version"];
+  const probe = spawnSync(candidate, probeArgs, { stdio: "ignore" });
+  if (probe.error && probe.error.code === "ENOENT") continue;
+  if (probe.status !== 0) continue;
+  for (const test of tests) {
+    const args = candidate === "py" ? ["-3", test] : [test];
+    const result = spawnSync(candidate, args, { stdio: "inherit" });
+    if (result.status !== 0) process.exit(result.status ?? 1);
+  }
+  process.exit(0);
 }
 console.error("No Python 3 interpreter found (tried: " + candidates.join(", ") + ")");
 process.exit(1);

--- a/scripts/test_auth_candidate_selection.py
+++ b/scripts/test_auth_candidate_selection.py
@@ -1,0 +1,65 @@
+import base64
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+
+
+def load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, ROOT / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+selector = load("selector", "select-auth-candidate.py")
+leveldb = load("leveldb", "extract-auth-leveldb.py")
+
+
+def jwt(exp):
+    enc = lambda obj: base64.urlsafe_b64encode(json.dumps(obj).encode()).decode().rstrip("=")
+    return enc({"alg": "none"}) + "." + enc({"exp": exp}) + ".x"
+
+
+class AuthCandidateSelectionTests(unittest.TestCase):
+    def test_furthest_expiry_wins_and_siblings_survive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            short = root / "cdp-9222.env"
+            long = root / "safari.env"
+            target = root / ".env"
+            short.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(100) + "\n")
+            long.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(300) + "\n")
+            target.write_text("ROBINHOOD_BROKERAGE_TOKEN=old\nROBINHOOD_WEB_APP_VERSION=keep\n")
+            exp, _mtime, _length, path, token = selector.select_freshest([short, long])
+            self.assertEqual(exp, 300)
+            self.assertEqual(path, long)
+            selector.write_target(target, token, path.stem, exp)
+            text = target.read_text()
+            self.assertIn("ROBINHOOD_WEB_APP_VERSION=keep", text)
+            self.assertIn("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(300), text)
+            self.assertNotIn(jwt(100), text)
+
+    def test_leveldb_scanner_ranks_jwt_exp_not_file_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            db = root / "Default" / "Local Storage" / "leveldb"
+            db.mkdir(parents=True)
+            older = {"access_token": jwt(900), "refresh_token": "r1"}
+            newer = {"access_token": jwt(400), "refresh_token": "r2"}
+            (db / "001.ldb").write_bytes(b"x" + json.dumps(older).encode() + b"x")
+            (db / "002.ldb").write_bytes(b"x" + json.dumps(newer).encode() + b"x")
+            exp, _mtime, _length, _source, token = leveldb.scan([root])
+            self.assertEqual(exp, 900)
+            self.assertEqual(token, jwt(900))
+
+    def test_no_candidate_fails_closed(self):
+        with self.assertRaises(RuntimeError):
+            selector.select_freshest([])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- collect auth candidates from CDP, Safari, and Chromium LevelDB instead of stopping at the first source
- select by verified JWT expiry so stale debug profiles cannot override a fresh trusted login
- preserve sibling env settings and keep token values off stdout/argv
- add cross-platform Python regression coverage to the normal test command

## Verification
- live frostbyte smoke selected the 10.97-day Safari token over the 5.09-day stale CDP token
- 494 CLI tests passed
- 16 MCP tests passed (2 skipped)
- 5 Python auth tests passed
- build, typecheck, lint, audit, diff-check, and gitleaks passed

- delilah 🌸