### PR TITLE
fix: redact order reference identifiers from share-safe output

### DIFF
--- a/cli/src/share-safe.ts
+++ b/cli/src/share-safe.ts
@@ -1,5 +1,5 @@
 const SENSITIVE_KEY =
-  /(?:balance|buying[_-]?power|cash|equity|order(?:[_-]?id)?|document(?:[_-]?url)?|private[_-]?(?:note|key)|password|passcode|secret|credential|api[_-]?key|access[_-]?key|token|authorization|bearer|cookie|session[_-]?(?:id|key|token)|mfa|otp|challenge|device[_-]?id|ssn|tax[_-]?id)/i;
+  /(?:balance|buying[_-]?power|cash|equity|order(?:[_-]?id)?|client[_-]?order[_-]?id|ref(?:erence)?[_-]?id|idempotency[_-]?key|document(?:[_-]?url)?|private[_-]?(?:note|key)|password|passcode|secret|credential|api[_-]?key|access[_-]?key|token|authorization|bearer|cookie|session[_-]?(?:id|key|token)|mfa|otp|challenge|device[_-]?id|ssn|tax[_-]?id)/i;
 const URL_KEY = /(?:url|uri|href|download|document|link)/i;
 const SIGNED_URL =
   /(?:X-(?:Amz|Goog)-(?:Signature|Credential)|(?:^|[?&])(?:signature|sig|token|access_token|jwt|download_url)=)/i;

--- a/cli/test/safety-edge-cases.test.ts
+++ b/cli/test/safety-edge-cases.test.ts
@@ -154,6 +154,11 @@ describe("safety edge cases", () => {
       sessionId: "session-secret",
       token: "987654321",
       deviceId: "device-secret-value",
+      refId: "AAPL-123456789-1787540000000",
+      ref_id: "AAPL-123456789-1787540000001",
+      referenceId: "reference-with-account-123456789",
+      clientOrderId: "client-order-123456789",
+      idempotencyKey: "idempotency-123456789",
       downloadLink: "https://files.test/report?X-Goog-Signature=secret",
       callbackUrl: "https://app.test/callback?access_token=secret",
     });
@@ -175,6 +180,11 @@ describe("safety edge cases", () => {
       sessionId: "[REDACTED]",
       token: "[REDACTED]",
       deviceId: "[REDACTED]",
+      refId: "[REDACTED]",
+      ref_id: "[REDACTED]",
+      referenceId: "[REDACTED]",
+      clientOrderId: "[REDACTED]",
+      idempotencyKey: "[REDACTED]",
       downloadLink: "[REDACTED_URL]",
       callbackUrl: "[REDACTED_URL]",
     });


### PR DESCRIPTION
## Summary

The equity order engine currently emits client reference IDs that include the full account number. Share-safe output masks the `account` field, but it did not classify `refId`, `ref_id`, `referenceId`, client order IDs, or idempotency keys as sensitive. That allowed the same account identifier to survive inside an order-reference field.

This patch expands share-safe key normalization and redaction for:

- `refId`, `ref_id`, and `referenceId`
- client order IDs
- idempotency keys

Regression coverage uses reference values containing a full account number and requires complete redaction.

## Validation

CI run 297 passed on head `a257eaf513aa2a14da35b81ba5fac29b98f20f29`:

- quality and high-severity dependency-audit gates passed
- build, typecheck, and full Vitest suites passed on Node 20 and 22 across Linux, macOS, and Windows
- coverage ratchet passed on Linux/Node 20
- generated API-map verification passed

## Scope

No order construction, brokerage request, auth, route-map, or live-write behavior changed. This is output-boundary hardening only.