### PR TITLE
feat: expose option Greek input coverage

### DIFF
--- a/cli/src/options-workbench.ts
+++ b/cli/src/options-workbench.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 type QuoteValue = number | string | null;
+type GreekName = "delta" | "gamma" | "theta" | "vega";
 
 export interface WorkbenchLeg {
   id: string;
@@ -27,6 +28,14 @@ export interface ExpirationPayoffSummary {
   exactForSameExpiration: true;
 }
 
+export interface GreekCoverage {
+  observedLegs: number;
+  totalLegs: number;
+  complete: boolean;
+  missingLegIds: string[];
+  invalidLegIds: string[];
+}
+
 function legPayoff(leg: WorkbenchLeg & { premium: number }, spot: number): number {
   const intrinsic =
     leg.type === "call" ? Math.max(0, spot - leg.strike) : Math.max(0, leg.strike - spot);
@@ -39,6 +48,17 @@ function finiteQuote(value: unknown): number | null {
   if (typeof value === "string" && value.trim() === "") return null;
   const numeric = Number(value);
   return Number.isFinite(numeric) && numeric >= 0 ? numeric : null;
+}
+
+function isMissingNumeric(value: unknown): boolean {
+  return value === null || value === undefined || (typeof value === "string" && value.trim() === "");
+}
+
+function finiteSignedNumber(value: unknown): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
 }
 
 export function resolvePremium(leg: WorkbenchLeg, mode: "natural" | "mid"): number {
@@ -144,21 +164,46 @@ export function buildOptionsWorkbench(input: {
     quantity,
     underlyingPrice: input.underlyingPrice,
   });
-  const greek = (name: "delta" | "gamma" | "theta" | "vega") =>
-    Number(
-      legs
-        .reduce(
-          (sum, leg) =>
-            sum +
-            (leg.action === "buy" ? 1 : -1) *
-              Number(leg[name] ?? 0) *
-              (leg.ratioQuantity ?? 1) *
-              quantity *
-              100,
-          0,
-        )
-        .toFixed(6),
-    );
+  const greek = (name: GreekName) => {
+    const missingLegIds: string[] = [];
+    const invalidLegIds: string[] = [];
+    let observedLegs = 0;
+    const total = legs.reduce((sum, leg) => {
+      const raw = leg[name];
+      if (isMissingNumeric(raw)) {
+        missingLegIds.push(leg.id);
+        return sum;
+      }
+      const numeric = finiteSignedNumber(raw);
+      if (numeric === null) {
+        invalidLegIds.push(leg.id);
+        return sum;
+      }
+      observedLegs += 1;
+      return (
+        sum +
+        (leg.action === "buy" ? 1 : -1) *
+          numeric *
+          (leg.ratioQuantity ?? 1) *
+          quantity *
+          100
+      );
+    }, 0);
+    return {
+      value: Number(total.toFixed(6)),
+      coverage: {
+        observedLegs,
+        totalLegs: legs.length,
+        complete: observedLegs === legs.length,
+        missingLegIds,
+        invalidLegIds,
+      } satisfies GreekCoverage,
+    };
+  };
+  const delta = greek("delta");
+  const gamma = greek("gamma");
+  const theta = greek("theta");
+  const vega = greek("vega");
   const bodyHash =
     input.orderBody === undefined
       ? null
@@ -183,10 +228,16 @@ export function buildOptionsWorkbench(input: {
     },
     payoff,
     netGreeks: {
-      delta: greek("delta"),
-      gamma: greek("gamma"),
-      theta: greek("theta"),
-      vega: greek("vega"),
+      delta: delta.value,
+      gamma: gamma.value,
+      theta: theta.value,
+      vega: vega.value,
+    },
+    greekCoverage: {
+      delta: delta.coverage,
+      gamma: gamma.coverage,
+      theta: theta.coverage,
+      vega: vega.coverage,
     },
     approvalCard: {
       body: input.orderBody ?? null,

--- a/cli/test/options-workbench-coverage.test.ts
+++ b/cli/test/options-workbench-coverage.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildOptionsWorkbench } from "../src/lib.js";
+
+describe("options workbench Greek coverage", () => {
+  it("keeps compatible numeric totals while exposing missing and invalid inputs", () => {
+    const result = buildOptionsWorkbench({
+      symbol: "AAPL",
+      expiration: "2026-12-18",
+      underlyingPrice: 100,
+      legs: [
+        {
+          id: "lower-call",
+          action: "buy",
+          type: "call",
+          strike: 95,
+          premium: 7,
+          delta: "0.50",
+          gamma: 0.02,
+          theta: null,
+          vega: "not-a-number",
+        },
+        {
+          id: "upper-call",
+          action: "buy",
+          type: "call",
+          strike: 105,
+          premium: 2,
+          delta: -0.25,
+          gamma: "",
+          theta: -0.01,
+          vega: 0.1,
+        },
+      ],
+    });
+
+    expect(result.netGreeks).toEqual({
+      delta: 25,
+      gamma: 2,
+      theta: -1,
+      vega: 10,
+    });
+    expect(Object.values(result.netGreeks).every(Number.isFinite)).toBe(true);
+    expect(result.greekCoverage).toEqual({
+      delta: {
+        observedLegs: 2,
+        totalLegs: 2,
+        complete: true,
+        missingLegIds: [],
+        invalidLegIds: [],
+      },
+      gamma: {
+        observedLegs: 1,
+        totalLegs: 2,
+        complete: false,
+        missingLegIds: ["upper-call"],
+        invalidLegIds: [],
+      },
+      theta: {
+        observedLegs: 1,
+        totalLegs: 2,
+        complete: false,
+        missingLegIds: ["lower-call"],
+        invalidLegIds: [],
+      },
+      vega: {
+        observedLegs: 1,
+        totalLegs: 2,
+        complete: false,
+        missingLegIds: [],
+        invalidLegIds: ["lower-call"],
+      },
+    });
+  });
+
+  it("treats an explicit zero Greek as observed data", () => {
+    const result = buildOptionsWorkbench({
+      symbol: "AAPL",
+      expiration: "2026-12-18",
+      underlyingPrice: 100,
+      legs: [
+        {
+          id: "zero-greeks",
+          action: "buy",
+          type: "call",
+          strike: 100,
+          premium: 4,
+          delta: 0,
+          gamma: 0,
+          theta: 0,
+          vega: 0,
+        },
+      ],
+    });
+
+    expect(result.netGreeks).toEqual({ delta: 0, gamma: 0, theta: 0, vega: 0 });
+    for (const coverage of Object.values(result.greekCoverage)) {
+      expect(coverage).toMatchObject({ observedLegs: 1, totalLegs: 1, complete: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The options workbench currently treats missing Greeks as zero and lets malformed non-null values propagate `NaN`. That makes an unavailable theta or vega look numerically complete, even though the package total is only partial.

This patch preserves the existing numeric `netGreeks` contract for compatibility while adding `greekCoverage` for delta, gamma, theta, and vega. Each metric reports:

- observed leg count
- total leg count
- completeness
- missing leg IDs
- invalid leg IDs

Missing or malformed values no longer poison the aggregate with `NaN`; valid zero Greeks remain explicitly observed data.

## Validation

CI run 299 passed on head `feec420ab8ac762c0b14a9a5bdc665dbe9f08cd7`:

- quality and high-severity dependency-audit gates passed
- build, typecheck, and full Vitest suites passed on Node 20 and 22 across Linux, macOS, and Windows
- coverage ratchet passed on Linux/Node 20
- generated API-map verification passed
- focused tests cover complete, missing, invalid, numeric-string, negative, and explicit-zero Greek inputs

## Scope

Pure options analysis only. No brokerage request, quote retrieval, order body, auth, route-map, or live-write behavior changed.