### PR TITLE
feat(options): strategy-quote expiry payoff + vertical risk max-loss

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2995,6 +2995,8 @@ options
         return {
           id: leg.template.id,
           action: leg.template.action,
+          optionType: leg.template.optionType as "call" | "put",
+          strike: leg.strike,
           ratioQuantity: leg.template.ratioQuantity,
           bid: mark.bid_price,
           ask: mark.ask_price,
@@ -3017,6 +3019,7 @@ options
         legs: pricingLegs,
         mode: opts.pricingMode ?? "mid",
         preferredDirection,
+        quantity: Number(quantity) || 1,
       });
       const computedLimitPrice = finiteNumber(opts.limitPrice ?? pricing.limitPrice);
       if (!Number.isFinite(computedLimitPrice) || computedLimitPrice < 0) {
@@ -3152,6 +3155,20 @@ options
         `\nnet natural: ${pricing.direction === "credit" ? "credit" : "debit"} ${usd(pricing.naturalPrice)}  ` +
           `net mid: ${usd(pricing.midPrice)}  limit: ${usd(computedLimitPrice)} (${output.pricing.limitPriceSource})\n`,
       );
+      if (pricing.payoff) {
+        const fmtBound = (value: number | "unlimited") =>
+          value === "unlimited" ? "unlimited" : usd(value);
+        process.stdout.write(
+          `payoff @ expiry (${pricing.payoff.pricingBasis} premiums ×${pricing.payoff.quantity}): ` +
+            `max profit ${fmtBound(pricing.payoff.maxProfit)}  ` +
+            `max loss ${fmtBound(pricing.payoff.maxLoss)}  ` +
+            `breakevens ${
+              pricing.payoff.breakevens.length
+                ? pricing.payoff.breakevens.map((b) => b.toFixed(2)).join(", ")
+                : "—"
+            }\n`,
+        );
+      }
       process.stdout.write(
         `strategy quote: ${strategyQuote ? "returned" : "not returned; using leg math"}\n`,
       );

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { computeExpirationPayoff } from "./options-workbench.js";
 import { maybeShareSafe } from "./share-safe.js";
 
 export * from "./capabilities.js";
@@ -221,6 +222,10 @@ export type OptionsStrategyPricingMode = "natural" | "mid" | "safe-sell-probe" |
 export interface OptionsStrategyPricingLegInput {
   id: string;
   action: "buy" | "sell";
+  /** Required for expiration payoff; omitted keeps pricing-only behavior. */
+  optionType?: "call" | "put";
+  /** Required for expiration payoff; omitted keeps pricing-only behavior. */
+  strike?: number | string | null;
   ratioQuantity?: number;
   bid?: number | string | null;
   ask?: number | string | null;
@@ -266,6 +271,19 @@ export interface OptionsStrategyPricingSummary {
     theta: number;
     vega: number;
     rho: number;
+  };
+  /**
+   * Same-expiration payoff envelope when every leg carries strike + optionType.
+   * Scaled by `quantity` (default 1). Probe modes still price the envelope off natural/mid
+   * premiums — not the far probe limit — so max profit/loss stays market-realistic.
+   */
+  payoff?: {
+    maxProfit: number | "unlimited";
+    maxLoss: number | "unlimited";
+    breakevens: number[];
+    quantity: number;
+    pricingBasis: "natural" | "mid";
+    exactForSameExpiration: true;
   };
   warnings: string[];
 }
