### PR TITLE
test: enforce the CLI/MCP surface contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  secrets:
+    name: secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+
   quality:
     name: quality gates
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,11 @@
-title = "Robinhood CLI secret scanning allowlist"
+title = "Robinhood CLI secret scanning configuration"
 
-[allowlist]
+# A repository-local config replaces Gitleaks' built-in rules unless it explicitly extends them.
+# Keep the full default detector set, then add only narrow project-specific allowlists below.
+[extend]
+useDefault = true
+
+[[allowlists]]
 description = "A public discovery-list UUID is not a credential"
 regexes = [
   '''8ce9f620-5bb0-4b6a-8c61-5a06763f7a8b''',


### PR DESCRIPTION
## Summary

This adds a machine-enforced and human-readable contract for the repository's product and trust surfaces.

The executable audit now fails when:

- root, CLI, and MCP versions drift
- Node runtime promises drift between workspace packages
- the CLI binary and importable library entrypoints are accidentally recombined
- capability IDs, MCP tool names, or CLI capability labels collide
- an MCP capability is present in the typed registry but absent from the server source
- a CLI capability is present in the registry but absent from the CLI adapter
- capability-profile resolution stops returning booleans

It runs before the built Vitest suites in every Node/OS matrix job and is also available as `pnpm surface:audit`.

The patch also:

- aligns CLI and MCP engine declarations with the root `>=20.19` contract
- adds an MCP version-contract test tying the advertised server version to all package versions
- adds `docs/surface-map.md`, covering trust boundaries, feature families, external interfaces, cross-surface invariants, and current concentration risks

## Scope

No brokerage request, authentication, account-data, route-map, order, cancellation, setting, or live-write behavior changed.