### PR TITLE
security: harden public privacy defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ git-crypt-key
 _local-backups-*/
 /_*.json
 
+# local exact-value denylist for the public portability scan
+.private-portability-values
+
 # private runtime output (the rest of local/ is intentionally git-crypt tracked)
 local/portfolio-snapshots.jsonl
 local/legacy-reports/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,10 +1,7 @@
 title = "Robinhood CLI secret scanning allowlist"
 
 [allowlist]
-description = "Ignored local auth files and a public discovery-list UUID are not credentials"
-paths = [
-  '''(^|/)\.env(\.bak)?$''',
-]
+description = "A public discovery-list UUID is not a credential"
 regexes = [
   '''8ce9f620-5bb0-4b6a-8c61-5a06763f7a8b''',
 ]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+This project can access and, when explicitly armed, mutate a live brokerage account. Treat authentication material, account data, order evidence, downloaded documents, and private route captures as sensitive.
+
+## Supported versions
+
+Security fixes target the latest commit on `main` and the latest tagged release. Older revisions may not receive backports.
+
+## Report vulnerabilities privately
+
+Use the repository's GitHub **Security** tab and private vulnerability reporting or a draft security advisory when that option is available.
+
+Never place any of the following in a public issue, pull request, discussion, or screenshot:
+
+- browser-session or brokerage bearer tokens
+- cookies, authorization headers, MFA or challenge data, device identifiers, or API/private keys
+- account numbers, balances, positions, order IDs, signed document URLs, or downloaded statements
+- unsanitized CDP captures, `.env` files, logs, or local operator ledgers
+- an exploit that could bypass a live-write, account-lock, notional-cap, provenance, deduplication, or idempotency guard
+
+If private reporting is unavailable, open a public issue containing only a request for a private contact channel. Do not include vulnerability details or sensitive data.
+
+## High-priority security scope
+
+Reports are especially important when they involve:
+
+- bypassing dry-run or `ROBINHOOD_ALLOW_LIVE_WRITE` controls
+- sending a mutation to an unapproved account or inferred/unverified route
+- duplicate order execution, unsafe retry behavior, or incorrect outcome evidence
+- credential, account, document, or signed-URL disclosure
+- path traversal or unsafe file writes in download/export flows
+- redaction failures in share-safe output or public fixtures
+- command, argument, URL, or request-body injection
+
+## Safe validation
+
+Use synthetic fixtures, local tests, and dry-run request bodies. Do not authenticate to another person's account. Do not submit, cancel, or modify a real order or account setting while validating a report unless the account owner has explicitly approved the exact account, operation, instrument, quantity, and limit.
+
+When sharing a reproduction privately, minimize the payload and replace all real identifiers and values with synthetic equivalents whenever possible.

--- a/scripts/check-public-portability.mjs
+++ b/scripts/check-public-portability.mjs
@@ -1,25 +1,112 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 
-const forbidden = [
-  { label: "private machine name", pattern: /\b(?:mothership|frostbyte|tracer)\b/i },
-  { label: "private Windows user path", pattern: /C:[\\/]Users[\\/]ZaydK/i },
-  { label: "private macOS user path", pattern: /\/Users\/zaydk/i },
-  {
-    label: "private Tailscale address",
-    pattern: /\b(?:100\.122\.197\.2|100\.84\.176\.61|100\.73\.83\.101|100\.86\.179\.58)\b/,
-  },
-];
+const LOCAL_DENYLIST_PATH = ".private-portability-values";
+const SCANNER_PATH = "scripts/check-public-portability.mjs";
 
