### PR TITLE
fix: bound sentinel lookahead to future events

### DIFF
--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -10517,8 +10517,9 @@ export async function computeSentinel(
   if (risk.warnings?.length) warnings.push(...risk.warnings);
   // Flag near-term expirations and assignments
   const lookaheadDays = opts.eventLookaheadDays ?? 7;
+  const today = new Date().toISOString().slice(0, 10);
   const cutoff = new Date(Date.now() + lookaheadDays * 86400000).toISOString().slice(0, 10);
-  const upcoming = events.events.filter((e) => e.date <= cutoff);
+  const upcoming = events.events.filter((e) => e.date >= today && e.date <= cutoff);
   if (upcoming.length > 0) {
     const assignmentEvents = upcoming.filter((e) => e.type === "assignment");
     const expirationEvents = upcoming.filter((e) => e.type === "expiration");

--- a/cli/test/signal-reads.test.ts
+++ b/cli/test/signal-reads.test.ts
@@ -254,4 +254,46 @@ describe("computeSentinel — composes risk scan + options-event guardian", () =
     expect(r.events.count).toBe(1);
     expect(r.warnings.some((w: string) => /assignment event/i.test(w))).toBe(true);
   });
+
+  it("does not classify historical events as upcoming", async () => {
+    const future = new Date(Date.now() + 2 * 86400000).toISOString().slice(0, 10);
+    const getJson = (async (url: string) => {
+      const acc = ownsA1(url);
+      if (acc) return acc;
+      if (url.includes("options/events"))
+        return {
+          results: [
+            {
+              event_date: "2000-01-01",
+              type: "expiration",
+              direction: "credit",
+              quantity: "1",
+              total_cash_amount: "0",
+              state: "confirmed",
+              account_number: "A1",
+              option_id: "oid-past",
+            },
+            {
+              event_date: future,
+              type: "expiration",
+              direction: "credit",
+              quantity: "1",
+              total_cash_amount: "0",
+              state: "confirmed",
+              account_number: "A1",
+              option_id: "oid-future",
+            },
+          ],
+        };
+      if (url.includes("options/instruments")) return { chain_symbol: "AAPL" };
+      return { results: [] };
+    }) as any;
+    const getAll = (async () => []) as any;
+    const r = await computeSentinel(
+      { accountNumber: "A1", eventLookaheadDays: 7 },
+      { getJson, getAll },
+    );
+    expect(r.events.count).toBe(2);
+    expect(r.warnings).toEqual(["1 expiration(s) in the next 7 days."]);
+  });
 });


### PR DESCRIPTION
## Summary
- Exclude historical option-event records from Sentinel’s near-term warning window
- Add a regression test covering historical plus future expiration records

## Verification
- `npx pnpm test` — 495 CLI tests passed; 16 MCP tests passed, 2 skipped; auth-session tests passed
- `npx pnpm quality` — lint, format ratchet, deadcode, API-map, skill, and portability gates passed
- Live custom CLI smoke — `sentinel --days 7 --json` no longer emits the false 50-expiration warning; authenticated `accounts --json` returned 5 verified accounts
- `gitleaks` clean

- delilah 🌸