### PR TITLE
fix: make the package root safe to import

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -6,11 +6,11 @@
   "bin": {
     "robinhood-cli": "dist/index.js"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/lib.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.js"
     },
     "./lib": {
       "types": "./dist/lib.d.ts",

--- a/cli/test/package-boundary.test.ts
+++ b/cli/test/package-boundary.test.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+interface PackageManifest {
+  bin: Record<string, string>;
+  types: string;
+  exports: Record<string, { types: string; import: string }>;
+}
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(
+  readFileSync(join(packageRoot, "package.json"), "utf8"),
+) as PackageManifest;
+
+describe("published package boundary", () => {
+  it("keeps the executable and library entrypoints separate", () => {
+    expect(manifest.bin["robinhood-cli"]).toBe("dist/index.js");
+    expect(manifest.types).toBe("./dist/lib.d.ts");
+    expect(manifest.exports["."]).toEqual({
+      types: "./dist/lib.d.ts",
+      import: "./dist/lib.js",
+    });
+    expect(manifest.exports["./lib"]).toEqual(manifest.exports["."]);
+  });
+
+  it("imports the built package root without parsing the host process arguments", () => {
+    const runtimeTarget = manifest.exports["."]?.import;
+    expect(runtimeTarget).toBeDefined();
+    const runtimePath = join(packageRoot, runtimeTarget.replace(/^\.\//, ""));
+
+    // The workspace CI builds before running Vitest. A direct source-only test still validates
+    // the manifest contract above without creating build artifacts as a test side effect.
+    if (!existsSync(runtimePath)) return;
+
+    const importScript = `const mod = await import(${JSON.stringify(pathToFileURL(runtimePath).href)}); if (typeof mod.repositoryRoot !== "function") process.exit(2);`;
+    const child = spawnSync(
+      process.execPath,
+      ["--input-type=module", "--eval", importScript, "--", "--definitely-not-a-cli-command"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+        env: { ...process.env, ROBINHOOD_ALLOW_LIVE_WRITE: "0" },
+        timeout: 10_000,
+      },
+    );
+
+    expect(child.error).toBeUndefined();
+    expect(child.status, child.stderr).toBe(0);
+  });
+});

--- a/cli/test/package-boundary.test.ts
+++ b/cli/test/package-boundary.test.ts
@@ -28,7 +28,7 @@ describe("published package boundary", () => {
 
   it("imports the built package root without parsing the host process arguments", () => {
     const runtimeTarget = manifest.exports["."]?.import;
-    expect(runtimeTarget).toBeDefined();
+    if (!runtimeTarget) throw new Error("Package root is missing a runtime export");
     const runtimePath = join(packageRoot, runtimeTarget.replace(/^\.\//, ""));
 
     // The workspace CI builds before running Vitest. A direct source-only test still validates


### PR DESCRIPTION
## Summary

The published package root currently resolves to `dist/index.js`, which is the executable CLI entrypoint. That module immediately parses `process.argv`, so importing `@zaydiscold/robinhood-cli` as a library can make Commander consume the host application's arguments and set an error exit code.

This patch:

- keeps the `robinhood-cli` binary pointed at `dist/index.js`
- points the package root and top-level TypeScript declarations at `dist/lib.js` / `dist/lib.d.ts`
- preserves the existing `@zaydiscold/robinhood-cli/lib` compatibility export
- adds a package-boundary regression test that imports the built root while passing a deliberately invalid CLI argument; the import must succeed without invoking the CLI parser

## Validation

CI run 291 passed on the current head (`9f7cb414982365059c7c34668d5dc8afdf2e6399`):

- quality and high-severity dependency-audit gates passed
- build, typecheck, and full Vitest suites passed on Node 20 and 22 across Linux, macOS, and Windows
- the package-root child-process import smoke test passed across the matrix
- coverage ratchet passed on Linux/Node 20
- generated API-map verification passed

The child-process probe was also verified locally against a synthetic ESM library target.

## Scope

- no command behavior, brokerage request, auth, route-map, order, or live-write implementation changed
- this changes the programmatic package root only; the installed CLI binary remains unchanged