+function isPlaceholderUser(segment) {
+  const raw = String(segment).trim();
+  if (!raw) return true;
+  if (/^(?:<[^>]+>|%[^%]+%|\$\{?[^}\/]+\}?|\[[^\]]+\])$/.test(raw)) return true;
+  const normalized = raw.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  return [
+    "user",
+    "username",
+    "youruser",
+    "yourusername",
+    "example",
+    "exampleuser",
+    "sample",
+    "sampleuser",
+  ].includes(normalized);
+}
+
+function containsPrivateUserPath(line) {
+  const patterns = [
+    /C:[\\/]Users[\\/]([^\\/\s"'`]+)/gi,
+    /(?:^|[\s"'`=(])\/Users\/([^/\s"'`]+)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of line.matchAll(pattern)) {
+      if (!isPlaceholderUser(match[1])) return true;
+    }
+  }
+  return false;
+}
+
+function containsPrivateNetworkAddress(line) {
+  const ipv4 = /\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g;
+  for (const match of line.matchAll(ipv4)) {
+    const octets = match.slice(1, 5).map(Number);
+    if (octets.some((octet) => octet > 255)) continue;
+    const end = (match.index ?? 0) + match[0].length;
+    if (line[end] === "/") continue; // CIDR documentation is not a host leak.
+    if (octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127) return true;
+  }
+  return false;
+}
+
+function loadExactPrivateValues() {
+  const values = [];
+  const addLines = (text) => {
+    for (const line of text.split(/\r?\n/)) {
+      const value = line.trim();
+      if (value && !value.startsWith("#")) values.push(value);
+    }
+  };
+
+  if (process.env.ROBINHOOD_PRIVATE_PORTABILITY_VALUES) {
+    addLines(process.env.ROBINHOOD_PRIVATE_PORTABILITY_VALUES);
+  }
+  if (existsSync(LOCAL_DENYLIST_PATH)) addLines(readFileSync(LOCAL_DENYLIST_PATH, "utf8"));
+  return [...new Set(values)];
+}
+
+function buildForbiddenRules(exactValues = []) {
+  return [
+    { label: "private absolute user path", test: containsPrivateUserPath },
+    { label: "private CGNAT/Tailscale host address", test: containsPrivateNetworkAddress },
+    ...exactValues.map((value, index) => ({
+      label: `local private value ${index + 1}`,
+      test: (line) => line.toLowerCase().includes(value.toLowerCase()),
+    })),
+  ];
+}
+
+function runRuleSelfChecks() {
+  const genericRules = buildForbiddenRules();
+  const flagged = (line, rules = genericRules) => rules.some((rule) => rule.test(line));
+  const cases = [
+    ["C:\\Users\\alice\\project", true],
+    ["/Users/alice/project", true],
+    ["C:\\Users\\<username>\\project", false],
+    ["/Users/$USER/project", false],
+    ["host 100.100.20.30", true],
+    ["CGNAT range 100.64.0.0/10", false],
+    ["public host 100.128.0.1", false],
+  ];
+  for (const [line, expected] of cases) {
+    if (flagged(line) !== expected) {
+      throw new Error(`Portability scanner self-check failed: ${line}`);
+    }
+  }
+  if (!flagged("connect to private-workstation", buildForbiddenRules(["private-workstation"]))) {
+    throw new Error("Portability scanner exact-value self-check failed");
+  }
+}
+
+runRuleSelfChecks();
+
+const forbidden = buildForbiddenRules(loadExactPrivateValues());
 const tracked = execFileSync("git", ["ls-files", "-z"], { encoding: "utf8" })
   .split("\0")
   .filter(Boolean)
   // local/ is git-crypt-backed private operator state, not public source.
   .filter((path) => !path.startsWith("local/"))
-  // The scanner necessarily contains its own denylist literals.
-  .filter((path) => path !== "scripts/check-public-portability.mjs");
+  // This file contains synthetic scanner self-check fixtures.
+  .filter((path) => path !== SCANNER_PATH);
 
 const findings = [];
 for (const path of tracked) {
@@ -42,9 +129,7 @@ for (const path of tracked) {
   const lines = text.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     for (const rule of forbidden) {
-      if (rule.pattern.test(lines[index])) {
-        findings.push(`${path}:${index + 1}: ${rule.label}`);
-      }
+      if (rule.test(lines[index])) findings.push(`${path}:${index + 1}: ${rule.label}`);
     }
   }
 }
@@ -55,4 +140,6 @@ if (findings.length) {
   process.exit(1);
 }
 
-console.log(`Public portability check passed (${tracked.length} tracked files scanned).`);
+console.log(
+  `Public portability check passed (${tracked.length} tracked files scanned; ${forbidden.length - 2} local exact-value rule(s)).`,
+);


### PR DESCRIPTION
## Summary

This patch fixes three public-repository privacy and disclosure problems:

1. The portability checker stored the exact private identifiers it was intended to keep out of public source.
2. `.gitleaks.toml` exempted `.env` and `.env.bak`, weakening detection if either file were accidentally committed.
3. The repository had no security-reporting policy despite handling live brokerage credentials and mutations.

The scanner now uses:

- generic detection for non-placeholder Windows and macOS user paths
- generic detection for host addresses inside the private CGNAT/Tailscale range, while allowing CIDR documentation
- an optional ignored `.private-portability-values` file for exact local machine names or other operator-specific strings
- optional newline-separated `ROBINHOOD_PRIVATE_PORTABILITY_VALUES` input for CI or local shells
- built-in rule self-checks that fail closed when scanner logic regresses

Secret scanning no longer exempts auth files, and `SECURITY.md` directs reporters to private disclosure while explicitly prohibiting public tokens, account data, order evidence, signed URLs, or unsanitized captures.

## Validation

CI run 290 passed on the current head (`4a10bfddc6b8da7e3390aeaaab7a5652ed39a26a`):

- quality and high-severity dependency-audit gates passed
- build, typecheck, and full Vitest suites passed on Node 20 and 22 across Linux, macOS, and Windows
- coverage ratchet passed on Linux/Node 20
- generated API-map verification passed

The portability scanner was also exercised in a temporary Git repository: placeholder paths passed; real-looking absolute user paths and private-range host addresses failed; CIDR documentation passed; and the ignored exact-value denylist caught a synthetic machine name without printing it.

## Scope

- no Robinhood API, authentication implementation, route-map, order, or live-write code changed
- no real private values were added to the patch