@@ -8931,6 +8949,10 @@ export function buildOptionsStrategyPricingSummary(input: {
   mode?: OptionsStrategyPricingMode;
   preferredDirection?: "credit" | "debit";
   farLimitOffset?: number;
+  /** Contract quantity for payoff scaling (default 1). Does not change per-unit limit price. */
+  quantity?: number;
+  /** Spot used only as an extra payoff sample point when finite. */
+  underlyingPrice?: number;
 }): OptionsStrategyPricingSummary {
   const mode = input.mode ?? "mid";
   if (!["natural", "mid", "safe-sell-probe", "safe-buy-probe"].includes(mode)) {
@@ -8939,6 +8961,7 @@ export function buildOptionsStrategyPricingSummary(input: {
   if (input.legs.length === 0) throw new Error("at least one option leg is required");
   const warnings: string[] = [];
   const farLimitOffset = input.farLimitOffset ?? 200;
+  const quantity = Math.max(1, Number(input.quantity) || 1);
 
   const legs = input.legs.map((leg): OptionsStrategyPricingLegSummary => {
     const bid = finitePrice(leg.bid);
@@ -9019,6 +9042,55 @@ export function buildOptionsStrategyPricingSummary(input: {
   if (!Number.isFinite(limitPrice))
     warnings.push("limit price could not be computed from available quotes.");
 
+  // Expiration payoff needs strike + call/put on every leg. Probe modes still build the
+  // envelope from natural premiums so max profit/loss stay market-realistic (not the far probe).
+  const premiumBasis: "natural" | "mid" = mode === "mid" ? "mid" : "natural";
+  let payoff: OptionsStrategyPricingSummary["payoff"];
+  const payoffLegs = input.legs.flatMap((leg, index) => {
+    const priced = legs[index];
+    const strike = Number(leg.strike);
+    const optionType = leg.optionType === "put" ? "put" : leg.optionType === "call" ? "call" : null;
+    if (!priced || !optionType || !Number.isFinite(strike)) return [];
+    const premium =
+      premiumBasis === "natural" ? priced.naturalUnitPrice : priced.midUnitPrice;
+    if (!Number.isFinite(premium)) return [];
+    return [
+      {
+        id: leg.id,
+        action: leg.action,
+        type: optionType as "call" | "put",
+        strike,
+        ratioQuantity: priced.ratioQuantity,
+        premium,
+      },
+    ];
+  });
+  if (payoffLegs.length === input.legs.length && payoffLegs.length > 0) {
+    try {
+      const envelope = computeExpirationPayoff({
+        legs: payoffLegs,
+        quantity,
+        underlyingPrice: input.underlyingPrice,
+      });
+      payoff = {
+        maxProfit: envelope.maxProfit,
+        maxLoss: envelope.maxLoss,
+        breakevens: envelope.breakevens,
+        quantity,
+        pricingBasis: premiumBasis,
+        exactForSameExpiration: true,
+      };
+    } catch (error) {
+      warnings.push(
+        `payoff unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  } else if (input.legs.some((leg) => leg.optionType != null || leg.strike != null)) {
+    warnings.push(
+      "payoff omitted: every leg needs optionType, strike, and a usable premium quote.",
+    );
+  }
+
   return {
     mode,
     direction,
@@ -9037,6 +9109,7 @@ export function buildOptionsStrategyPricingSummary(input: {
       vega: signedGreek(input.legs, "vega", 100),
       rho: signedGreek(input.legs, "rho", 100),
     },
+    ...(payoff ? { payoff } : {}),
     warnings,
   };
 }
@@ -9390,6 +9463,48 @@ export async function computePerformance(opts: any = {}, deps: any = {}) {
     warnings,
   };
 }
+
+/**
+ * Max loss in dollars for a simple same-type vertical (one short + one long, equal ratio).
+ * Topology distinguishes credit vs debit:
+ *   call credit: shortStrike < longStrike; put credit: shortStrike > longStrike.
+ * `averageOpenPricePerContract` is Robinhood aggregate per-contract dollars (premium × 100).
+ * Returns null for iron condors, ratio spreads, single legs, or missing inputs.
+ */
+export function computeVerticalDefinedMaxLossUsd(input: {
+  legs: Array<{
+    side: "short" | "long";
+    type: "call" | "put";
+    strike: number;
+    ratioQuantity?: number;
+  }>;
+  averageOpenPricePerContract: number;
+  quantity: number;
+}): number | null {
+  const shorts = input.legs.filter((leg) => leg.side === "short");
+  const longs = input.legs.filter((leg) => leg.side === "long");
+  if (shorts.length !== 1 || longs.length !== 1) return null;
+  const shortLeg = shorts[0]!;
+  const longLeg = longs[0]!;
+  if (shortLeg.type !== longLeg.type) return null;
+  const shortRatio = Math.max(1, Number(shortLeg.ratioQuantity) || 1);
+  const longRatio = Math.max(1, Number(longLeg.ratioQuantity) || 1);
+  if (shortRatio !== longRatio) return null;
+  const width = Math.abs(Number(shortLeg.strike) - Number(longLeg.strike));
+  const net = Math.abs(Number(input.averageOpenPricePerContract));
+  const qty = Number(input.quantity);
+  if (!(width > 0) || !Number.isFinite(net) || !(qty > 0)) return null;
+  const isCredit =
+    shortLeg.type === "call"
+      ? Number(shortLeg.strike) < Number(longLeg.strike)
+      : Number(shortLeg.strike) > Number(longLeg.strike);
+  // width × 100 × ratio = dollars per contract package; avg open is already per-contract $.
+  const widthDollars = width * 100 * shortRatio;
+  const perPackage = isCredit ? widthDollars - net : net;
+  if (!(perPackage >= 0) || !Number.isFinite(perPackage)) return null;
+  return Number((perPackage * qty).toFixed(2));
+}
+
 /**
  * Portfolio risk scanner: max loss across open positions, assignment exposure (ITM shorts),
  * undercovered short legs, margin utilization (borrowed/equity), and concentration warnings (>20% in one symbol).
@@ -9584,23 +9699,23 @@ export async function computeRisk(opts: any = {}, deps: any = {}) {
       // (premium × 100; see optionReturnPct), so it is multiplied by the contract count
       // ONLY — never by another 100 — and only after the leg loop, so a multi-leg long
       // (e.g. a long straddle) is not counted once per leg. Any short leg already set
-      // maxLoss = null (spread defined-risk is intentionally left unmodeled here).
+      // maxLoss = null; simple same-type verticals are filled in below from wing width.
       if (maxLoss !== null) {
         const debit = n(p.avgOpenPrice) * p.qty;
         maxLoss = Number.isFinite(debit) ? debit : null;
       }
-      // Honest loss-shape classification for labeling — we do NOT model spread/naked payoff here.
+      // Honest loss-shape classification for labeling.
       // Uses net leg RATIOS (not mere presence) so a ratio spread (e.g. short 2 / long 1 call) is
       // recognized as net-naked, never mislabeled bounded:
       //  • number maxLoss                             → "defined" (long-only debit, modeled)
-      //  • long ratio ≥ short ratio for BOTH types    → "defined-spread" (bounded, not modeled)
+      //  • long ratio ≥ short ratio for BOTH types    → "defined-spread" (bounded; verticals modeled)
       //  • net-excess short CALLS, not share-covered  → "unlimited" (truly unbounded upside)
       //  • else (naked short put = bounded-but-large, covered call, unclassifiable) → "not-modeled"
       const hasShort = shortCallRatio > 0 || shortPutRatio > 0;
       const fullyWinged = longCallRatio >= shortCallRatio && longPutRatio >= shortPutRatio;
       const netShortCalls = shortCallRatio - longCallRatio;
       const nakedUnlimitedCall = netShortCalls > 0 && undercovered > 0;
-      const riskClass: "defined" | "defined-spread" | "unlimited" | "not-modeled" =
+      let riskClass: "defined" | "defined-spread" | "unlimited" | "not-modeled" =
         maxLoss !== null
           ? "defined"
           : !hasShort
@@ -9610,6 +9725,19 @@ export async function computeRisk(opts: any = {}, deps: any = {}) {
               : nakedUnlimitedCall
                 ? "unlimited"
                 : "not-modeled";
+      if (riskClass === "defined-spread" && maxLoss === null) {
+        const modeled = computeVerticalDefinedMaxLossUsd({
+          legs: p.legs.map((leg: any) => ({
+            side: leg.side,
+            type: leg.type,
+            strike: leg.strike,
+            ratioQuantity: leg.ratioQuantity,
+          })),
+          averageOpenPricePerContract: p.avgOpenPrice,
+          quantity: p.qty,
+        });
+        if (modeled !== null) maxLoss = modeled;
+      }
       positions.push({
         kind: "option",
         symbol: p.symbol,

--- a/cli/src/lib.ts
+++ b/cli/src/lib.ts
@@ -9715,7 +9715,7 @@ export async function computeRisk(opts: any = {}, deps: any = {}) {
       const fullyWinged = longCallRatio >= shortCallRatio && longPutRatio >= shortPutRatio;
       const netShortCalls = shortCallRatio - longCallRatio;
       const nakedUnlimitedCall = netShortCalls > 0 && undercovered > 0;
-      let riskClass: "defined" | "defined-spread" | "unlimited" | "not-modeled" =
+      const riskClass: "defined" | "defined-spread" | "unlimited" | "not-modeled" =
         maxLoss !== null
           ? "defined"
           : !hasShort
@@ -9727,9 +9727,14 @@ export async function computeRisk(opts: any = {}, deps: any = {}) {
                 : "not-modeled";
       if (riskClass === "defined-spread" && maxLoss === null) {
         const modeled = computeVerticalDefinedMaxLossUsd({
-          legs: p.legs.map((leg: any) => ({
+          legs: p.legs.map((leg: {
+            side: "short" | "long";
+            type: string;
+            strike: number;
+            ratioQuantity: number;
+          }) => ({
             side: leg.side,
-            type: leg.type,
+            type: leg.type === "put" ? "put" : "call",
             strike: leg.strike,
             ratioQuantity: leg.ratioQuantity,
           })),

--- a/cli/src/options-workbench.ts
+++ b/cli/src/options-workbench.ts
@@ -10,18 +10,33 @@ export interface WorkbenchLeg {
   bid?: number;
   ask?: number;
   mark?: number;
-  delta?: number; gamma?: number; theta?: number; vega?: number;
+  delta?: number;
+  gamma?: number;
+  theta?: number;
+  vega?: number;
 }
 
-function legPayoff(leg: WorkbenchLeg, spot: number): number {
-  const intrinsic = leg.type === "call" ? Math.max(0, spot - leg.strike) : Math.max(0, leg.strike - spot);
+export interface ExpirationPayoffSummary {
+  scenarios: Array<{ spot: number; pnl: number }>;
+  maxProfit: number | "unlimited";
+  maxLoss: number | "unlimited";
+  breakevens: number[];
+  rightTailSlope: number;
+  exactForSameExpiration: true;
+}
+
+function legPayoff(leg: WorkbenchLeg & { premium: number }, spot: number): number {
+  const intrinsic =
+    leg.type === "call" ? Math.max(0, spot - leg.strike) : Math.max(0, leg.strike - spot);
   const signed = leg.action === "buy" ? 1 : -1;
   return signed * (intrinsic - Number(leg.premium)) * (leg.ratioQuantity ?? 1) * 100;
 }
 
-function resolvePremium(leg: WorkbenchLeg, mode: "natural" | "mid"): number {
+export function resolvePremium(leg: WorkbenchLeg, mode: "natural" | "mid"): number {
   if (Number.isFinite(leg.premium)) return Number(leg.premium);
-  const bid = Number(leg.bid), ask = Number(leg.ask), mark = Number(leg.mark);
+  const bid = Number(leg.bid),
+    ask = Number(leg.ask),
+    mark = Number(leg.mark);
   if (mode === "natural") {
     const natural = leg.action === "buy" ? ask : bid;
     if (Number.isFinite(natural)) return natural;
@@ -29,6 +44,66 @@ function resolvePremium(leg: WorkbenchLeg, mode: "natural" | "mid"): number {
   if (Number.isFinite(bid) && Number.isFinite(ask)) return (bid + ask) / 2;
   if (Number.isFinite(mark)) return mark;
   throw new Error(`Leg ${leg.id} needs premium, mark, or a usable bid/ask`);
+}
+
+/**
+ * Exact same-expiration payoff envelope from resolved premiums.
+ * Shared by the options workbench and strategy-quote pricing summary.
+ */
+export function computeExpirationPayoff(input: {
+  legs: Array<WorkbenchLeg & { premium: number }>;
+  quantity?: number;
+  underlyingPrice?: number;
+}): ExpirationPayoffSummary {
+  if (!input.legs.length) throw new Error("Expiration payoff requires at least one leg");
+  const quantity = input.quantity ?? 1;
+  const legs = input.legs;
+  const strikes = legs.map((leg) => leg.strike);
+  const breakpoints = [...new Set([0, ...strikes])].sort((a, b) => a - b);
+  const payoffAt = (spot: number) =>
+    Number((legs.reduce((sum, leg) => sum + legPayoff(leg, spot), 0) * quantity).toFixed(2));
+  const scenarioSpots = [
+    ...new Set([
+      ...breakpoints,
+      ...(Number.isFinite(input.underlyingPrice) ? [Number(input.underlyingPrice)] : []),
+    ]),
+  ].sort((a, b) => a - b);
+  const scenarios = scenarioSpots.map((spot) => ({ spot, pnl: payoffAt(spot) }));
+  const breakpointValues = breakpoints.map(payoffAt);
+  const rightTailSlope = legs.reduce(
+    (sum, leg) =>
+      sum +
+      (leg.type === "call"
+        ? (leg.action === "buy" ? 1 : -1) * (leg.ratioQuantity ?? 1) * quantity * 100
+        : 0),
+    0,
+  );
+  const maxProfit: number | "unlimited" =
+    rightTailSlope > 0 ? "unlimited" : Math.max(...breakpointValues);
+  const maxLoss: number | "unlimited" =
+    rightTailSlope < 0 ? "unlimited" : Math.abs(Math.min(...breakpointValues, 0));
+  const breakevens: number[] = [];
+  for (let i = 0; i < breakpoints.length - 1; i += 1) {
+    const x1 = breakpoints[i]!,
+      x2 = breakpoints[i + 1]!,
+      y1 = payoffAt(x1),
+      y2 = payoffAt(x2);
+    if (y1 === 0) breakevens.push(x1);
+    if (y1 * y2 < 0)
+      breakevens.push(Number((x1 + ((0 - y1) * (x2 - x1)) / (y2 - y1)).toFixed(4)));
+  }
+  const lastX = breakpoints.at(-1)!,
+    lastY = payoffAt(lastX);
+  if (rightTailSlope !== 0 && lastY * rightTailSlope < 0)
+    breakevens.push(Number((lastX - lastY / rightTailSlope).toFixed(4)));
+  return {
+    scenarios,
+    maxProfit,
+    maxLoss,
+    breakevens,
+    rightTailSlope,
+    exactForSameExpiration: true,
+  };
 }
 
 /** Pure options package analysis. Review/collateral responses stay body-bound to this exact leg set. */
@@ -46,31 +121,66 @@ export function buildOptionsWorkbench(input: {
 }) {
   if (!input.legs.length) throw new Error("Options workbench requires at least one leg");
   const quantity = input.quantity ?? 1;
-  const legs = input.legs.map((leg) => ({ ...leg, premium: resolvePremium(leg, input.pricingMode ?? "mid") }));
-  const strikes = legs.map((leg) => leg.strike);
-  const breakpoints = [...new Set([0, ...strikes])].sort((a, b) => a - b);
-  const payoffAt = (spot: number) => Number((legs.reduce((sum, leg) => sum + legPayoff(leg, spot), 0) * quantity).toFixed(2));
-  const payoff = [...new Set([...breakpoints, input.underlyingPrice])].sort((a, b) => a - b).map((spot) => ({ spot, pnl: payoffAt(spot) }));
-  const breakpointValues = breakpoints.map(payoffAt);
-  const rightTailSlope = legs.reduce((sum, leg) => sum + (leg.type === "call" ? (leg.action === "buy" ? 1 : -1) * (leg.ratioQuantity ?? 1) * quantity * 100 : 0), 0);
-  const maxProfit: number | "unlimited" = rightTailSlope > 0 ? "unlimited" : Math.max(...breakpointValues);
-  const maxLoss: number | "unlimited" = rightTailSlope < 0 ? "unlimited" : Math.abs(Math.min(...breakpointValues, 0));
-  const breakevens: number[] = [];
-  for (let i = 0; i < breakpoints.length - 1; i += 1) {
-    const x1 = breakpoints[i]!, x2 = breakpoints[i + 1]!, y1 = payoffAt(x1), y2 = payoffAt(x2);
-    if (y1 === 0) breakevens.push(x1);
-    if (y1 * y2 < 0) breakevens.push(Number((x1 + (0 - y1) * (x2 - x1) / (y2 - y1)).toFixed(4)));
-  }
-  const lastX = breakpoints.at(-1)!, lastY = payoffAt(lastX);
-  if (rightTailSlope !== 0 && lastY * rightTailSlope < 0) breakevens.push(Number((lastX - lastY / rightTailSlope).toFixed(4)));
-  const greek = (name: "delta"|"gamma"|"theta"|"vega") => Number((legs.reduce((sum, leg) => sum + (leg.action === "buy" ? 1 : -1) * Number(leg[name] ?? 0) * (leg.ratioQuantity ?? 1) * quantity * 100, 0)).toFixed(6));
-  const bodyHash = input.orderBody === undefined ? null : createHash("sha256").update(JSON.stringify(input.orderBody)).digest("hex");
+  const legs = input.legs.map((leg) => ({
+    ...leg,
+    premium: resolvePremium(leg, input.pricingMode ?? "mid"),
+  }));
+  const payoff = computeExpirationPayoff({
+    legs,
+    quantity,
+    underlyingPrice: input.underlyingPrice,
+  });
+  const greek = (name: "delta" | "gamma" | "theta" | "vega") =>
+    Number(
+      (
+        legs.reduce(
+          (sum, leg) =>
+            sum +
+            (leg.action === "buy" ? 1 : -1) *
+              Number(leg[name] ?? 0) *
+              (leg.ratioQuantity ?? 1) *
+              quantity *
+              100,
+          0,
+        )
+      ).toFixed(6),
+    );
+  const bodyHash =
+    input.orderBody === undefined
+      ? null
+      : createHash("sha256").update(JSON.stringify(input.orderBody)).digest("hex");
   return {
     contract: { symbol: input.symbol.toUpperCase(), expiration: input.expiration, quantity, legs },
-    package: { pricingMode: input.pricingMode ?? "mid", netPremium: Number((legs.reduce((sum, leg) => sum + (leg.action === "sell" ? 1 : -1) * Number(leg.premium) * (leg.ratioQuantity ?? 1) * 100, 0) * quantity).toFixed(2)) },
-    payoff: { scenarios: payoff, maxProfit, maxLoss, breakevens, rightTailSlope, exactForSameExpiration: true },
-    netGreeks: { delta: greek("delta"), gamma: greek("gamma"), theta: greek("theta"), vega: greek("vega") },
-    approvalCard: { body: input.orderBody ?? null, bodySha256: bodyHash, collateral: input.collateral ?? null, review: input.review ?? null, bodyBound: Boolean(input.orderBody) },
-    rollAlternatives: input.rollAlternatives ?? []
+    package: {
+      pricingMode: input.pricingMode ?? "mid",
+      netPremium: Number(
+        (
+          legs.reduce(
+            (sum, leg) =>
+              sum +
+              (leg.action === "sell" ? 1 : -1) *
+                Number(leg.premium) *
+                (leg.ratioQuantity ?? 1) *
+                100,
+            0,
+          ) * quantity
+        ).toFixed(2),
+      ),
+    },
+    payoff,
+    netGreeks: {
+      delta: greek("delta"),
+      gamma: greek("gamma"),
+      theta: greek("theta"),
+      vega: greek("vega"),
+    },
+    approvalCard: {
+      body: input.orderBody ?? null,
+      bodySha256: bodyHash,
+      collateral: input.collateral ?? null,
+      review: input.review ?? null,
+      bodyBound: Boolean(input.orderBody),
+    },
+    rollAlternatives: input.rollAlternatives ?? [],
   };
 }

--- a/cli/test/financial-tools.test.ts
+++ b/cli/test/financial-tools.test.ts
@@ -603,7 +603,7 @@ describe("computeRisk — portfolio risk scanner", () => {
     expect(pos.undercoveredShortLegs).toBe(0);
   });
 
-  it("defined-risk credit spread (short call + long call) has maxLoss that does not crash", async () => {
+  it("defined-risk credit spread (short call + long call) models maxLoss from wing width", async () => {
     const fix = buildFixture({
       accounts: { results: [{ type: "rhs", account_number: "333333333", account_name: "SpreadAcct" }] },
       positions: { "333333333": [] },
@@ -611,7 +611,7 @@ describe("computeRisk — portfolio risk scanner", () => {
         "333333333": [
           {
             symbol: "XYZ", strategy: "short call spread", quantity: "1",
-            average_open_price: "1.50", // net credit received
+            average_open_price: "150.00", // net $1.50/sh credit → $150 per contract
             legs: [
               { option_id: "optShort", position_type: "short", option_type: "call", strike_price: "100.0000", expiration_date: "2026-09-19", ratio_quantity: "1" },
               { option_id: "optLong",  position_type: "long",  option_type: "call", strike_price: "105.0000", expiration_date: "2026-09-19", ratio_quantity: "1" }
@@ -629,9 +629,8 @@ describe("computeRisk — portfolio risk scanner", () => {
     const r = await computeRisk({}, fix);
     const pos = r.positions.find(p => p.kind === "option" && p.symbol === "XYZ")!;
     expect(pos).toBeTruthy();
-    // Spread has at least one short leg → maxLoss null (defined-risk left unmodeled), but it must be
-    // positively classified so the CLI renders "defined-risk", never "unlimited".
-    expect(pos.maxLossUsd).toBeNull();
+    // Call credit: width $5 → $500, credit $150 → max loss $350. Still labeled defined-spread.
+    expect(pos.maxLossUsd).toBe(350);
     expect(pos.riskClass).toBe("defined-spread");
   });
 

--- a/cli/test/lib.test.ts
+++ b/cli/test/lib.test.ts
@@ -8,6 +8,7 @@ import {
   classifyMoneyness,
   classifyRobinhoodError,
   collarSanity,
+  computeVerticalDefinedMaxLossUsd,
   selectRouteByQueryAndMethod,
   executeBrokerageRequest,
   executeCryptoRequest,
@@ -317,7 +318,102 @@ describe("Robinhood API map", () => {
     expect(pricing.limitPrice).toBeCloseTo(200.7);
     expect(pricing.netGreeks.delta).toBeCloseTo(-20);
     expect(pricing.netGreeks.theta).toBeCloseTo(2);
+    expect(pricing.payoff).toBeUndefined();
     expect(pricing.warnings.join("\n")).toContain("safe-sell-probe");
+  });
+
+  it("attaches same-expiration payoff when every leg has optionType + strike", () => {
+    const pricing = buildOptionsStrategyPricingSummary({
+      mode: "mid",
+      preferredDirection: "credit",
+      quantity: 1,
+      legs: [
+        {
+          id: "short_call",
+          action: "sell",
+          optionType: "call",
+          strike: 105,
+          ratioQuantity: 1,
+          bid: 2.9,
+          ask: 3.1,
+          mark: 3,
+        },
+        {
+          id: "long_call",
+          action: "buy",
+          optionType: "call",
+          strike: 110,
+          ratioQuantity: 1,
+          bid: 0.9,
+          ask: 1.1,
+          mark: 1,
+        },
+      ],
+    });
+
+    expect(pricing.payoff).toBeDefined();
+    expect(pricing.payoff!.maxProfit).toBe(200);
+    expect(pricing.payoff!.maxLoss).toBe(300);
+    expect(pricing.payoff!.breakevens.length).toBeGreaterThan(0);
+    expect(pricing.payoff!.pricingBasis).toBe("mid");
+    expect(pricing.payoff!.exactForSameExpiration).toBe(true);
+  });
+
+  it("marks naked short-call payoff as unlimited loss", () => {
+    const pricing = buildOptionsStrategyPricingSummary({
+      mode: "natural",
+      legs: [
+        {
+          id: "short_call",
+          action: "sell",
+          optionType: "call",
+          strike: 100,
+          bid: 2,
+          ask: 2.1,
+        },
+      ],
+    });
+    expect(pricing.payoff?.maxLoss).toBe("unlimited");
+  });
+
+  it("computeVerticalDefinedMaxLossUsd models call/put credit and debit verticals", () => {
+    expect(
+      computeVerticalDefinedMaxLossUsd({
+        legs: [
+          { side: "short", type: "call", strike: 100 },
+          { side: "long", type: "call", strike: 105 },
+        ],
+        averageOpenPricePerContract: 150,
+        quantity: 1,
+      }),
+    ).toBe(350);
+    expect(
+      computeVerticalDefinedMaxLossUsd({
+        legs: [
+          { side: "short", type: "put", strike: 95 },
+          { side: "long", type: "put", strike: 90 },
+        ],
+        averageOpenPricePerContract: 100,
+        quantity: 2,
+      }),
+    ).toBe(800); // (5*100 - 100) * 2
+    expect(
+      computeVerticalDefinedMaxLossUsd({
+        legs: [
+          { side: "long", type: "call", strike: 100 },
+          { side: "short", type: "call", strike: 105 },
+        ],
+        averageOpenPricePerContract: 200,
+        quantity: 1,
+      }),
+    ).toBe(200); // debit vertical: max loss = debit
+    expect(
+      computeVerticalDefinedMaxLossUsd({
+        legs: [{ side: "short", type: "call", strike: 100 }],
+        averageOpenPricePerContract: 150,
+        quantity: 1,
+      }),
+    ).toBeNull();
   });
 
   it("prices option debit spreads from ask paid and bid received", () => {

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -3302,13 +3302,14 @@ server.registerTool(
   {
     title: "Robinhood Options Strategy Quote",
     description:
-      "Multi-leg live pricing for an options strategy (verticals, condors, straddles, etc.). Takes leg inputs (id, action: buy|sell, strike, bid/ask/mark/last, greeks, ratioQuantity) and returns per-leg natural/mid pricing, net credit/debit, direction, and limit-price recommendations by mode (natural/mid/safe-sell-probe/safe-buy-probe). Wraps the shared buildOptionsStrategyPricingSummary() engine — same as the CLI `options strategy-quote` command. Live reads happen BEFORE calling this tool (fetch quotes/greeks separately); this tool does pure math. Read-only; no gate.",
+      "Multi-leg live pricing for an options strategy (verticals, condors, straddles, etc.). Takes leg inputs (id, action: buy|sell, optional optionType/strike, bid/ask/mark/last, greeks, ratioQuantity) and returns per-leg natural/mid pricing, net credit/debit, direction, limit-price recommendations by mode (natural/mid/safe-sell-probe/safe-buy-probe), and — when every leg includes optionType + strike — same-expiration max profit / max loss / breakevens. Wraps the shared buildOptionsStrategyPricingSummary() engine — same as the CLI `options strategy-quote` command. Live reads happen BEFORE calling this tool (fetch quotes/greeks separately); this tool does pure math. Read-only; no gate.",
     inputSchema: z.object({
       legs: z
         .array(
           z.object({
             id: z.string(),
             action: z.enum(["buy", "sell"]),
+            optionType: z.enum(["call", "put"]).optional(),
             strike: z.number().optional(),
             bid: z.number().optional(),
             ask: z.number().optional(),
@@ -3326,15 +3327,18 @@ server.registerTool(
       mode: z.enum(["natural", "mid", "safe-sell-probe", "safe-buy-probe"]).default("mid"),
       preferredDirection: z.enum(["credit", "debit"]).optional(),
       farLimitOffset: z.number().default(200),
+      quantity: z.number().int().positive().default(1),
+      underlyingPrice: z.number().optional(),
     }),
     annotations: toolAnnotations(true, "read"),
   },
-  async ({ legs, mode, preferredDirection, farLimitOffset }) => {
+  async ({ legs, mode, preferredDirection, farLimitOffset, quantity, underlyingPrice }) => {
     try {
       const summary = buildOptionsStrategyPricingSummary({
         legs: legs.map((leg) => ({
           id: leg.id,
           action: leg.action,
+          optionType: leg.optionType,
           strike: leg.strike,
           bid: leg.bid,
           ask: leg.ask,
@@ -3350,6 +3354,8 @@ server.registerTool(
         mode,
         preferredDirection,
         farLimitOffset,
+        quantity,
+        underlyingPrice,
       });
       return jsonResponse(summary);
     } catch (e: any) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Real engine upgrades (not docs/path sync):

1. **Strategy-quote expiration payoff** — Shared `computeExpirationPayoff` (from the options workbench) is now attached to `buildOptionsStrategyPricingSummary` when every leg has `optionType` + `strike`. CLI `options strategy-quote` prints max profit / max loss / breakevens and includes them in JSON; MCP `robinhood_options_strategy_quote` accepts `optionType` / `quantity` / `underlyingPrice` and returns the same `payoff` object.

2. **Defined-risk vertical max loss in `risk`** — Simple same-type verticals (one short + one long, equal ratio) now get a numeric `maxLossUsd` from wing width − net credit (or debit paid), while keeping `riskClass: "defined-spread"`. Iron condors / ratio spreads stay unmodeled.

## New behavior vs main

| Surface | Before | After |
| --- | --- | --- |
| `options strategy-quote` human output | Net premium + limit only | Also prints max profit / max loss / breakevens |
| Strategy pricing JSON / MCP | Pricing + Greeks only | Optional `payoff` envelope when strikes/types present |
| `risk` on a call/put credit vertical | `maxLossUsd: null` ("defined-risk" label) | Dollar max loss from width − credit |

## Safety

- Read/plan math only — no live writes, no gate changes.
- CLI and MCP share `buildOptionsStrategyPricingSummary` / `computeVerticalDefinedMaxLossUsd`.

## Verification

- Local: CLI/MCP build, focused + full vitest, ESLint ratchet 364/364, format/deadcode/api-map/skill/portability
- CI: prior failure was ESLint ratchet (+2 warnings); fixed in `2b31e3c`

## Test plan

- [x] Unit: payoff attached / omitted / unlimited short call
- [x] Unit: vertical max-loss helper (call/put credit + debit)
- [x] Unit: `computeRisk` credit-spread fixture expects $350 max loss
- [x] Full CLI + MCP test suites green
- [x] ESLint ratchet at baseline

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cff0405d-ee9a-47bb-a160-1a13bd1dcb25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cff0405d-ee9a-47bb-a160-1a13bd1dcb25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

