### PR TITLE
feat: add source-backed tax strategy research routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Emit canonical formatting patch for new tax sources
-        run: |
-          pnpm exec prettier --write cli/src/tax-cli.ts cli/src/tax-strategy.ts
-          git diff -- cli/src/tax-cli.ts cli/src/tax-strategy.ts
-          exit 1
       # pnpm 10's audit client calls npm's retired legacy endpoint (HTTP 410). Pin a current audit
       # client that uses the supported bulk-advisory endpoint without changing the build/install line.
       # HIGH/CRITICAL advisories still stop the merge.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Emit canonical formatting patch for new tax sources
+        run: |
+          pnpm exec prettier --write cli/src/tax-cli.ts cli/src/tax-strategy.ts
+          git diff -- cli/src/tax-cli.ts cli/src/tax-strategy.ts
+          exit 1
       # pnpm 10's audit client calls npm's retired legacy endpoint (HTTP 410). Pin a current audit
       # client that uses the supported bulk-advisory endpoint without changing the build/install line.
       # HIGH/CRITICAL advisories still stop the merge.

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Use this skill when the user asks to inspect, research, plan, or operate a Robinhood account through
   the repository's CLI, MCP server, or importable API. It routes account reads, portfolio analysis,
   equities, options, orders, watchlists, recurring investments, settings, tax lots, tax documents,
-  tax-mechanics research, endpoint discovery, and operator knowledge while preserving the dry-run,
-  account-scope, exact-consent, and order-evidence contracts.
-version: 3.0.0
+  tax-rule and tax-strategy research, endpoint discovery, and operator knowledge while preserving
+  account scope, missing-data honesty, dry-run defaults, exact consent, and order-history evidence.
+version: 3.1.0
 author: Zayd (@zaydiscold)
 license: MIT
 platforms: [linux, macos, windows]
@@ -35,97 +35,121 @@ metadata:
 
 > **REAL-MONEY CONTROL PLANE:** this repository can submit trades, cancel orders, alter recurring
 > investments, and change account settings on an account the operator owns. Reads and dry-runs may
-> proceed when they are necessary to answer the request. Every state-changing action requires the
-> user's exact approval for the resolved action and remains subject to the repository's write gate.
+> proceed when necessary to answer the request. Every state-changing action requires exact user
+> approval for the fully resolved action and remains subject to the repository's write policy.
 
-This file is the **router and binding operating contract**. It is deliberately not the full API
-manual. Load one focused module from [`knowledge/`](knowledge/README.md) for the task, use
-[`AGENTS.md`](AGENTS.md) for maintainer-level detail, and use [`docs/`](docs/README.md) only when the
-focused module links to a deeper study.
+This file is the binding router, not the complete manual. Load the smallest focused module from
+[`knowledge/`](knowledge/README.md), use [`AGENTS.md`](AGENTS.md) for maintainer-level detail, and
+open deep research under `docs/` only when the focused module directs you there.
 
 ## 30-second operating contract
 
-1. **Discover, do not assume.** Enumerate accounts at runtime. Never invent or reuse an account
-   number from prose, examples, memory, or another user.
-2. **Prefer a first-class command or MCP tool.** Use raw route execution only when the capability
-   has no maintained wrapper.
-3. **Read before planning.** Resolve the account, instrument, contract, position, live quote, and
-   account capability before constructing an action.
-4. **Classify the exact action.** A sell-to-close, covered call, cash-secured put, credit spread,
-   naked short, recurring-investment edit, and account-setting toggle are not interchangeable.
-5. **Dry-run is the resting state.** `ROBINHOOD_ALLOW_LIVE_WRITE=1` gives the process permission to
-   attempt writes. It does not replace exact user approval. `--dry-run` or `dryRun:true` always wins.
-6. **Echo the resolved action before a live mutation.** Include account tail and label, symbol or
-   exact option contract, side, position effect, quantity, price or maximum notional, time in force,
-   and session.
-7. **Order history is the only proof.** A plan, UI state, HTTP `201`, response body, or tool success
-   message is not execution evidence. Re-read the order from brokerage history.
-8. **Unknown means unknown.** Never label an uncertain order outcome retry-safe and never resend the
+1. **Discover, do not assume.** Enumerate accounts, instruments, contracts, and current capabilities
+   at runtime. Never reuse an account number or contract ID from prose, examples, memory, or another
+   user.
+2. **Prefer maintained first-class surfaces.** Use a CLI command or MCP tool before raw route
+   execution. Raw access is a fallback, not the normal path.
+3. **Read before planning.** Resolve account, asset, position, quote, session, buying power,
+   collateral, and account capability before constructing a possible action.
+4. **Classify the exact structure.** A sell-to-close, covered call, cash-secured put, credit spread,
+   naked short, roll, recurring edit, and setting toggle are materially different operations.
+5. **Dry-run is the resting state.** `ROBINHOOD_ALLOW_LIVE_WRITE=1` makes a process capable of
+   attempting writes. It does not replace exact user approval. `--dry-run` or `dryRun:true` always
+   forces a preview.
+6. **Echo the resolved action.** Before a live mutation, state the account label and masked tail,
+   symbol or exact option instruments, side, position effect, quantity, price or maximum notional,
+   time in force, and session.
+7. **Order history is the only proof.** A plan, app screen, HTTP `201`, response body, or successful
+   tool call is not execution evidence. Re-read the order from brokerage history.
+8. **Unknown stays unknown.** Never label an uncertain order outcome retry-safe. Never resend an
    original order merely because the response was interrupted.
-9. **Research is not authorization.** Tax, market, strategy, and due-diligence reads can inform a
-   plan. They never authorize a trade or account change.
-10. **Use structured output as authority.** Tables and prose help humans. CLI JSON and MCP
-    `structuredContent` are the machine contract.
+9. **Research is not authorization.** Market, strategy, tax, and legal-mechanics research can inform
+   a plan. It never authorizes a trade, roll, exercise, assignment response, lot selection, or
+   account change.
+10. **Structured output is authoritative.** CLI JSON and MCP `structuredContent` are the machine
+    contract. Human tables and prose summarize that contract but must not contradict it.
 
 ## Progressive disclosure
 
-Load the smallest layer that can answer the question:
+Load the smallest layer that can answer the request:
 
 | Layer | Source | Purpose |
 | --- | --- | --- |
 | Router | This `SKILL.md` | Safety contract, surface selection, and intent routing |
 | Focused operation | [`knowledge/*.md`](knowledge/README.md) | Commands, decision rules, and task-specific failure modes |
-| Deep research | [`docs/*.md`](docs/README.md) | Dated evidence, methodology, and long-form analysis |
-| Full maintainer reference | [`AGENTS.md`](AGENTS.md) | Auth, route map, command inventory, write internals, and raw examples |
-| Runtime truth | CLI `--help`, MCP `tools/list`, generated API map | What the installed build actually exposes now |
+| Machine-backed reference | generated catalogs, API maps, and validated JSON | Versioned claims and cross-surface contracts |
+| Deep research | `docs/*.md` | Dated evidence, methodology, and long-form analysis |
+| Maintainer reference | [`AGENTS.md`](AGENTS.md) | Auth, route map, implementation, and raw examples |
+| Runtime truth | CLI `--help`, MCP `tools/list`, package exports | What the installed build exposes now |
 
-When documents disagree, do not choose the most convenient sentence. Report the discrepancy and
-prefer, in order: current runtime behavior, current generated contracts, primary evidence, focused
-module, dated deep research, then legacy prose.
+When sources conflict, do not choose the sentence that makes an action easier. Report the conflict
+and prefer, in order:
+
+```text
+current runtime
+> current machine-backed contract
+> primary evidence
+> focused operating module
+> dated deep research
+> legacy prose
+```
+
+Use [`docs/evidence-confidence-ledger.md`](docs/evidence-confidence-ledger.md) when a capability's
+live verification or confidence level matters.
 
 ## Choose the surface
 
 ### CLI
 
-Use the CLI for human-in-the-loop work, shell automation, readable dry-runs, and reproducible
-commands. The normal executable is:
+Use the CLI for human-in-the-loop work, reproducible shell automation, readable previews, and exact
+commands. Installed use:
 
 ```bash
-node cli/dist/index.js --help
+robinhood-cli --help
 ```
 
-Use the dedicated source-backed tax reference CLI for tax mechanics:
+Source-tree use after `pnpm build`:
 
 ```bash
-node cli/dist/tax-cli.js
-node cli/dist/tax-cli.js wash-sales
-node cli/dist/tax-cli.js --query "qualified covered call"
+node cli/dist/cli-entry.js --help
 ```
 
-Installed package binaries are `robinhood-cli` and `robinhood-tax`.
+Tax mechanics and structure routing use the same main binary:
+
+```bash
+robinhood-cli tax
+robinhood-cli tax wash-sales
+robinhood-cli tax strategy wheel
+robinhood-cli tax strategy "covered call" --account-context taxable --json
+robinhood-cli tax status --json
+```
+
+The dedicated `robinhood-tax` binary accepts the same arguments without the leading `tax`.
 
 ### MCP
 
-Use MCP when an agent client needs typed discovery and structured results. The selected capability
-profile controls the visible tool set. **Call `tools/list`; never rely on a hard-coded tool count.**
-A missing tool may mean the server is stale, the profile excludes it, or the build was not restarted.
-Load [`knowledge/mcp-operations.md`](knowledge/mcp-operations.md) for setup and diagnosis.
+Use MCP when an agent client needs typed discovery and structured results. The selected profile
+controls the visible tool set. **Call `tools/list`; never rely on a hard-coded tool count.** A missing
+tool can mean the server is stale, the profile excludes it, or the build was not restarted. Load
+[`knowledge/mcp-operations.md`](knowledge/mcp-operations.md) for setup and diagnosis.
 
-Tax research is available through the generated `tax-reference` knowledge module using
-`robinhood_knowledge`. Live tax-lot, document, history, recurring, and settings facts remain separate
-account tools.
+For tax strategy questions, read `tax-strategy-routing` and `tax-reference` with
+`robinhood_knowledge`, then collect live facts through the named account tools. A knowledge read and
+a brokerage read are separate operations.
 
 ### Importable API
 
-Use the package API for applications and tests that need the shared engine without parsing CLI text:
+Use package exports when an application or test needs structured data without parsing CLI text:
 
 ```ts
-import { getTaxReference } from "@zaydiscold/robinhood-cli/tax-reference";
 import { placeEquityOrder } from "@zaydiscold/robinhood-cli";
+import { getTaxReference } from "@zaydiscold/robinhood-cli/tax-reference";
+import { getTaxStrategyGuide } from "@zaydiscold/robinhood-cli/tax-strategy";
 ```
 
-Do not recreate order bodies, write gates, account checks, retry policy, or evidence logic in a new
-adapter. CLI, MCP, scripts, and applications must call the same canonical engine functions.
+Do not recreate order bodies, account ownership checks, write gates, retries, caps, deduplication,
+redaction, or evidence logic in another adapter. **CLI, MCP, scripts, and package APIs must share
+business logic.**
 
 ## Intent router
 
@@ -134,286 +158,282 @@ adapter. CLI, MCP, scripts, and applications must call the same canonical engine
 | What accounts exist or what can this account do? | `accounts`, `account-pulse`, `buying-power` | [`knowledge/accounts.md`](knowledge/accounts.md) |
 | What do I own? | `positions`, `options positions`, `options holdings` | [`knowledge/accounts.md`](knowledge/accounts.md) |
 | Why am I up or down today or after hours? | `portfolio --day` or `portfolio --after-hours` | [`knowledge/cli-routing.md`](knowledge/cli-routing.md) |
-| Quote or research a ticker | `quote`, `stock profile`, `news`, `ratings`, `earnings` | [`knowledge/signals.md`](knowledge/signals.md) |
-| Price or analyze an option strategy | `options strategy-quote`, `options workbench` | [`knowledge/multi-leg.md`](knowledge/multi-leg.md), [`knowledge/greeks.md`](knowledge/greeks.md) |
-| Roll or defend an option | `options roll-plan` | [`knowledge/rolling.md`](knowledge/rolling.md) |
-| Build or manage a wheel | `wheel` | [`knowledge/wheel.md`](knowledge/wheel.md) |
+| Quote or research a ticker | `quote`, `stock profile`, `news`, `ratings`, `earnings` | `knowledge/signals.md` |
+| Price or analyze a multi-leg option structure | `options strategy-quote`, `options workbench` | `knowledge/multi-leg.md`, `knowledge/greeks.md` |
+| Roll or defend an option | `options roll-plan` | `knowledge/rolling.md` |
+| Build or manage a wheel | `wheel` | `knowledge/wheel.md` |
 | Buy or sell stock | `buy` or `sell`, dry-run first | [`knowledge/execution-safety.md`](knowledge/execution-safety.md) |
 | Review open or completed orders | `orders open`, `order-status`, `order-watch` | [`knowledge/execution-safety.md`](knowledge/execution-safety.md) |
 | Cancel one or all open orders | `cancel` or `panic` | [`knowledge/execution-safety.md`](knowledge/execution-safety.md) |
-| Manage a watchlist | `watchlist` subcommands | [`knowledge/cli-routing.md`](knowledge/cli-routing.md) |
 | Manage recurring investments | `recurring` subcommands | [`knowledge/accounts.md`](knowledge/accounts.md) |
 | Change DRIP, PDT, lending, sweep, or expiration settings | `settings` subcommands | [`knowledge/accounts.md`](knowledge/accounts.md) |
-| Review tax mechanics or product structure | `robinhood-tax` or `tax-reference` knowledge | [`knowledge/tax-reference.md`](knowledge/tax-reference.md) |
-| Inspect tax lots or plan a lot-aware sale | `tax-lots` | [`knowledge/tax.md`](knowledge/tax.md) |
-| Harvest losses | tax reference first, then live lots/history/automation checks | [`knowledge/tax-loss-harvesting.md`](knowledge/tax-loss-harvesting.md) |
+| Research a tax rule | `robinhood-cli tax <topic>` | [`knowledge/tax-reference.md`](knowledge/tax-reference.md) |
+| Research tax mechanics of a named structure | `robinhood-cli tax strategy <id-or-alias>` | [`knowledge/tax-strategy-routing.md`](knowledge/tax-strategy-routing.md) |
+| Combine tax rules with live account facts | tax research first, then named account reads | [`knowledge/tax.md`](knowledge/tax.md) |
+| Inspect lots or build a non-sending lot-aware plan | `tax-lots list` or `tax-lots plan-sell` | [`knowledge/tax.md`](knowledge/tax.md) |
+| Harvest a loss | strategy guide, exact lots, then 61-day acquisition review | [`knowledge/tax-loss-harvesting.md`](knowledge/tax-loss-harvesting.md) |
 | Download statements or tax forms | `documents list` or `documents download` | [`knowledge/tax.md`](knowledge/tax.md) |
-| Inspect an unwrapped endpoint | `brokerage describe`, `brokerage plan`, then `brokerage execute` | [`knowledge/cli-routing.md`](knowledge/cli-routing.md) |
-| Add or verify a route | generated map and evidence workflow | [`docs/undocumented-surface.md`](docs/undocumented-surface.md) |
+| Inspect an unwrapped endpoint | `brokerage describe`, `brokerage plan`, then `brokerage execute` | `knowledge/cli-routing.md` |
+| Add or verify a route | generated map and evidence workflow | `docs/undocumented-surface.md` |
 
 ## Account discovery and scope
 
-A login can expose multiple taxable, retirement, crypto, or other account classes. The plain
-`accounts/` endpoint can under-report. Use the first-class `accounts` surface, which resolves the
-owned account graph, then preserve the selected account explicitly through every subsequent read,
-plan, and write.
+A login can expose several taxable, retirement, crypto, and other account classes. The plain
+`accounts/` endpoint can under-report. Use the maintained account surface, then preserve the selected
+account explicitly through each subsequent read, plan, and write.
 
 Before an account-scoped mutation:
 
 1. Enumerate owned accounts.
-2. Match the user's description to account type, nickname, and current holdings.
+2. Match the user's description to account type, nickname, and relevant holdings.
 3. Echo the selected account label and masked tail.
 4. Refuse an unowned, malformed, missing, or ambiguous account.
 5. Re-run account capability and buying-power checks when the action depends on them.
+6. Respect any configured account allow-list.
 
-Never infer that the account holding an existing position is also the account intended for a new
-position.
+Never assume that the account holding an existing position is also the intended account for a new
+position. Never expose full account numbers in share-safe output, logs, examples, or client reference
+identifiers.
 
-## Read and planning workflow
+## Read and analysis contract
 
-For a normal account question:
-
-```text
-intent
-  -> choose first-class surface
-  -> discover account or instrument identifiers
-  -> perform live read or local reference lookup
-  -> preserve missing data as missing
-  -> report timestamps, account scope, and limitations
-```
-
-For an equity action:
+For an account question:
 
 ```text
 intent
-  -> account discovery
-  -> ticker resolution
-  -> instrument eligibility
-  -> quote and market session
-  -> account capability and buying power
-  -> dry-run body
-  -> exact approval
-  -> gated send
-  -> order-history evidence
-  -> trading log
+  -> choose maintained surface
+  -> resolve account and instrument identifiers
+  -> perform a live read or local reference lookup
+  -> preserve missing and partial data
+  -> report timestamp, account scope, source, and limitations
 ```
 
-For an option action:
+Use dollar-weighted results when position size matters. A percentage leaderboard can overstate a tiny
+lot and hide the position driving actual P&L.
 
-```text
-intent
-  -> classify strategy and exposure
-  -> discover account
-  -> enumerate exact option UUIDs
-  -> verify expiration, strike, type, side, and position effect
-  -> quote every leg and show Greek-input completeness
-  -> pretrade/collateral review
-  -> dry-run exact body
-  -> exact approval
-  -> gated send
-  -> options-order-history evidence
-```
+Preserve these states distinctly:
 
-Do not use ticker, strike, or human-readable OCC text where an exact option instrument ID is required.
-Do not present a package Greek as complete when one or more leg inputs are missing.
+- observed
+- inferred
+- stale
+- partial
+- missing
+- not evaluated
+- unsupported
+- blocked
+
+Do not turn `null`, an empty string, an absent Greek, or a failed read into numeric zero. Do not turn
+an empty broker response into proof that an outside fact does not exist.
+
+## Options and strategy contract
+
+Before discussing or planning an option action:
+
+1. Classify the economic structure and whether risk is defined or undefined.
+2. Resolve exact option instrument IDs for every leg.
+3. Verify expiration, strike, call or put, side, position effect, ratio, and quantity.
+4. Read current bid, ask, mark, liquidity, and any available Greeks.
+5. Show Greek-input completeness. A partial package Greek is not a complete package Greek.
+6. Check account capability, collateral, buying power, assignment, exercise, and settlement.
+7. Build the exact non-sending body.
+8. Obtain exact approval only after the body and risks are resolved.
+
+Do not infer naked exposure from loose wording. Do not use ticker, strike, or human-readable OCC text
+where an exact option instrument ID is required. Do not treat a strategy label as a tax
+classification.
 
 ## Raw brokerage executor
 
 Prefer maintained commands. When raw execution is necessary:
 
 ```bash
-node cli/dist/index.js brokerage describe "<route substring>" --json
-node cli/dist/index.js brokerage plan "<route substring>" --method GET --json
-node cli/dist/index.js brokerage execute "<route substring>" \
+robinhood-cli brokerage describe "<route substring>" --json
+robinhood-cli brokerage plan "<route substring>" --method GET --json
+robinhood-cli brokerage execute "<route substring>" \
   --method GET \
   --query-param key=value \
   --json
 ```
 
 The raw CLI **does support repeatable `--query-param key=value` flags**. Query values are appended
-after the mapped route is selected. Do not embed arbitrary query text to bypass route selection.
+after the mapped route is selected. Do not embed arbitrary query text to evade route selection.
 
-When the same URL supports multiple verbs, pass `--method`. Method is part of the safety identity.
-A write method must never inherit a read route's risk classification. An inferred mutation remains
-non-sending until the route and request contract have sufficient evidence.
+When one URL supports several verbs, pass `--method`. Method is part of the safety identity. A write
+method must not inherit a read route's risk level. An inferred mutation remains non-sending until the
+route and request contract have sufficient evidence.
 
 ## Live-write contract
 
-`ROBINHOOD_ALLOW_LIVE_WRITE=1` is the process-level switch. The default without it is a dry-run.
-Keep it inline for one CLI invocation rather than permanently exporting it.
+`ROBINHOOD_ALLOW_LIVE_WRITE=1` is the process-level capability switch. Without it, mutations are
+planned but not sent. Keep the switch inline for one CLI invocation rather than permanently exporting
+it.
 
 A live mutation requires all of the following:
 
-- The user explicitly requested this exact action.
-- The owned account was resolved and echoed.
-- Instrument or contract identity was resolved.
-- Side, effect, quantity, price/notional, TIF, and session are known.
-- Account capability, collateral, buying power, and relevant caps were checked.
-- A dry-run of the exact body was shown or summarized.
-- No recent duplicate or unresolved prior outcome blocks the action.
-- The route and method are eligible for live execution.
-- The environment switch is enabled.
+- the user explicitly requested this exact action
+- the owned account is resolved and echoed
+- the exact instrument or contracts are resolved
+- side, position effect, quantity, price or notional, TIF, and session are known
+- account capability, collateral, buying power, and configured caps are checked
+- a dry-run of the exact action is shown or summarized
+- no recent duplicate or unresolved prior outcome blocks the action
+- the route and method are eligible for live execution
+- the process switch is enabled
 
-Useful defense-in-depth environment controls include an account allow-list, per-order maximum, and
-process/session maximum. Run `doctor` before an armed session and treat missing guardrails as a
-warning, not as harmless configuration trivia.
+Defense-in-depth controls should include an account allow-list, a per-order maximum, and a process or
+session maximum. Run `doctor` before an armed session. Missing guardrails are not harmless
+configuration trivia.
 
-After a send:
+After sending:
 
-1. Preserve the generated idempotency reference.
-2. Follow broker-directed retry behavior only where the canonical engine proves retry safety.
-3. Reconcile by reading order history.
-4. Report `confirmed`, state, order ID, and any evidence warning.
-5. Log the action and intent.
-6. If evidence is unavailable, say **unconfirmed** and do not resend the original order.
+1. Preserve the client reference and broker order ID without exposing private identifiers.
+2. Re-read order history.
+3. Report `evidence.confirmed` separately from HTTP status.
+4. If outcome is unknown, do not resend the original order.
+5. Log the action and intent after verification.
+6. For lot-aware sales, verify the selected or closed lots separately.
+
+See [`docs/write-operations.md`](docs/write-operations.md) for the detailed mutation contract.
 
 ## Tax and legal-mechanics research contract
 
-Tax content in this repository is educational research, not a personalized filing conclusion. For
-any tax question, load [`knowledge/tax-reference.md`](knowledge/tax-reference.md) first or query
-`robinhood-tax`. It is generated from a versioned catalog and separates four evidence lanes:
+Tax research has two lanes that must not be collapsed.
 
-1. **Primary law or regulation**
+### Rule lane
+
+Use [`knowledge/tax-reference.md`](knowledge/tax-reference.md), generated from the versioned source
+catalog, for source-backed federal mechanics. Separate:
+
+1. **primary law or regulation**
 2. **IRS guidance or reporting instruction**
-3. **Broker-platform behavior**
-4. **Planning inference**
+3. **broker-platform behavior**
+4. **planning inference**
 
-These lanes are not interchangeable. Robinhood's app estimate, product label, or help article does
-not decide federal tax law. A planning inference must never be phrased as settled law.
+State the jurisdiction and review date. Link material claims to official sources. Do not use a broker
+help page as controlling federal law. Do not hard-code rate comparisons without the return year and
+complete taxpayer facts.
 
-Before giving a personalized numerical tax estimate, the necessary facts may include filing status,
-taxable income, basis, holding period, capital-loss carryovers, elections, state, other brokers,
-retirement accounts, spouse transactions, and automatic acquisitions. If those are absent, explain
-the mechanics and uncertainty rather than inventing a liability.
+### Structure lane
 
-Always flag, rather than adjudicate, ambiguous questions involving:
-
-- substantially identical stock or options
-- wash sales across taxable and IRA or Roth IRA accounts
-- qualified covered calls and straddles
-- mixed Section 1256 and non-Section-1256 positions
-- conversion transactions or box spreads
-- constructive sales
-- missing or transferred basis
-
-Use live account surfaces only to gather facts:
+Use [`knowledge/tax-strategy-routing.md`](knowledge/tax-strategy-routing.md) or:
 
 ```bash
-node cli/dist/tax-cli.js wash-sales
-node cli/dist/index.js tax-lots list <SYMBOL> --account <ACCOUNT> --json
-node cli/dist/index.js history --account <ACCOUNT> --json
-node cli/dist/index.js recurring list --json
-node cli/dist/index.js settings show --account <ACCOUNT>
-node cli/dist/index.js documents list --year <YEAR> --json
+robinhood-cli tax strategy <id-or-alias> --json
 ```
 
-A tax-lot plan is not lot-selection evidence. Verify the filled order, selected or closed lots, and
-year-end tax forms. A tax-reference read never authorizes the sale it discusses.
+The strategy guide returns required facts, maintained broker reads, linked rule topics, red flags,
+and stop conditions. Its output contract must preserve:
 
-## Research and operator memory
+```text
+known broker facts
+user-supplied and external facts
+missing material facts
+official rule topics
+broker-platform behavior
+planning inference
+not evaluated
+sources
+mutation status: not authorized
+```
 
-Research should distinguish signal speed from evidence quality. Load [`knowledge/signals.md`](knowledge/signals.md)
-for the source ladder. Treat `ball-knowledge.md`, the hotlist, trade notes, and prior logs as operator
-context, not as current market fact or authorization.
+### Account-fact lane
 
-Before relying on a memory entry:
+Only after routing should an agent read lots, history, options events, recurring purchases, settings,
+dividends, or documents. Robinhood cannot determine spouse activity, other brokers, elections,
+return-wide carryovers, or every substantially identical position.
 
-- note its date
-- verify current market or account facts
-- distinguish observation from thesis
-- preserve contradictory evidence
-- do not convert a past trade into a standing instruction
+A tax-reference read never authorizes a trade. A tax-strategy guide never determines a filing result.
+Neither supplies consent for a sale, roll, exercise, assignment response, lot selection, or account
+change.
 
-## Output contract
+Automatically stop and recommend qualified professional review when a material question depends on:
 
-- Use dollar-weighted impact for portfolio attribution and risk, not size-blind percentage rankings.
-- Include account scope and `as of` time for live reads.
-- Preserve `null`, unavailable, partial coverage, stale, and inferred states. Do not coerce them to
-  zero or omit the limitation.
-- Use exact units for price, quantity, notional, option multiplier, Greeks, and percentages.
-- Keep raw credentials, account identifiers, signed URLs, order references, and private notes out of
-  shareable output. Use the share-safe surface when output will leave the operator's environment.
-- State whether a result is a live read, local reference, dry-run plan, live send, or post-send
-  evidence.
+- substantially identical property without a clear controlling answer
+- qualified-covered-call status with incomplete contract or stock facts
+- a mixed straddle or election
+- a conversion transaction or box-spread financing characterization
+- a constructive sale
+- missing or transferred basis
+- cross-broker, spouse, IRA, or Roth IRA activity
+- personalized rates, carryovers, netting, state law, or filing positions
 
-## Failure modes that must stop the workflow
+## Agent response contracts
 
-Stop or fail closed when any of these is true:
+### Account read
 
-- Account identity is missing, ambiguous, unowned, or cannot be verified for a live mutation.
-- A ticker or option contract was guessed rather than resolved.
-- A write route or method is inferred, deprecated, or classified as a read.
-- Quantity, price, notional, date, account, or UUID is invalid.
-- A live quote is missing where order construction depends on it.
-- A pending duplicate exists or the duplicate check failed.
-- Buying power, collateral, or account capability cannot be established for a live action.
-- The intended structure could create uncovered or otherwise unintended exposure.
-- The dry-run body differs from the body about to be sent.
-- The user approved a general idea but not the resolved action.
-- A prior order outcome is unknown.
-- A source-backed tax answer is being converted into a personalized filing conclusion without the
-  necessary facts.
+Include account label and masked tail, timestamp, live or local source, known values, missing values,
+and any degraded account reads.
 
-## Verification checklist
+### Strategy analysis
 
-Before considering a task complete:
-
-### Read or analysis
-
-- Correct account, symbol, contract, and time window
-- Current timestamp and data provenance
-- Missing-data and coverage limitations visible
-- Correct units and dollar weighting
-- Structured result preserved
+Include exact position structure, position-weighted dollar exposure, quote timestamp, Greek coverage,
+scenario assumptions, liquidity limitations, and what is not evaluated.
 
 ### Dry-run
 
-- Exact route and method
-- Exact account and instrument IDs
-- Exact body, side, effect, quantity, price/notional, TIF, and session
-- Eligibility, capability, buying power, collateral, duplicate, and cap checks
-- Explicit statement that nothing was sent
+Include exact account, instrument or contracts, side, effect, quantity, price or maximum notional,
+TIF, session, route confidence, and the statement `NOT EXECUTED`.
 
-### Live mutation
+### Live result
 
-- Exact user approval
-- `ROBINHOOD_ALLOW_LIVE_WRITE=1`
-- Canonical shared engine
-- Order-history or account-state evidence
-- No retry of an unknown original action
-- Intent logged
+Include requested action, broker status, order ID in share-safe form, order-history evidence,
+remaining uncertainty, and whether any follow-up read or lot verification is required.
 
 ### Tax research
 
-- Jurisdiction and review date
-- Evidence lane for each material claim
-- Primary or official source IDs
-- Broker behavior separated from law
-- Fact-specific uncertainty visible
-- No implied trade authorization
+Include strategy and account context, jurisdiction, review date, known facts, missing facts, evidence
+lanes, not-evaluated items, official sources, and `tradeAuthorized: false`.
+
+## Failure modes that must stop the workflow
+
+Stop rather than guessing when:
+
+- the account is missing, ambiguous, malformed, or not owned
+- an exact option instrument cannot be resolved
+- quote, book, price, or quantity is invalid
+- a write route is inferred, deprecated, or insufficiently verified
+- account capability, collateral, or buying-power checks fail
+- the pending-order deduplication read fails before a live send
+- a recent same-side duplicate exists and the user has not explicitly overridden it
+- notional caps or account allow-list rules block the action
+- an earlier order outcome is unknown
+- a package Greek is partial but is being presented as complete
+- tax basis, contract classification, related positions, elections, or cross-account facts are
+  material and unavailable
+- the requested conclusion would require financial, legal, or tax facts the repository cannot know
+
+Do not bypass a stop condition because the requested action sounds routine.
+
+## Verification checklist
+
+Before answering or acting, verify:
+
+- [ ] Current CLI or MCP surface was discovered, not assumed.
+- [ ] Account scope is explicit and owned.
+- [ ] Instrument or contract identity is exact.
+- [ ] Read timestamps and degraded states are preserved.
+- [ ] Missing values remain missing.
+- [ ] Strategy and position effect are classified.
+- [ ] Tax rule lane and account-fact lane are separated when relevant.
+- [ ] Mutation remains dry-run unless exact approval and all live gates are satisfied.
+- [ ] No unresolved duplicate or unknown prior outcome exists.
+- [ ] Order history, not HTTP status, is used as evidence.
+- [ ] Share-safe output removes account, credential, signed URL, order-reference, and private-note data.
+- [ ] Any selected or closed tax lots are verified after a fill.
 
 ## Maintainer rules
 
-- CLI, MCP, scripts, and package APIs must share business logic rather than copy it.
-- Add a capability to the registry before exposing it through MCP.
-- Treat CLI `--help`, MCP `tools/list`, package exports, and generated maps as contracts.
-- Update focused modules rather than expanding this router into another encyclopedia.
-- Edit `knowledge/tax-reference.json`, run `pnpm generate:tax-reference`, and commit the generated
-  Markdown when tax research changes.
-- Run `pnpm quality`, `pnpm build`, and `pnpm test:built` before merging.
-- Never weaken dry-run defaults, account ownership checks, notional caps, deduplication, route
-  provenance, or post-send evidence merely to make a workflow easier.
-
-## Canonical references
-
-- [`knowledge/README.md`](knowledge/README.md): focused module index
-- [`knowledge/execution-safety.md`](knowledge/execution-safety.md): mutation failure modes
-- [`knowledge/accounts.md`](knowledge/accounts.md): account discovery and capabilities
-- [`knowledge/mcp-operations.md`](knowledge/mcp-operations.md): MCP profiles and setup
-- [`knowledge/tax-reference.md`](knowledge/tax-reference.md): source-backed tax mechanics
-- [`knowledge/tax.md`](knowledge/tax.md): tax-aware account workflow
-- [`knowledge/tax-loss-harvesting.md`](knowledge/tax-loss-harvesting.md): harvesting control procedure
-- [`docs/write-operations.md`](docs/write-operations.md): write-gate contract
-- [`docs/evidence-confidence-ledger.md`](docs/evidence-confidence-ledger.md): evidence levels
-- [`docs/cli-mcp-architecture.md`](docs/cli-mcp-architecture.md): adapter and engine architecture
-- [`AGENTS.md`](AGENTS.md): full maintainer reference
+1. Keep one canonical implementation for auth, routing, write policy, account ownership, caps,
+   deduplication, idempotency, order construction, redaction, and evidence.
+2. Add functionality to the shared engine before adding adapter-specific behavior.
+3. Keep CLI help, MCP schemas, package exports, capability registry, and focused modules aligned.
+4. Never create a second direct brokerage write client in a script.
+5. Validate external payloads at boundaries and preserve unknown fields honestly.
+6. Make generated API-map and tax-reference drift fail CI.
+7. Treat documentation contradictions as product defects.
+8. Keep this skill between the configured size bounds. Move implementation details into
+   [`AGENTS.md`](AGENTS.md), focused depth into [`knowledge/`](knowledge/README.md), and architecture
+   into [`docs/cli-mcp-architecture.md`](docs/cli-mcp-architecture.md).
+9. Re-run build, quality, full tests, and package-boundary checks after changing a public surface.
+10. Never weaken dry-run, account scope, exact approval, evidence, or privacy invariants to make a
+    new feature easier to demo.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,7 +1,7 @@
 # @zaydiscold/robinhood-cli
 
 TypeScript CLI for the repository's mapped Robinhood brokerage/account surface, official Crypto API
-helpers, and source-backed tax-mechanics reference. This package is the human and script front door
+helpers, and source-backed tax-mechanics research. This package is the human and script front door
 over the shared engine used by the MCP server.
 
 ## Safety model
@@ -12,7 +12,7 @@ over the shared engine used by the MCP server.
 - `--dry-run` always sends nothing, even when the process is armed.
 - Use exact-action consent before trades, cancels, transfers, settings changes, or other mutations.
 - Order history is the only proof an order happened.
-- Tax research is educational reference content and never authorizes a trade.
+- Tax research is educational, does not determine a filing result, and never authorizes a trade.
 
 ## Build
 
@@ -23,10 +23,9 @@ node cli/dist/cli-entry.js --help
 ```
 
 The published `robinhood-cli` binary points to `dist/cli-entry.js`. It routes the local `tax`
-subcommand to the tax reference without loading brokerage auth, and delegates every other command to
-the existing CLI implementation.
+subcommand without loading brokerage auth, and delegates every other command to the account CLI.
 
-The build copies `api-map/` into `cli/dist/api-map/` and the tax catalog into
+The build copies `api-map/` into `cli/dist/api-map/` and the tax reference and strategy catalogs into
 `cli/dist/knowledge/`. Rebuild after route-map or tax-catalog changes.
 
 ## Common reads
@@ -44,37 +43,75 @@ robinhood-cli brokerage describe "orders/" --json
 Prefer first-class commands over raw `brokerage execute`; they handle joins, query parameters,
 account discovery, and instrument UUID resolution.
 
-## Tax reference
+## Tax research
 
-The same source-backed catalog is available through the main CLI, the dedicated binary, and the
-importable API.
+Two source-backed layers are available through the main CLI, the dedicated binary, and importable
+APIs.
+
+### Rule topics
 
 ```bash
-# Main CLI
 robinhood-cli tax
 robinhood-cli tax wash-sales
 robinhood-cli tax --query "qualified covered call"
 robinhood-cli tax section-1256 --json
-
-# Dedicated equivalent
-robinhood-tax box-spreads
 ```
 
-The command performs a local file read. It does not load a Robinhood token or make a brokerage
+### Strategy-to-rule routing
+
+A strategy guide lists required facts, maintained Robinhood reads, linked official rule topics, red
+flags, stop conditions, and the facts that remain unevaluated. It does not select or authorize a
+trade.
+
+```bash
+robinhood-cli tax strategy
+robinhood-cli tax strategy wheel
+robinhood-cli tax strategy "covered call" --account-context taxable
+robinhood-cli tax strategy --query "dividend" --json
+robinhood-cli tax status --json
+```
+
+The dedicated `robinhood-tax` binary accepts the same arguments without the leading `tax`:
+
+```bash
+robinhood-tax strategy box-spread --json
+```
+
+These commands perform local file reads. They do not load a Robinhood token or make a brokerage
 request. Live account facts remain separate:
 
 ```bash
-robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT> --json
-robinhood-cli history --account <ACCOUNT> --json
-robinhood-cli recurring list --json
-robinhood-cli documents list --year <YEAR> --json
+robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json
+robinhood-cli history --account <ACCOUNT_NUMBER> --json
+robinhood-cli options events --account <ACCOUNT_NUMBER> --json
+robinhood-cli recurring list --account <ACCOUNT_NUMBER> --json
+robinhood-cli settings show --account <ACCOUNT_NUMBER> --json
+robinhood-cli documents list --account <ACCOUNT_NUMBER> --year <YEAR> --json
 ```
 
-Applications can import:
+Applications can import the same structured catalogs:
 
 ```ts
 import { getTaxReference } from "@zaydiscold/robinhood-cli/tax-reference";
+import {
+  getTaxResearchStatus,
+  getTaxStrategyGuide,
+  listTaxStrategies,
+} from "@zaydiscold/robinhood-cli/tax-strategy";
 ```
+
+Every strategy guide explicitly returns:
+
+```ts
+{
+  notPersonalizedAdvice: true,
+  filingResultDetermined: false,
+  tradeAuthorized: false
+}
+```
+
+MCP clients read `tax-strategy-routing` and `tax-reference` through `robinhood_knowledge`, then use
+the named account tools to collect live facts. Research and account evidence remain distinct.
 
 ## Dry-run and live writes
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -20,6 +20,10 @@
     "./tax-reference": {
       "types": "./dist/tax-reference.d.ts",
       "import": "./dist/tax-reference.js"
+    },
+    "./tax-strategy": {
+      "types": "./dist/tax-strategy.d.ts",
+      "import": "./dist/tax-strategy.js"
     }
   },
   "files": [

--- a/cli/scripts/copy-tax-reference.mjs
+++ b/cli/scripts/copy-tax-reference.mjs
@@ -4,8 +4,11 @@ import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../..");
-const source = resolve(repoRoot, "knowledge", "tax-reference.json");
-const destination = resolve(repoRoot, "cli", "dist", "knowledge", "tax-reference.json");
+const files = ["tax-reference.json", "tax-strategies.json"];
 
-await mkdir(dirname(destination), { recursive: true });
-await copyFile(source, destination);
+for (const file of files) {
+  const source = resolve(repoRoot, "knowledge", file);
+  const destination = resolve(repoRoot, "cli", "dist", "knowledge", file);
+  await mkdir(dirname(destination), { recursive: true });
+  await copyFile(source, destination);
+}

--- a/cli/src/tax-cli.ts
+++ b/cli/src/tax-cli.ts
@@ -9,6 +9,16 @@ import {
   loadTaxReferenceCatalog,
   type TaxReferenceCatalog,
 } from "./tax-reference.js";
+import {
+  formatTaxStrategyText,
+  getTaxResearchStatus,
+  getTaxStrategyGuide,
+  listTaxStrategies,
+  loadTaxStrategyCatalog,
+  searchTaxStrategies,
+  type TaxAccountContext,
+  type TaxStrategyCatalog,
+} from "./tax-strategy.js";
 
 export interface TaxCliIo {
   writeOut: (text: string) => void;
@@ -24,19 +34,44 @@ const processIo: TaxCliIo = {
   },
 };
 
+function parseAccountContext(value: string | undefined): TaxAccountContext {
+  if (!value) return "unknown";
+  const normalized = value.trim().toLowerCase();
+  const aliases: Record<string, TaxAccountContext> = {
+    taxable: "taxable",
+    brokerage: "taxable",
+    individual: "taxable",
+    "traditional-ira": "traditional-ira",
+    traditional_ira: "traditional-ira",
+    ira: "traditional-ira",
+    "roth-ira": "roth-ira",
+    roth_ira: "roth-ira",
+    roth: "roth-ira",
+    unknown: "unknown",
+  };
+  const context = aliases[normalized];
+  if (!context) {
+    throw new Error(
+      `Unknown account context "${value}". Use taxable, traditional-ira, roth-ira, or unknown.`,
+    );
+  }
+  return context;
+}
+
 export function createTaxProgram(
   io: TaxCliIo = processIo,
   loadCatalog: () => TaxReferenceCatalog = loadTaxReferenceCatalog,
+  loadStrategies: () => TaxStrategyCatalog = loadTaxStrategyCatalog,
 ): Command {
   const program = new Command();
 
   program
     .name("robinhood-tax")
     .description(
-      "Source-backed US federal tax mechanics for Robinhood, equities, options, index options, and tax lots. Educational reference only.",
+      "Source-backed US federal tax mechanics and strategy-to-rule research routing for Robinhood, equities, options, index options, and tax lots. Educational reference only.",
     )
     .version("1.1.0")
-    .argument("[topic]", "topic id; omit to list topics")
+    .argument("[topic]", "topic id; omit to list topics and strategy guides")
     .option("-q, --query <text>", "search claims, caveats, evidence lanes, and source ids")
     .option("--source <source_id>", "show one source record")
     .option("--json", "emit structured JSON")
@@ -44,14 +79,21 @@ export function createTaxProgram(
       "after",
       [
         "",
-        "Examples:",
-        "  robinhood-tax",
-        "  robinhood-tax wash-sales",
-        '  robinhood-tax --query "covered call"',
-        "  robinhood-tax --source irs-pub-550-2025 --json",
+        "Reference examples:",
+        "  robinhood-cli tax",
+        "  robinhood-cli tax wash-sales",
+        '  robinhood-cli tax --query "qualified covered call"',
+        "  robinhood-cli tax --source irs-pub-550-2025 --json",
         "",
-        "MCP parity: read the generated tax-reference knowledge module with robinhood_knowledge.",
-        "API parity: import getTaxReference from @zaydiscold/robinhood-cli/tax-reference.",
+        "Strategy research examples:",
+        "  robinhood-cli tax strategy wheel",
+        "  robinhood-cli tax strategy covered-call --account-context taxable --json",
+        '  robinhood-cli tax strategy --query "dividend"',
+        "  robinhood-cli tax status --json",
+        "",
+        "The dedicated `robinhood-tax` binary accepts the same arguments after `tax`.",
+        "MCP parity: read `tax-strategy-routing` and `tax-reference` with robinhood_knowledge, then collect live account facts with the named account tools.",
+        "API parity: import from @zaydiscold/robinhood-cli/tax-reference and /tax-strategy.",
       ].join("\n"),
     )
     .configureOutput({
@@ -63,6 +105,8 @@ export function createTaxProgram(
         const catalog = loadCatalog();
         if (!topic && !options.query && !options.source) {
           const topics = listTaxReferenceTopics(catalog);
+          const strategyCatalog = loadStrategies();
+          const strategies = listTaxStrategies(strategyCatalog);
           if (options.json) {
             io.writeOut(
               `${JSON.stringify(
@@ -71,7 +115,9 @@ export function createTaxProgram(
                   jurisdiction: catalog.jurisdiction,
                   disclaimer: catalog.disclaimer,
                   topics,
+                  strategies,
                   notPersonalizedAdvice: true,
+                  tradeAuthorized: false,
                 },
                 null,
                 2,
@@ -81,15 +127,20 @@ export function createTaxProgram(
           }
           io.writeOut(
             [
-              `Tax Reference — ${catalog.jurisdiction}`,
+              `Tax Research — ${catalog.jurisdiction}`,
               `Reviewed: ${catalog.reviewedAt}`,
               catalog.disclaimer,
               "",
-              "Topics:",
+              "Reference topics:",
               ...topics.map((entry) => `  ${entry.id} — ${entry.title}`),
               "",
-              'Search: robinhood-tax --query "wash sale"',
-              "Show:   robinhood-tax section-1256",
+              "Strategy guides:",
+              ...strategies.map((entry) => `  ${entry.id} — ${entry.title}`),
+              "",
+              'Search rules:      robinhood-cli tax --query "wash sale"',
+              "Show rule topic:   robinhood-cli tax section-1256",
+              "Show strategy:     robinhood-cli tax strategy wheel",
+              "Check review age:  robinhood-cli tax status",
               "",
             ].join("\n"),
           );
@@ -108,6 +159,117 @@ export function createTaxProgram(
         if (result.matchCount === 0 && !options.source) io.setExitCode(2);
       },
     );
+
+  program
+    .command("strategy [strategy]")
+    .description(
+      "Map a named strategy to required facts, Robinhood reads, official rule topics, red flags, and stop conditions. Research only; never authorizes a trade.",
+    )
+    .option("-q, --query <text>", "search strategy ids, aliases, tags, facts, and red flags")
+    .option(
+      "--account-context <type>",
+      "taxable, traditional-ira, roth-ira, or unknown (default: unknown)",
+    )
+    .option("--json", "emit structured JSON")
+    .action(
+      (
+        strategy: string | undefined,
+        options: { query?: string; accountContext?: string; json?: boolean },
+      ) => {
+        const strategyCatalog = loadStrategies();
+        const referenceCatalog = loadCatalog();
+        if (strategy && options.query) {
+          throw new Error("Use either a strategy id/alias or --query, not both.");
+        }
+        if (!strategy) {
+          const matches = options.query
+            ? searchTaxStrategies(options.query, strategyCatalog)
+            : strategyCatalog.strategies;
+          const rows = matches.map(({ id, title, summary, aliases, tags }) => ({
+            id,
+            title,
+            summary,
+            aliases,
+            tags,
+          }));
+          if (options.json) {
+            io.writeOut(
+              `${JSON.stringify(
+                {
+                  reviewedAt: strategyCatalog.reviewedAt,
+                  jurisdiction: strategyCatalog.jurisdiction,
+                  strategies: rows,
+                  matchCount: rows.length,
+                  notPersonalizedAdvice: true,
+                  tradeAuthorized: false,
+                },
+                null,
+                2,
+              )}\n`,
+            );
+          } else if (rows.length === 0) {
+            io.writeOut("No tax strategy matched the query.\n");
+            io.setExitCode(2);
+          } else {
+            io.writeOut(
+              [
+                `Tax Strategy Guides — ${strategyCatalog.jurisdiction}`,
+                `Reviewed: ${strategyCatalog.reviewedAt}`,
+                "",
+                ...rows.map((entry) => `  ${entry.id} — ${entry.title}`),
+                "",
+                "Show one: robinhood-cli tax strategy <id>",
+                "",
+              ].join("\n"),
+            );
+          }
+          return;
+        }
+
+        const guide = getTaxStrategyGuide(
+          {
+            strategy,
+            accountContext: parseAccountContext(options.accountContext),
+          },
+          strategyCatalog,
+          referenceCatalog,
+        );
+        if (options.json) {
+          io.writeOut(`${JSON.stringify(guide, null, 2)}\n`);
+          return;
+        }
+        io.writeOut(formatTaxStrategyText(guide));
+      },
+    );
+
+  program
+    .command("status")
+    .description(
+      "Show tax research review date, source/topic/strategy counts, and an internal re-review signal. No brokerage initialization or network request.",
+    )
+    .option("--json", "emit structured JSON")
+    .action((options: { json?: boolean }) => {
+      const referenceCatalog = loadCatalog();
+      const strategyCatalog = loadStrategies();
+      const status = getTaxResearchStatus(referenceCatalog, strategyCatalog);
+      if (options.json) {
+        io.writeOut(`${JSON.stringify(status, null, 2)}\n`);
+        return;
+      }
+      io.writeOut(
+        [
+          `Tax Research Status — ${status.jurisdiction}`,
+          `Reviewed: ${status.reviewedAt}`,
+          `Reference topics: ${status.referenceTopicCount}`,
+          `Strategy guides: ${status.strategyCount}`,
+          `Sources: ${status.sourceCount}`,
+          `Review age: ${status.reviewAgeDays ?? "unknown"} day(s)`,
+          `Review recommended: ${status.reviewRecommended ? "yes" : "no"}`,
+          status.maintenancePolicy,
+          "",
+        ].join("\n"),
+      );
+    });
 
   return program;
 }

--- a/cli/src/tax-cli.ts
+++ b/cli/src/tax-cli.ts
@@ -70,9 +70,7 @@ function writeStrategyList(
   catalog: TaxStrategyCatalog,
   options: TaxCliOptions,
 ): void {
-  const matches = options.query
-    ? searchTaxStrategies(options.query, catalog)
-    : catalog.strategies;
+  const matches = options.query ? searchTaxStrategies(options.query, catalog) : catalog.strategies;
   const rows = matches.map(({ id, title, summary, aliases, tags }) => ({
     id,
     title,

--- a/cli/src/tax-cli.ts
+++ b/cli/src/tax-cli.ts
@@ -26,6 +26,13 @@ export interface TaxCliIo {
   setExitCode: (code: number) => void;
 }
 
+interface TaxCliOptions {
+  query?: string;
+  source?: string;
+  accountContext?: string;
+  json?: boolean;
+}
+
 const processIo: TaxCliIo = {
   writeOut: (text) => process.stdout.write(text),
   writeErr: (text) => process.stderr.write(text),
@@ -58,6 +65,85 @@ function parseAccountContext(value: string | undefined): TaxAccountContext {
   return context;
 }
 
+function writeStrategyList(
+  io: TaxCliIo,
+  catalog: TaxStrategyCatalog,
+  options: TaxCliOptions,
+): void {
+  const matches = options.query
+    ? searchTaxStrategies(options.query, catalog)
+    : catalog.strategies;
+  const rows = matches.map(({ id, title, summary, aliases, tags }) => ({
+    id,
+    title,
+    summary,
+    aliases,
+    tags,
+  }));
+
+  if (options.json) {
+    io.writeOut(
+      `${JSON.stringify(
+        {
+          reviewedAt: catalog.reviewedAt,
+          jurisdiction: catalog.jurisdiction,
+          strategies: rows,
+          matchCount: rows.length,
+          notPersonalizedAdvice: true,
+          tradeAuthorized: false,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+
+  if (rows.length === 0) {
+    io.writeOut("No tax strategy matched the query.\n");
+    io.setExitCode(2);
+    return;
+  }
+
+  io.writeOut(
+    [
+      `Tax Strategy Guides — ${catalog.jurisdiction}`,
+      `Reviewed: ${catalog.reviewedAt}`,
+      "",
+      ...rows.map((entry) => `  ${entry.id} — ${entry.title}`),
+      "",
+      "Show one: robinhood-cli tax strategy <id-or-alias>",
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeTaxStatus(
+  io: TaxCliIo,
+  referenceCatalog: TaxReferenceCatalog,
+  strategyCatalog: TaxStrategyCatalog,
+  json: boolean | undefined,
+): void {
+  const status = getTaxResearchStatus(referenceCatalog, strategyCatalog);
+  if (json) {
+    io.writeOut(`${JSON.stringify(status, null, 2)}\n`);
+    return;
+  }
+  io.writeOut(
+    [
+      `Tax Research Status — ${status.jurisdiction}`,
+      `Reviewed: ${status.reviewedAt}`,
+      `Reference topics: ${status.referenceTopicCount}`,
+      `Strategy guides: ${status.strategyCount}`,
+      `Sources: ${status.sourceCount}`,
+      `Review age: ${status.reviewAgeDays ?? "unknown"} day(s)`,
+      `Review recommended: ${status.reviewRecommended ? "yes" : "no"}`,
+      status.maintenancePolicy,
+      "",
+    ].join("\n"),
+  );
+}
+
 export function createTaxProgram(
   io: TaxCliIo = processIo,
   loadCatalog: () => TaxReferenceCatalog = loadTaxReferenceCatalog,
@@ -71,9 +157,14 @@ export function createTaxProgram(
       "Source-backed US federal tax mechanics and strategy-to-rule research routing for Robinhood, equities, options, index options, and tax lots. Educational reference only.",
     )
     .version("1.1.0")
-    .argument("[topic]", "topic id; omit to list topics and strategy guides")
-    .option("-q, --query <text>", "search claims, caveats, evidence lanes, and source ids")
-    .option("--source <source_id>", "show one source record")
+    .argument("[topic]", "rule topic id, `strategy`, or `status`")
+    .argument("[detail...]", "strategy id or alias after `strategy`")
+    .option("-q, --query <text>", "search rule or strategy research")
+    .option("--source <source_id>", "show one tax-reference source record")
+    .option(
+      "--account-context <type>",
+      "strategy context: taxable, traditional-ira, roth-ira, or unknown",
+    )
     .option("--json", "emit structured JSON")
     .addHelpText(
       "after",
@@ -100,132 +191,22 @@ export function createTaxProgram(
       writeOut: io.writeOut,
       writeErr: io.writeErr,
     })
-    .action(
-      (topic: string | undefined, options: { query?: string; source?: string; json?: boolean }) => {
-        const catalog = loadCatalog();
-        if (!topic && !options.query && !options.source) {
-          const topics = listTaxReferenceTopics(catalog);
-          const strategyCatalog = loadStrategies();
-          const strategies = listTaxStrategies(strategyCatalog);
-          if (options.json) {
-            io.writeOut(
-              `${JSON.stringify(
-                {
-                  reviewedAt: catalog.reviewedAt,
-                  jurisdiction: catalog.jurisdiction,
-                  disclaimer: catalog.disclaimer,
-                  topics,
-                  strategies,
-                  notPersonalizedAdvice: true,
-                  tradeAuthorized: false,
-                },
-                null,
-                2,
-              )}\n`,
-            );
-            return;
-          }
-          io.writeOut(
-            [
-              `Tax Research — ${catalog.jurisdiction}`,
-              `Reviewed: ${catalog.reviewedAt}`,
-              catalog.disclaimer,
-              "",
-              "Reference topics:",
-              ...topics.map((entry) => `  ${entry.id} — ${entry.title}`),
-              "",
-              "Strategy guides:",
-              ...strategies.map((entry) => `  ${entry.id} — ${entry.title}`),
-              "",
-              'Search rules:      robinhood-cli tax --query "wash sale"',
-              "Show rule topic:   robinhood-cli tax section-1256",
-              "Show strategy:     robinhood-cli tax strategy wheel",
-              "Check review age:  robinhood-cli tax status",
-              "",
-            ].join("\n"),
-          );
-          return;
-        }
+    .action((topic: string | undefined, detail: string[], options: TaxCliOptions) => {
+      const referenceCatalog = loadCatalog();
+      const strategyCatalog = loadStrategies();
 
-        const result = getTaxReference(
-          { topic, query: options.query, source: options.source },
-          catalog,
-        );
-        if (options.json) {
-          io.writeOut(`${JSON.stringify(result, null, 2)}\n`);
-          return;
+      if (topic === "strategy") {
+        if (options.source) {
+          throw new Error("--source applies to tax-reference topics, not strategy guides.");
         }
-        io.writeOut(formatTaxReferenceText(result));
-        if (result.matchCount === 0 && !options.source) io.setExitCode(2);
-      },
-    );
-
-  program
-    .command("strategy [strategy]")
-    .description(
-      "Map a named strategy to required facts, Robinhood reads, official rule topics, red flags, and stop conditions. Research only; never authorizes a trade.",
-    )
-    .option("-q, --query <text>", "search strategy ids, aliases, tags, facts, and red flags")
-    .option(
-      "--account-context <type>",
-      "taxable, traditional-ira, roth-ira, or unknown (default: unknown)",
-    )
-    .option("--json", "emit structured JSON")
-    .action(
-      (
-        strategy: string | undefined,
-        options: { query?: string; accountContext?: string; json?: boolean },
-      ) => {
-        const strategyCatalog = loadStrategies();
-        const referenceCatalog = loadCatalog();
+        const strategy = detail.join(" ").trim() || undefined;
         if (strategy && options.query) {
-          throw new Error("Use either a strategy id/alias or --query, not both.");
+          throw new Error("Use either a strategy id or alias or --query, not both.");
         }
         if (!strategy) {
-          const matches = options.query
-            ? searchTaxStrategies(options.query, strategyCatalog)
-            : strategyCatalog.strategies;
-          const rows = matches.map(({ id, title, summary, aliases, tags }) => ({
-            id,
-            title,
-            summary,
-            aliases,
-            tags,
-          }));
-          if (options.json) {
-            io.writeOut(
-              `${JSON.stringify(
-                {
-                  reviewedAt: strategyCatalog.reviewedAt,
-                  jurisdiction: strategyCatalog.jurisdiction,
-                  strategies: rows,
-                  matchCount: rows.length,
-                  notPersonalizedAdvice: true,
-                  tradeAuthorized: false,
-                },
-                null,
-                2,
-              )}\n`,
-            );
-          } else if (rows.length === 0) {
-            io.writeOut("No tax strategy matched the query.\n");
-            io.setExitCode(2);
-          } else {
-            io.writeOut(
-              [
-                `Tax Strategy Guides — ${strategyCatalog.jurisdiction}`,
-                `Reviewed: ${strategyCatalog.reviewedAt}`,
-                "",
-                ...rows.map((entry) => `  ${entry.id} — ${entry.title}`),
-                "",
-                "Show one: robinhood-cli tax strategy <id>",
-                "",
-              ].join("\n"),
-            );
-          }
+          writeStrategyList(io, strategyCatalog, options);
           return;
         }
-
         const guide = getTaxStrategyGuide(
           {
             strategy,
@@ -239,36 +220,79 @@ export function createTaxProgram(
           return;
         }
         io.writeOut(formatTaxStrategyText(guide));
-      },
-    );
-
-  program
-    .command("status")
-    .description(
-      "Show tax research review date, source/topic/strategy counts, and an internal re-review signal. No brokerage initialization or network request.",
-    )
-    .option("--json", "emit structured JSON")
-    .action((options: { json?: boolean }) => {
-      const referenceCatalog = loadCatalog();
-      const strategyCatalog = loadStrategies();
-      const status = getTaxResearchStatus(referenceCatalog, strategyCatalog);
-      if (options.json) {
-        io.writeOut(`${JSON.stringify(status, null, 2)}\n`);
         return;
       }
-      io.writeOut(
-        [
-          `Tax Research Status — ${status.jurisdiction}`,
-          `Reviewed: ${status.reviewedAt}`,
-          `Reference topics: ${status.referenceTopicCount}`,
-          `Strategy guides: ${status.strategyCount}`,
-          `Sources: ${status.sourceCount}`,
-          `Review age: ${status.reviewAgeDays ?? "unknown"} day(s)`,
-          `Review recommended: ${status.reviewRecommended ? "yes" : "no"}`,
-          status.maintenancePolicy,
-          "",
-        ].join("\n"),
+
+      if (topic === "status") {
+        if (detail.length > 0 || options.query || options.source || options.accountContext) {
+          throw new Error("`tax status` accepts only --json.");
+        }
+        writeTaxStatus(io, referenceCatalog, strategyCatalog, options.json);
+        return;
+      }
+
+      if (detail.length > 0) {
+        throw new Error(
+          `Unexpected extra argument after tax topic "${topic ?? ""}": ${detail.join(" ")}`,
+        );
+      }
+      if (options.accountContext) {
+        throw new Error("--account-context is available only with `tax strategy`.");
+      }
+
+      if (!topic && !options.query && !options.source) {
+        const topics = listTaxReferenceTopics(referenceCatalog);
+        const strategies = listTaxStrategies(strategyCatalog);
+        if (options.json) {
+          io.writeOut(
+            `${JSON.stringify(
+              {
+                reviewedAt: referenceCatalog.reviewedAt,
+                jurisdiction: referenceCatalog.jurisdiction,
+                disclaimer: referenceCatalog.disclaimer,
+                topics,
+                strategies,
+                notPersonalizedAdvice: true,
+                tradeAuthorized: false,
+              },
+              null,
+              2,
+            )}\n`,
+          );
+          return;
+        }
+        io.writeOut(
+          [
+            `Tax Reference — ${referenceCatalog.jurisdiction}`,
+            `Reviewed: ${referenceCatalog.reviewedAt}`,
+            referenceCatalog.disclaimer,
+            "",
+            "Reference topics:",
+            ...topics.map((entry) => `  ${entry.id} — ${entry.title}`),
+            "",
+            "Strategy guides:",
+            ...strategies.map((entry) => `  ${entry.id} — ${entry.title}`),
+            "",
+            'Search rules:      robinhood-cli tax --query "wash sale"',
+            "Show rule topic:   robinhood-cli tax section-1256",
+            "Show strategy:     robinhood-cli tax strategy wheel",
+            "Check review age:  robinhood-cli tax status",
+            "",
+          ].join("\n"),
+        );
+        return;
+      }
+
+      const result = getTaxReference(
+        { topic, query: options.query, source: options.source },
+        referenceCatalog,
       );
+      if (options.json) {
+        io.writeOut(`${JSON.stringify(result, null, 2)}\n`);
+        return;
+      }
+      io.writeOut(formatTaxReferenceText(result));
+      if (result.matchCount === 0 && !options.source) io.setExitCode(2);
     });
 
   return program;

--- a/cli/src/tax-strategy.ts
+++ b/cli/src/tax-strategy.ts
@@ -169,9 +169,7 @@ function validateStrategyClaims(
   id: string,
   context: CatalogValidationContext,
 ): void {
-  const claims = Array.isArray(strategy.supplementalClaims)
-    ? strategy.supplementalClaims
-    : [];
+  const claims = Array.isArray(strategy.supplementalClaims) ? strategy.supplementalClaims : [];
   for (const [claimIndex, rawClaim] of claims.entries()) {
     const label = `strategies[${index}].supplementalClaims[${claimIndex}]`;
     const claim = asRecord(rawClaim, label);
@@ -219,11 +217,7 @@ function validateStrategyFacts(
   }
 }
 
-function validateStrategyReads(
-  strategy: Record<string, unknown>,
-  index: number,
-  id: string,
-): void {
+function validateStrategyReads(strategy: Record<string, unknown>, index: number, id: string): void {
   const reads = Array.isArray(strategy.brokerReads) ? strategy.brokerReads : [];
   if (reads.length === 0) {
     throw new Error(`Tax strategy ${id} has no broker reads`);

--- a/cli/src/tax-strategy.ts
+++ b/cli/src/tax-strategy.ts
@@ -1,0 +1,474 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  loadTaxReferenceCatalog,
+  type TaxEvidenceLaneId,
+  type TaxReferenceCatalog,
+  type TaxReferenceClaim,
+  type TaxReferenceSource,
+  type TaxReferenceTopic,
+} from "./tax-reference.js";
+
+export type TaxAccountContext = "taxable" | "traditional-ira" | "roth-ira" | "unknown";
+export type TaxFactSource = "brokerage" | "tax-form" | "user" | "external";
+
+export interface TaxStrategyRequiredFact {
+  id: string;
+  prompt: string;
+  why: string;
+  source: TaxFactSource;
+}
+
+export interface TaxStrategyBrokerRead {
+  purpose: string;
+  cli: string;
+  mcp: string;
+}
+
+export interface TaxStrategyDefinition {
+  id: string;
+  title: string;
+  aliases: string[];
+  tags: string[];
+  summary: string;
+  accountContexts: TaxAccountContext[];
+  topicIds: string[];
+  supplementalClaims: TaxReferenceClaim[];
+  requiredFacts: TaxStrategyRequiredFact[];
+  brokerReads: TaxStrategyBrokerRead[];
+  workflow: string[];
+  redFlags: string[];
+  stopConditions: string[];
+}
+
+export interface TaxStrategyCatalog {
+  schemaVersion: 1;
+  reviewedAt: string;
+  jurisdiction: string;
+  scope: string;
+  disclaimer: string;
+  agentOutputContract: string[];
+  strategies: TaxStrategyDefinition[];
+}
+
+export interface TaxStrategyGuide {
+  schemaVersion: 1;
+  reviewedAt: string;
+  jurisdiction: string;
+  scope: string;
+  disclaimer: string;
+  accountContext: TaxAccountContext;
+  strategy: TaxStrategyDefinition;
+  ruleTopics: TaxReferenceTopic[];
+  sources: TaxReferenceSource[];
+  agentOutputContract: string[];
+  notPersonalizedAdvice: true;
+  tradeAuthorized: false;
+  filingResultDetermined: false;
+}
+
+export interface TaxResearchStatus {
+  reviewedAt: string;
+  jurisdiction: string;
+  referenceTopicCount: number;
+  strategyCount: number;
+  sourceCount: number;
+  reviewAgeDays: number | null;
+  reviewYearMatchesCurrentYear: boolean;
+  reviewRecommended: boolean;
+  maintenancePolicy: string;
+}
+
+let cachedCatalog: TaxStrategyCatalog | undefined;
+
+function defaultCatalogPath(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(moduleDir, "knowledge", "tax-strategies.json"),
+    resolve(moduleDir, "..", "..", "knowledge", "tax-strategies.json"),
+  ];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `Tax strategy catalog was not found. Checked: ${candidates.join(", ")}. Rebuild the CLI package so knowledge/tax-strategies.json is copied into dist.`,
+    );
+  }
+  return found;
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid tax strategy catalog: ${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid tax strategy catalog: ${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requireStringArray(value: unknown, label: string, allowEmpty = false): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(`Invalid tax strategy catalog: ${label} must be a string array`);
+  }
+  if (!allowEmpty && value.length === 0) {
+    throw new Error(`Invalid tax strategy catalog: ${label} must not be empty`);
+  }
+  return value as string[];
+}
+
+function validateCatalog(
+  value: unknown,
+  referenceCatalog: TaxReferenceCatalog,
+): TaxStrategyCatalog {
+  const root = asRecord(value, "root");
+  if (root.schemaVersion !== 1) {
+    throw new Error(`Unsupported tax strategy schema version: ${String(root.schemaVersion)}`);
+  }
+
+  const reviewedAt = requireString(root.reviewedAt, "reviewedAt");
+  if (reviewedAt !== referenceCatalog.reviewedAt) {
+    throw new Error(
+      `Tax strategy catalog review date ${reviewedAt} does not match tax reference review date ${referenceCatalog.reviewedAt}`,
+    );
+  }
+  const jurisdiction = requireString(root.jurisdiction, "jurisdiction");
+  if (jurisdiction !== referenceCatalog.jurisdiction) {
+    throw new Error(
+      `Tax strategy jurisdiction ${jurisdiction} does not match tax reference jurisdiction ${referenceCatalog.jurisdiction}`,
+    );
+  }
+  requireString(root.scope, "scope");
+  requireString(root.disclaimer, "disclaimer");
+  requireStringArray(root.agentOutputContract, "agentOutputContract");
+
+  const strategies = Array.isArray(root.strategies) ? root.strategies : [];
+  if (strategies.length === 0) throw new Error("Tax strategy catalog has no strategies");
+  const topicIds = new Set(referenceCatalog.topics.map((topic) => topic.id));
+  const sourceIds = new Set(referenceCatalog.sources.map((source) => source.id));
+  const laneIds = new Set(referenceCatalog.evidenceLanes.map((lane) => lane.id));
+  const validContexts = new Set<TaxAccountContext>([
+    "taxable",
+    "traditional-ira",
+    "roth-ira",
+    "unknown",
+  ]);
+  const validFactSources = new Set<TaxFactSource>(["brokerage", "tax-form", "user", "external"]);
+  const strategyIds = new Set<string>();
+  const normalizedNames = new Map<string, string>();
+
+  for (const [index, rawStrategy] of strategies.entries()) {
+    const strategy = asRecord(rawStrategy, `strategies[${index}]`);
+    const id = requireString(strategy.id, `strategies[${index}].id`);
+    if (strategyIds.has(id)) throw new Error(`Duplicate tax strategy id: ${id}`);
+    strategyIds.add(id);
+    requireString(strategy.title, `strategies[${index}].title`);
+    requireString(strategy.summary, `strategies[${index}].summary`);
+    const aliases = requireStringArray(strategy.aliases, `strategies[${index}].aliases`, true);
+    requireStringArray(strategy.tags, `strategies[${index}].tags`);
+
+    for (const name of [id, ...aliases]) {
+      const normalized = normalizeStrategyName(name);
+      const prior = normalizedNames.get(normalized);
+      if (prior && prior !== id) {
+        throw new Error(`Tax strategy name or alias "${name}" is shared by ${prior} and ${id}`);
+      }
+      normalizedNames.set(normalized, id);
+    }
+
+    const contexts = requireStringArray(
+      strategy.accountContexts,
+      `strategies[${index}].accountContexts`,
+    );
+    for (const context of contexts) {
+      if (!validContexts.has(context as TaxAccountContext)) {
+        throw new Error(`Tax strategy ${id} has unknown account context ${context}`);
+      }
+    }
+
+    const linkedTopics = requireStringArray(strategy.topicIds, `strategies[${index}].topicIds`);
+    for (const topicId of linkedTopics) {
+      if (!topicIds.has(topicId)) throw new Error(`Tax strategy ${id} references unknown topic ${topicId}`);
+    }
+
+    const claims = Array.isArray(strategy.supplementalClaims)
+      ? strategy.supplementalClaims
+      : [];
+    for (const [claimIndex, rawClaim] of claims.entries()) {
+      const claim = asRecord(
+        rawClaim,
+        `strategies[${index}].supplementalClaims[${claimIndex}]`,
+      );
+      const lane = requireString(
+        claim.lane,
+        `strategies[${index}].supplementalClaims[${claimIndex}].lane`,
+      );
+      if (!laneIds.has(lane as TaxEvidenceLaneId)) {
+        throw new Error(`Tax strategy ${id} references unknown evidence lane ${lane}`);
+      }
+      requireString(
+        claim.certainty,
+        `strategies[${index}].supplementalClaims[${claimIndex}].certainty`,
+      );
+      requireString(claim.text, `strategies[${index}].supplementalClaims[${claimIndex}].text`);
+      const claimSources = requireStringArray(
+        claim.sourceIds,
+        `strategies[${index}].supplementalClaims[${claimIndex}].sourceIds`,
+      );
+      for (const sourceId of claimSources) {
+        if (!sourceIds.has(sourceId)) {
+          throw new Error(`Tax strategy ${id} references unknown source ${sourceId}`);
+        }
+      }
+    }
+
+    const facts = Array.isArray(strategy.requiredFacts) ? strategy.requiredFacts : [];
+    if (facts.length === 0) throw new Error(`Tax strategy ${id} has no required facts`);
+    const factIds = new Set<string>();
+    for (const [factIndex, rawFact] of facts.entries()) {
+      const fact = asRecord(rawFact, `strategies[${index}].requiredFacts[${factIndex}]`);
+      const factId = requireString(
+        fact.id,
+        `strategies[${index}].requiredFacts[${factIndex}].id`,
+      );
+      if (factIds.has(factId)) throw new Error(`Tax strategy ${id} has duplicate fact ${factId}`);
+      factIds.add(factId);
+      requireString(fact.prompt, `strategies[${index}].requiredFacts[${factIndex}].prompt`);
+      requireString(fact.why, `strategies[${index}].requiredFacts[${factIndex}].why`);
+      const source = requireString(
+        fact.source,
+        `strategies[${index}].requiredFacts[${factIndex}].source`,
+      );
+      if (!validFactSources.has(source as TaxFactSource)) {
+        throw new Error(`Tax strategy ${id} fact ${factId} has unknown source ${source}`);
+      }
+    }
+
+    const reads = Array.isArray(strategy.brokerReads) ? strategy.brokerReads : [];
+    if (reads.length === 0) throw new Error(`Tax strategy ${id} has no broker reads`);
+    for (const [readIndex, rawRead] of reads.entries()) {
+      const read = asRecord(rawRead, `strategies[${index}].brokerReads[${readIndex}]`);
+      requireString(read.purpose, `strategies[${index}].brokerReads[${readIndex}].purpose`);
+      requireString(read.cli, `strategies[${index}].brokerReads[${readIndex}].cli`);
+      requireString(read.mcp, `strategies[${index}].brokerReads[${readIndex}].mcp`);
+    }
+
+    requireStringArray(strategy.workflow, `strategies[${index}].workflow`);
+    requireStringArray(strategy.redFlags, `strategies[${index}].redFlags`);
+    requireStringArray(strategy.stopConditions, `strategies[${index}].stopConditions`);
+  }
+
+  return value as TaxStrategyCatalog;
+}
+
+function normalizeStrategyName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function searchableStrategy(strategy: TaxStrategyDefinition): string {
+  return [
+    strategy.id,
+    strategy.title,
+    strategy.summary,
+    ...strategy.aliases,
+    ...strategy.tags,
+    ...strategy.topicIds,
+    ...strategy.supplementalClaims.flatMap((claim) => [
+      claim.lane,
+      claim.certainty,
+      claim.text,
+      ...claim.sourceIds,
+    ]),
+    ...strategy.requiredFacts.flatMap((fact) => [fact.id, fact.prompt, fact.why, fact.source]),
+    ...strategy.workflow,
+    ...strategy.redFlags,
+    ...strategy.stopConditions,
+  ]
+    .join("\n")
+    .toLowerCase();
+}
+
+export function loadTaxStrategyCatalog(
+  path?: string,
+  referenceCatalog: TaxReferenceCatalog = loadTaxReferenceCatalog(),
+): TaxStrategyCatalog {
+  const resolvedPath = path ?? defaultCatalogPath();
+  const isDefault = path === undefined;
+  if (isDefault && cachedCatalog) return cachedCatalog;
+  const parsed = JSON.parse(readFileSync(resolvedPath, "utf8")) as unknown;
+  const catalog = validateCatalog(parsed, referenceCatalog);
+  if (isDefault) cachedCatalog = catalog;
+  return catalog;
+}
+
+export function resetTaxStrategyCache(): void {
+  cachedCatalog = undefined;
+}
+
+export function listTaxStrategies(
+  catalog: TaxStrategyCatalog = loadTaxStrategyCatalog(),
+): Array<Pick<TaxStrategyDefinition, "id" | "title" | "summary" | "aliases" | "tags">> {
+  return catalog.strategies.map(({ id, title, summary, aliases, tags }) => ({
+    id,
+    title,
+    summary,
+    aliases,
+    tags,
+  }));
+}
+
+export function searchTaxStrategies(
+  query: string,
+  catalog: TaxStrategyCatalog = loadTaxStrategyCatalog(),
+): TaxStrategyDefinition[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return catalog.strategies;
+  return catalog.strategies.filter((strategy) => searchableStrategy(strategy).includes(normalized));
+}
+
+export function resolveTaxStrategy(
+  idOrAlias: string,
+  catalog: TaxStrategyCatalog = loadTaxStrategyCatalog(),
+): TaxStrategyDefinition {
+  const normalized = normalizeStrategyName(idOrAlias);
+  const strategy = catalog.strategies.find(
+    (candidate) =>
+      normalizeStrategyName(candidate.id) === normalized ||
+      candidate.aliases.some((alias) => normalizeStrategyName(alias) === normalized),
+  );
+  if (!strategy) {
+    throw new Error(
+      `Unknown tax strategy "${idOrAlias}". Available: ${catalog.strategies
+        .map((candidate) => candidate.id)
+        .join(", ")}`,
+    );
+  }
+  return strategy;
+}
+
+export function getTaxStrategyGuide(
+  input: { strategy: string; accountContext?: TaxAccountContext },
+  strategyCatalog: TaxStrategyCatalog = loadTaxStrategyCatalog(),
+  referenceCatalog: TaxReferenceCatalog = loadTaxReferenceCatalog(),
+): TaxStrategyGuide {
+  const strategy = resolveTaxStrategy(input.strategy, strategyCatalog);
+  const accountContext = input.accountContext ?? "unknown";
+  const ruleTopics = strategy.topicIds.map((topicId) => {
+    const topic = referenceCatalog.topics.find((candidate) => candidate.id === topicId);
+    if (!topic) throw new Error(`Tax strategy ${strategy.id} references missing topic ${topicId}`);
+    return topic;
+  });
+  const sourceIds = new Set([
+    ...ruleTopics.flatMap((topic) => topic.claims.flatMap((claim) => claim.sourceIds)),
+    ...strategy.supplementalClaims.flatMap((claim) => claim.sourceIds),
+  ]);
+  const sources = referenceCatalog.sources.filter((source) => sourceIds.has(source.id));
+  return {
+    schemaVersion: strategyCatalog.schemaVersion,
+    reviewedAt: strategyCatalog.reviewedAt,
+    jurisdiction: strategyCatalog.jurisdiction,
+    scope: strategyCatalog.scope,
+    disclaimer: strategyCatalog.disclaimer,
+    accountContext,
+    strategy,
+    ruleTopics,
+    sources,
+    agentOutputContract: strategyCatalog.agentOutputContract,
+    notPersonalizedAdvice: true,
+    tradeAuthorized: false,
+    filingResultDetermined: false,
+  };
+}
+
+export function getTaxResearchStatus(
+  referenceCatalog: TaxReferenceCatalog = loadTaxReferenceCatalog(),
+  strategyCatalog: TaxStrategyCatalog = loadTaxStrategyCatalog(undefined, referenceCatalog),
+  now: Date = new Date(),
+): TaxResearchStatus {
+  const reviewedMs = Date.parse(`${referenceCatalog.reviewedAt}T00:00:00Z`);
+  const nowMs = now.getTime();
+  const reviewAgeDays =
+    Number.isFinite(reviewedMs) && Number.isFinite(nowMs)
+      ? Math.max(0, Math.floor((nowMs - reviewedMs) / 86_400_000))
+      : null;
+  const reviewYear = Number(referenceCatalog.reviewedAt.slice(0, 4));
+  const currentYear = now.getUTCFullYear();
+  const reviewYearMatchesCurrentYear = reviewYear === currentYear;
+  const reviewRecommended =
+    reviewAgeDays === null || reviewAgeDays > 120 || !reviewYearMatchesCurrentYear;
+  return {
+    reviewedAt: referenceCatalog.reviewedAt,
+    jurisdiction: referenceCatalog.jurisdiction,
+    referenceTopicCount: referenceCatalog.topics.length,
+    strategyCount: strategyCatalog.strategies.length,
+    sourceCount: referenceCatalog.sources.length,
+    reviewAgeDays,
+    reviewYearMatchesCurrentYear,
+    reviewRecommended,
+    maintenancePolicy:
+      "Internal maintenance signal only: re-review when the filing year changes, controlling authority or broker behavior changes, or 120 days elapse. It is not a legal validity period.",
+  };
+}
+
+export function formatTaxStrategyText(guide: TaxStrategyGuide): string {
+  const { strategy } = guide;
+  const lines = [
+    `Tax Strategy Research — ${strategy.title} [${strategy.id}]`,
+    `Jurisdiction: ${guide.jurisdiction}`,
+    `Reviewed: ${guide.reviewedAt}`,
+    `Account context: ${guide.accountContext}`,
+    guide.disclaimer,
+    "",
+    strategy.summary,
+    "",
+    "Required facts:",
+    ...strategy.requiredFacts.map(
+      (fact) => `  - [${fact.source}] ${fact.prompt}\n    why: ${fact.why}`,
+    ),
+    "",
+    "Broker reads:",
+    ...strategy.brokerReads.map(
+      (read) => `  - ${read.purpose}\n    CLI: ${read.cli}\n    MCP: ${read.mcp}`,
+    ),
+    "",
+    "Linked rule topics:",
+    ...guide.ruleTopics.map((topic) => `  - ${topic.id}: ${topic.summary}`),
+  ];
+
+  if (strategy.supplementalClaims.length > 0) {
+    lines.push(
+      "",
+      "Strategy-specific claims:",
+      ...strategy.supplementalClaims.map(
+        (claim) =>
+          `  - [${claim.lane}; certainty=${claim.certainty}] ${claim.text}\n    sources: ${claim.sourceIds.join(", ")}`,
+      ),
+    );
+  }
+
+  lines.push(
+    "",
+    "Workflow:",
+    ...strategy.workflow.map((step, index) => `  ${index + 1}. ${step}`),
+    "",
+    "Red flags:",
+    ...strategy.redFlags.map((flag) => `  - ${flag}`),
+    "",
+    "Stop and escalate when:",
+    ...strategy.stopConditions.map((condition) => `  - ${condition}`),
+    "",
+    "Sources:",
+    ...guide.sources.map((source) => `  - ${source.id} [${source.lane}] ${source.url}`),
+    "",
+    "Result state: educational research only; no filing result determined; no trade authorized.",
+  );
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/cli/src/tax-strategy.ts
+++ b/cli/src/tax-strategy.ts
@@ -80,6 +80,16 @@ export interface TaxResearchStatus {
   maintenancePolicy: string;
 }
 
+interface CatalogValidationContext {
+  topicIds: ReadonlySet<string>;
+  sourceIds: ReadonlySet<string>;
+  laneIds: ReadonlySet<string>;
+  validContexts: ReadonlySet<TaxAccountContext>;
+  validFactSources: ReadonlySet<TaxFactSource>;
+  strategyIds: Set<string>;
+  normalizedNames: Map<string, string>;
+}
+
 let cachedCatalog: TaxStrategyCatalog | undefined;
 
 function defaultCatalogPath(): string {
@@ -91,7 +101,8 @@ function defaultCatalogPath(): string {
   const found = candidates.find((candidate) => existsSync(candidate));
   if (!found) {
     throw new Error(
-      `Tax strategy catalog was not found. Checked: ${candidates.join(", ")}. Rebuild the CLI package so knowledge/tax-strategies.json is copied into dist.`,
+      `Tax strategy catalog was not found. Checked: ${candidates.join(", ")}. ` +
+        "Rebuild the CLI package so knowledge/tax-strategies.json is copied into dist.",
     );
   }
   return found;
@@ -121,6 +132,148 @@ function requireStringArray(value: unknown, label: string, allowEmpty = false): 
   return value as string[];
 }
 
+function normalizeStrategyName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function validateStrategyNames(
+  strategy: Record<string, unknown>,
+  index: number,
+  context: CatalogValidationContext,
+): { id: string; aliases: string[] } {
+  const id = requireString(strategy.id, `strategies[${index}].id`);
+  if (context.strategyIds.has(id)) {
+    throw new Error(`Duplicate tax strategy id: ${id}`);
+  }
+  context.strategyIds.add(id);
+
+  const aliases = requireStringArray(strategy.aliases, `strategies[${index}].aliases`, true);
+  for (const name of [id, ...aliases]) {
+    const normalized = normalizeStrategyName(name);
+    const prior = context.normalizedNames.get(normalized);
+    if (prior && prior !== id) {
+      throw new Error(`Tax strategy name or alias "${name}" is shared by ${prior} and ${id}`);
+    }
+    context.normalizedNames.set(normalized, id);
+  }
+  return { id, aliases };
+}
+
+function validateStrategyClaims(
+  strategy: Record<string, unknown>,
+  index: number,
+  id: string,
+  context: CatalogValidationContext,
+): void {
+  const claims = Array.isArray(strategy.supplementalClaims)
+    ? strategy.supplementalClaims
+    : [];
+  for (const [claimIndex, rawClaim] of claims.entries()) {
+    const label = `strategies[${index}].supplementalClaims[${claimIndex}]`;
+    const claim = asRecord(rawClaim, label);
+    const lane = requireString(claim.lane, `${label}.lane`);
+    if (!context.laneIds.has(lane as TaxEvidenceLaneId)) {
+      throw new Error(`Tax strategy ${id} references unknown evidence lane ${lane}`);
+    }
+    requireString(claim.certainty, `${label}.certainty`);
+    requireString(claim.text, `${label}.text`);
+    const claimSources = requireStringArray(claim.sourceIds, `${label}.sourceIds`);
+    for (const sourceId of claimSources) {
+      if (!context.sourceIds.has(sourceId)) {
+        throw new Error(`Tax strategy ${id} references unknown source ${sourceId}`);
+      }
+    }
+  }
+}
+
+function validateStrategyFacts(
+  strategy: Record<string, unknown>,
+  index: number,
+  id: string,
+  context: CatalogValidationContext,
+): void {
+  const facts = Array.isArray(strategy.requiredFacts) ? strategy.requiredFacts : [];
+  if (facts.length === 0) {
+    throw new Error(`Tax strategy ${id} has no required facts`);
+  }
+
+  const factIds = new Set<string>();
+  for (const [factIndex, rawFact] of facts.entries()) {
+    const label = `strategies[${index}].requiredFacts[${factIndex}]`;
+    const fact = asRecord(rawFact, label);
+    const factId = requireString(fact.id, `${label}.id`);
+    if (factIds.has(factId)) {
+      throw new Error(`Tax strategy ${id} has duplicate fact ${factId}`);
+    }
+    factIds.add(factId);
+    requireString(fact.prompt, `${label}.prompt`);
+    requireString(fact.why, `${label}.why`);
+    const source = requireString(fact.source, `${label}.source`);
+    if (!context.validFactSources.has(source as TaxFactSource)) {
+      throw new Error(`Tax strategy ${id} fact ${factId} has unknown source ${source}`);
+    }
+  }
+}
+
+function validateStrategyReads(
+  strategy: Record<string, unknown>,
+  index: number,
+  id: string,
+): void {
+  const reads = Array.isArray(strategy.brokerReads) ? strategy.brokerReads : [];
+  if (reads.length === 0) {
+    throw new Error(`Tax strategy ${id} has no broker reads`);
+  }
+
+  for (const [readIndex, rawRead] of reads.entries()) {
+    const label = `strategies[${index}].brokerReads[${readIndex}]`;
+    const read = asRecord(rawRead, label);
+    requireString(read.purpose, `${label}.purpose`);
+    requireString(read.cli, `${label}.cli`);
+    requireString(read.mcp, `${label}.mcp`);
+  }
+}
+
+function validateStrategy(
+  rawStrategy: unknown,
+  index: number,
+  context: CatalogValidationContext,
+): void {
+  const strategy = asRecord(rawStrategy, `strategies[${index}]`);
+  const { id } = validateStrategyNames(strategy, index, context);
+  requireString(strategy.title, `strategies[${index}].title`);
+  requireString(strategy.summary, `strategies[${index}].summary`);
+  requireStringArray(strategy.tags, `strategies[${index}].tags`);
+
+  const contexts = requireStringArray(
+    strategy.accountContexts,
+    `strategies[${index}].accountContexts`,
+  );
+  for (const accountContext of contexts) {
+    if (!context.validContexts.has(accountContext as TaxAccountContext)) {
+      throw new Error(`Tax strategy ${id} has unknown account context ${accountContext}`);
+    }
+  }
+
+  const topicIds = requireStringArray(strategy.topicIds, `strategies[${index}].topicIds`);
+  for (const topicId of topicIds) {
+    if (!context.topicIds.has(topicId)) {
+      throw new Error(`Tax strategy ${id} references unknown topic ${topicId}`);
+    }
+  }
+
+  validateStrategyClaims(strategy, index, id, context);
+  validateStrategyFacts(strategy, index, id, context);
+  validateStrategyReads(strategy, index, id);
+  requireStringArray(strategy.workflow, `strategies[${index}].workflow`);
+  requireStringArray(strategy.redFlags, `strategies[${index}].redFlags`);
+  requireStringArray(strategy.stopConditions, `strategies[${index}].stopConditions`);
+}
+
 function validateCatalog(
   value: unknown,
   referenceCatalog: TaxReferenceCatalog,
@@ -133,144 +286,40 @@ function validateCatalog(
   const reviewedAt = requireString(root.reviewedAt, "reviewedAt");
   if (reviewedAt !== referenceCatalog.reviewedAt) {
     throw new Error(
-      `Tax strategy catalog review date ${reviewedAt} does not match tax reference review date ${referenceCatalog.reviewedAt}`,
+      `Tax strategy catalog review date ${reviewedAt} does not match ` +
+        `tax reference review date ${referenceCatalog.reviewedAt}`,
     );
   }
+
   const jurisdiction = requireString(root.jurisdiction, "jurisdiction");
   if (jurisdiction !== referenceCatalog.jurisdiction) {
     throw new Error(
-      `Tax strategy jurisdiction ${jurisdiction} does not match tax reference jurisdiction ${referenceCatalog.jurisdiction}`,
+      `Tax strategy jurisdiction ${jurisdiction} does not match ` +
+        `tax reference jurisdiction ${referenceCatalog.jurisdiction}`,
     );
   }
+
   requireString(root.scope, "scope");
   requireString(root.disclaimer, "disclaimer");
   requireStringArray(root.agentOutputContract, "agentOutputContract");
-
   const strategies = Array.isArray(root.strategies) ? root.strategies : [];
-  if (strategies.length === 0) throw new Error("Tax strategy catalog has no strategies");
-  const topicIds = new Set(referenceCatalog.topics.map((topic) => topic.id));
-  const sourceIds = new Set(referenceCatalog.sources.map((source) => source.id));
-  const laneIds = new Set(referenceCatalog.evidenceLanes.map((lane) => lane.id));
-  const validContexts = new Set<TaxAccountContext>([
-    "taxable",
-    "traditional-ira",
-    "roth-ira",
-    "unknown",
-  ]);
-  const validFactSources = new Set<TaxFactSource>(["brokerage", "tax-form", "user", "external"]);
-  const strategyIds = new Set<string>();
-  const normalizedNames = new Map<string, string>();
-
-  for (const [index, rawStrategy] of strategies.entries()) {
-    const strategy = asRecord(rawStrategy, `strategies[${index}]`);
-    const id = requireString(strategy.id, `strategies[${index}].id`);
-    if (strategyIds.has(id)) throw new Error(`Duplicate tax strategy id: ${id}`);
-    strategyIds.add(id);
-    requireString(strategy.title, `strategies[${index}].title`);
-    requireString(strategy.summary, `strategies[${index}].summary`);
-    const aliases = requireStringArray(strategy.aliases, `strategies[${index}].aliases`, true);
-    requireStringArray(strategy.tags, `strategies[${index}].tags`);
-
-    for (const name of [id, ...aliases]) {
-      const normalized = normalizeStrategyName(name);
-      const prior = normalizedNames.get(normalized);
-      if (prior && prior !== id) {
-        throw new Error(`Tax strategy name or alias "${name}" is shared by ${prior} and ${id}`);
-      }
-      normalizedNames.set(normalized, id);
-    }
-
-    const contexts = requireStringArray(
-      strategy.accountContexts,
-      `strategies[${index}].accountContexts`,
-    );
-    for (const context of contexts) {
-      if (!validContexts.has(context as TaxAccountContext)) {
-        throw new Error(`Tax strategy ${id} has unknown account context ${context}`);
-      }
-    }
-
-    const linkedTopics = requireStringArray(strategy.topicIds, `strategies[${index}].topicIds`);
-    for (const topicId of linkedTopics) {
-      if (!topicIds.has(topicId)) throw new Error(`Tax strategy ${id} references unknown topic ${topicId}`);
-    }
-
-    const claims = Array.isArray(strategy.supplementalClaims)
-      ? strategy.supplementalClaims
-      : [];
-    for (const [claimIndex, rawClaim] of claims.entries()) {
-      const claim = asRecord(
-        rawClaim,
-        `strategies[${index}].supplementalClaims[${claimIndex}]`,
-      );
-      const lane = requireString(
-        claim.lane,
-        `strategies[${index}].supplementalClaims[${claimIndex}].lane`,
-      );
-      if (!laneIds.has(lane as TaxEvidenceLaneId)) {
-        throw new Error(`Tax strategy ${id} references unknown evidence lane ${lane}`);
-      }
-      requireString(
-        claim.certainty,
-        `strategies[${index}].supplementalClaims[${claimIndex}].certainty`,
-      );
-      requireString(claim.text, `strategies[${index}].supplementalClaims[${claimIndex}].text`);
-      const claimSources = requireStringArray(
-        claim.sourceIds,
-        `strategies[${index}].supplementalClaims[${claimIndex}].sourceIds`,
-      );
-      for (const sourceId of claimSources) {
-        if (!sourceIds.has(sourceId)) {
-          throw new Error(`Tax strategy ${id} references unknown source ${sourceId}`);
-        }
-      }
-    }
-
-    const facts = Array.isArray(strategy.requiredFacts) ? strategy.requiredFacts : [];
-    if (facts.length === 0) throw new Error(`Tax strategy ${id} has no required facts`);
-    const factIds = new Set<string>();
-    for (const [factIndex, rawFact] of facts.entries()) {
-      const fact = asRecord(rawFact, `strategies[${index}].requiredFacts[${factIndex}]`);
-      const factId = requireString(
-        fact.id,
-        `strategies[${index}].requiredFacts[${factIndex}].id`,
-      );
-      if (factIds.has(factId)) throw new Error(`Tax strategy ${id} has duplicate fact ${factId}`);
-      factIds.add(factId);
-      requireString(fact.prompt, `strategies[${index}].requiredFacts[${factIndex}].prompt`);
-      requireString(fact.why, `strategies[${index}].requiredFacts[${factIndex}].why`);
-      const source = requireString(
-        fact.source,
-        `strategies[${index}].requiredFacts[${factIndex}].source`,
-      );
-      if (!validFactSources.has(source as TaxFactSource)) {
-        throw new Error(`Tax strategy ${id} fact ${factId} has unknown source ${source}`);
-      }
-    }
-
-    const reads = Array.isArray(strategy.brokerReads) ? strategy.brokerReads : [];
-    if (reads.length === 0) throw new Error(`Tax strategy ${id} has no broker reads`);
-    for (const [readIndex, rawRead] of reads.entries()) {
-      const read = asRecord(rawRead, `strategies[${index}].brokerReads[${readIndex}]`);
-      requireString(read.purpose, `strategies[${index}].brokerReads[${readIndex}].purpose`);
-      requireString(read.cli, `strategies[${index}].brokerReads[${readIndex}].cli`);
-      requireString(read.mcp, `strategies[${index}].brokerReads[${readIndex}].mcp`);
-    }
-
-    requireStringArray(strategy.workflow, `strategies[${index}].workflow`);
-    requireStringArray(strategy.redFlags, `strategies[${index}].redFlags`);
-    requireStringArray(strategy.stopConditions, `strategies[${index}].stopConditions`);
+  if (strategies.length === 0) {
+    throw new Error("Tax strategy catalog has no strategies");
   }
 
+  const context: CatalogValidationContext = {
+    topicIds: new Set(referenceCatalog.topics.map((topic) => topic.id)),
+    sourceIds: new Set(referenceCatalog.sources.map((source) => source.id)),
+    laneIds: new Set(referenceCatalog.evidenceLanes.map((lane) => lane.id)),
+    validContexts: new Set(["taxable", "traditional-ira", "roth-ira", "unknown"]),
+    validFactSources: new Set(["brokerage", "tax-form", "user", "external"]),
+    strategyIds: new Set(),
+    normalizedNames: new Map(),
+  };
+  for (const [index, strategy] of strategies.entries()) {
+    validateStrategy(strategy, index, context);
+  }
   return value as TaxStrategyCatalog;
-}
-
-function normalizeStrategyName(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }
 
 function searchableStrategy(strategy: TaxStrategyDefinition): string {
@@ -288,6 +337,7 @@ function searchableStrategy(strategy: TaxStrategyDefinition): string {
       ...claim.sourceIds,
     ]),
     ...strategy.requiredFacts.flatMap((fact) => [fact.id, fact.prompt, fact.why, fact.source]),
+    ...strategy.brokerReads.flatMap((read) => [read.purpose, read.cli, read.mcp]),
     ...strategy.workflow,
     ...strategy.redFlags,
     ...strategy.stopConditions,
@@ -345,11 +395,8 @@ export function resolveTaxStrategy(
       candidate.aliases.some((alias) => normalizeStrategyName(alias) === normalized),
   );
   if (!strategy) {
-    throw new Error(
-      `Unknown tax strategy "${idOrAlias}". Available: ${catalog.strategies
-        .map((candidate) => candidate.id)
-        .join(", ")}`,
-    );
+    const available = catalog.strategies.map((candidate) => candidate.id).join(", ");
+    throw new Error(`Unknown tax strategy "${idOrAlias}". Available: ${available}`);
   }
   return strategy;
 }
@@ -363,7 +410,9 @@ export function getTaxStrategyGuide(
   const accountContext = input.accountContext ?? "unknown";
   const ruleTopics = strategy.topicIds.map((topicId) => {
     const topic = referenceCatalog.topics.find((candidate) => candidate.id === topicId);
-    if (!topic) throw new Error(`Tax strategy ${strategy.id} references missing topic ${topicId}`);
+    if (!topic) {
+      throw new Error(`Tax strategy ${strategy.id} references missing topic ${topicId}`);
+    }
     return topic;
   });
   const sourceIds = new Set([
@@ -414,7 +463,8 @@ export function getTaxResearchStatus(
     reviewYearMatchesCurrentYear,
     reviewRecommended,
     maintenancePolicy:
-      "Internal maintenance signal only: re-review when the filing year changes, controlling authority or broker behavior changes, or 120 days elapse. It is not a legal validity period.",
+      "Internal maintenance signal only: re-review when the filing year changes, controlling " +
+      "authority or broker behavior changes, or 120 days elapse. It is not a legal validity period.",
   };
 }
 
@@ -449,7 +499,8 @@ export function formatTaxStrategyText(guide: TaxStrategyGuide): string {
       "Strategy-specific claims:",
       ...strategy.supplementalClaims.map(
         (claim) =>
-          `  - [${claim.lane}; certainty=${claim.certainty}] ${claim.text}\n    sources: ${claim.sourceIds.join(", ")}`,
+          `  - [${claim.lane}; certainty=${claim.certainty}] ${claim.text}\n` +
+          `    sources: ${claim.sourceIds.join(", ")}`,
       ),
     );
   }

--- a/cli/test/package-boundary.test.ts
+++ b/cli/test/package-boundary.test.ts
@@ -39,6 +39,10 @@ describe("published package boundary", () => {
       types: "./dist/tax-reference.d.ts",
       import: "./dist/tax-reference.js",
     });
+    expect(manifest.exports["./tax-strategy"]).toEqual({
+      types: "./dist/tax-strategy.d.ts",
+      import: "./dist/tax-strategy.js",
+    });
   });
 
   it("imports the built package root without parsing the host process arguments", () => {
@@ -66,6 +70,29 @@ describe("published package boundary", () => {
     expect(child.status, child.stderr).toBe(0);
   });
 
+  it("imports the tax strategy API without initializing brokerage state", () => {
+    const runtimeTarget = manifest.exports["./tax-strategy"]?.import;
+    if (!runtimeTarget) throw new Error("Tax strategy API is missing a runtime export");
+    const runtimePath = join(packageRoot, runtimeTarget.replace(/^\.\//, ""));
+    if (!existsSync(runtimePath)) return;
+
+    const importScript = [
+      `const mod = await import(${JSON.stringify(pathToFileURL(runtimePath).href)});`,
+      `const guide = mod.getTaxStrategyGuide({ strategy: "wheel", accountContext: "taxable" });`,
+      `if (guide.strategy.id !== "wheel" || guide.tradeAuthorized !== false) process.exit(2);`,
+    ].join(" ");
+    const child = spawnSync(process.execPath, ["--input-type=module", "--eval", importScript], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: safeEnvironment(),
+      timeout: 10_000,
+    });
+
+    expect(child.error).toBeUndefined();
+    expect(child.status, child.stderr).toBe(0);
+    expect(child.stderr).not.toMatch(/token|auth|brokerage request/i);
+  });
+
   it("routes tax research through the main binary without loading brokerage auth", () => {
     const binary = join(packageRoot, manifest.bin["robinhood-cli"]);
     if (!existsSync(binary)) return;
@@ -88,6 +115,34 @@ describe("published package boundary", () => {
       matchCount: 1,
       notPersonalizedAdvice: true,
       topics: [expect.objectContaining({ id: "section-1256" })],
+    });
+    expect(child.stderr).not.toMatch(/token|auth|brokerage request/i);
+  });
+
+  it("routes strategy research through the main binary without loading brokerage auth", () => {
+    const binary = join(packageRoot, manifest.bin["robinhood-cli"]);
+    if (!existsSync(binary)) return;
+
+    const child = spawnSync(
+      process.execPath,
+      [binary, "tax", "strategy", "covered call", "--account-context", "taxable", "--json"],
+      {
+        cwd: packageRoot,
+        encoding: "utf8",
+        env: safeEnvironment(),
+        timeout: 10_000,
+      },
+    );
+
+    expect(child.error).toBeUndefined();
+    expect(child.status, child.stderr).toBe(0);
+    const result = JSON.parse(child.stdout) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      accountContext: "taxable",
+      strategy: expect.objectContaining({ id: "covered-call" }),
+      notPersonalizedAdvice: true,
+      tradeAuthorized: false,
+      filingResultDetermined: false,
     });
     expect(child.stderr).not.toMatch(/token|auth|brokerage request/i);
   });

--- a/cli/test/tax-strategy.test.ts
+++ b/cli/test/tax-strategy.test.ts
@@ -17,6 +17,14 @@ import {
 const referenceCatalog = loadTaxReferenceCatalog();
 const strategyCatalog = loadTaxStrategyCatalog(undefined, referenceCatalog);
 
+function normalizeName(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 function captureIo() {
   let stdout = "";
   let stderr = "";
@@ -41,7 +49,7 @@ function captureIo() {
 }
 
 describe("tax strategy catalog", () => {
-  it("loads a review-aligned strategy catalog with unique ids and aliases", () => {
+  it("loads a review-aligned strategy catalog with unique cross-strategy aliases", () => {
     expect(strategyCatalog.schemaVersion).toBe(1);
     expect(strategyCatalog.reviewedAt).toBe(referenceCatalog.reviewedAt);
     expect(strategyCatalog.jurisdiction).toBe(referenceCatalog.jurisdiction);
@@ -49,13 +57,17 @@ describe("tax strategy catalog", () => {
     expect(new Set(strategyCatalog.strategies.map((strategy) => strategy.id)).size).toBe(
       strategyCatalog.strategies.length,
     );
-    const normalizedNames = strategyCatalog.strategies.flatMap((strategy) => [
-      strategy.id,
-      ...strategy.aliases,
-    ]);
-    expect(new Set(normalizedNames.map((name) => name.toLowerCase())).size).toBe(
-      normalizedNames.length,
-    );
+
+    const owners = new Map<string, string>();
+    for (const strategy of strategyCatalog.strategies) {
+      for (const name of [strategy.id, ...strategy.aliases]) {
+        const normalized = normalizeName(name);
+        const prior = owners.get(normalized);
+        expect(prior === undefined || prior === strategy.id).toBe(true);
+        owners.set(normalized, strategy.id);
+      }
+    }
+
     expect(strategyCatalog.agentOutputContract.join("\n")).toMatch(
       /missing fact|not evaluated|never authoriz|does not.*authoriz|Tax research never/i,
     );
@@ -121,7 +133,7 @@ describe("tax strategy catalog", () => {
     );
     const dividendText = JSON.stringify(dividend.strategy.supplementalClaims);
     expect(dividendText).toMatch(/more than 60 days.*121-day period/i);
-    expect(dividendText).toMatch(/diminished risk/i);
+    expect(dividendText).toMatch(/diminished risk|risk of loss is diminished/i);
     expect(dividendText).toMatch(/payments in lieu/i);
     expect(dividend.strategy.supplementalClaims.every((claim) => claim.sourceIds.length > 0)).toBe(
       true,
@@ -134,6 +146,21 @@ describe("tax strategy catalog", () => {
     );
     expect(JSON.stringify(shortSale.strategy.supplementalClaims)).toMatch(/Section 1233/i);
     expect(shortSale.sources.map((source) => source.id)).toContain("usc-1233");
+  });
+
+  it("keeps machine-provided broker reads on current CLI grammar", () => {
+    const commands = strategyCatalog.strategies.flatMap((strategy) =>
+      strategy.brokerReads.map((read) => read.cli),
+    );
+    expect(commands.join("\n")).not.toMatch(/robinhood-cli tax-lots --account/);
+    expect(commands.join("\n")).not.toMatch(/robinhood-cli tax-lot\s/);
+    expect(commands).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/tax-lots list <SYMBOL>/),
+        expect.stringMatching(/tax-lots plan-sell <SYMBOL>/),
+        expect.stringMatching(/tax-lots order <ORDER_ID>/),
+      ]),
+    );
   });
 
   it("reports review age as an internal maintenance signal, not a validity period", () => {
@@ -174,6 +201,7 @@ describe("tax strategy CLI", () => {
       [],
       { from: "user" },
     );
+    expect(capture.stdout()).toMatch(/Tax Reference/);
     expect(capture.stdout()).toMatch(/Reference topics:/);
     expect(capture.stdout()).toMatch(/Strategy guides:/);
     expect(capture.stdout()).toMatch(/covered-call/);

--- a/cli/test/tax-strategy.test.ts
+++ b/cli/test/tax-strategy.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -9,9 +9,9 @@ import {
   getTaxStrategyGuide,
   listTaxStrategies,
   loadTaxStrategyCatalog,
-  resetTaxStrategyCache,
   resolveTaxStrategy,
   searchTaxStrategies,
+  type TaxStrategyCatalog,
 } from "../src/tax-strategy.js";
 
 const referenceCatalog = loadTaxReferenceCatalog();
@@ -78,9 +78,9 @@ describe("tax strategy catalog", () => {
     expect(searchTaxStrategies("Form 6781", strategyCatalog).map((strategy) => strategy.id)).toEqual(
       expect.arrayContaining(["section-1256-index-options", "box-spread"]),
     );
-    expect(searchTaxStrategies("selected lot", strategyCatalog).map((strategy) => strategy.id)).toContain(
-      "specific-lot-sale",
-    );
+    expect(
+      searchTaxStrategies("selected lot", strategyCatalog).map((strategy) => strategy.id),
+    ).toContain("specific-lot-sale");
     expect(listTaxStrategies(strategyCatalog)[0]).not.toHaveProperty("requiredFacts");
   });
 
@@ -155,18 +155,14 @@ describe("tax strategy catalog", () => {
   });
 
   it("fails closed when strategy data drifts from the reference catalog", () => {
-    const sourcePath = join(
-      process.cwd(),
-      "knowledge",
-      "tax-strategies.json",
-    );
-    const parsed = JSON.parse(readFileSync(sourcePath, "utf8")) as Record<string, unknown>;
+    const parsed = JSON.parse(JSON.stringify(strategyCatalog)) as TaxStrategyCatalog;
     const directory = mkdtempSync(join(tmpdir(), "rh-tax-strategy-"));
     const path = join(directory, "invalid.json");
-    const strategies = parsed.strategies as Array<Record<string, unknown>>;
-    const first = { ...strategies[0], topicIds: ["not-a-real-topic"] };
-    writeFileSync(path, JSON.stringify({ ...parsed, strategies: [first, ...strategies.slice(1)] }));
-    resetTaxStrategyCache();
+    const first = { ...parsed.strategies[0]!, topicIds: ["not-a-real-topic"] };
+    writeFileSync(
+      path,
+      JSON.stringify({ ...parsed, strategies: [first, ...parsed.strategies.slice(1)] }),
+    );
     expect(() => loadTaxStrategyCatalog(path, referenceCatalog)).toThrow(/unknown topic/);
   });
 });

--- a/cli/test/tax-strategy.test.ts
+++ b/cli/test/tax-strategy.test.ts
@@ -1,0 +1,246 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createTaxProgram, type TaxCliIo } from "../src/tax-cli.js";
+import { loadTaxReferenceCatalog } from "../src/tax-reference.js";
+import {
+  getTaxResearchStatus,
+  getTaxStrategyGuide,
+  listTaxStrategies,
+  loadTaxStrategyCatalog,
+  resetTaxStrategyCache,
+  resolveTaxStrategy,
+  searchTaxStrategies,
+} from "../src/tax-strategy.js";
+
+const referenceCatalog = loadTaxReferenceCatalog();
+const strategyCatalog = loadTaxStrategyCatalog(undefined, referenceCatalog);
+
+function captureIo() {
+  let stdout = "";
+  let stderr = "";
+  const exitCodes: number[] = [];
+  const io: TaxCliIo = {
+    writeOut: (text) => {
+      stdout += text;
+    },
+    writeErr: (text) => {
+      stderr += text;
+    },
+    setExitCode: (code) => {
+      exitCodes.push(code);
+    },
+  };
+  return {
+    io,
+    stdout: () => stdout,
+    stderr: () => stderr,
+    exitCodes,
+  };
+}
+
+describe("tax strategy catalog", () => {
+  it("loads a review-aligned strategy catalog with unique ids and aliases", () => {
+    expect(strategyCatalog.schemaVersion).toBe(1);
+    expect(strategyCatalog.reviewedAt).toBe(referenceCatalog.reviewedAt);
+    expect(strategyCatalog.jurisdiction).toBe(referenceCatalog.jurisdiction);
+    expect(strategyCatalog.strategies.length).toBeGreaterThanOrEqual(11);
+    expect(new Set(strategyCatalog.strategies.map((strategy) => strategy.id)).size).toBe(
+      strategyCatalog.strategies.length,
+    );
+    const normalizedNames = strategyCatalog.strategies.flatMap((strategy) => [
+      strategy.id,
+      ...strategy.aliases,
+    ]);
+    expect(new Set(normalizedNames.map((name) => name.toLowerCase())).size).toBe(
+      normalizedNames.length,
+    );
+    expect(strategyCatalog.agentOutputContract.join("\n")).toMatch(
+      /missing fact|not evaluated|never authoriz|does not.*authoriz|Tax research never/i,
+    );
+  });
+
+  it("resolves ids and human aliases without guessing nearby strategies", () => {
+    expect(resolveTaxStrategy("wheel", strategyCatalog).id).toBe("wheel");
+    expect(resolveTaxStrategy("covered call", strategyCatalog).id).toBe("covered-call");
+    expect(resolveTaxStrategy("CSP", strategyCatalog).id).toBe("cash-secured-put");
+    expect(resolveTaxStrategy("short against the box", strategyCatalog).id).toBe(
+      "short-stock",
+    );
+    expect(() => resolveTaxStrategy("covered", strategyCatalog)).toThrow(/Unknown tax strategy/);
+  });
+
+  it("searches strategy mechanics, facts, aliases, tags, and red flags", () => {
+    expect(searchTaxStrategies("dividend", strategyCatalog).map((strategy) => strategy.id)).toEqual(
+      expect.arrayContaining(["covered-call", "dividend-capture", "collar-or-protective-put"]),
+    );
+    expect(searchTaxStrategies("Form 6781", strategyCatalog).map((strategy) => strategy.id)).toEqual(
+      expect.arrayContaining(["section-1256-index-options", "box-spread"]),
+    );
+    expect(searchTaxStrategies("selected lot", strategyCatalog).map((strategy) => strategy.id)).toContain(
+      "specific-lot-sale",
+    );
+    expect(listTaxStrategies(strategyCatalog)[0]).not.toHaveProperty("requiredFacts");
+  });
+
+  it("returns a body-bound research guide with linked topics and sources", () => {
+    const guide = getTaxStrategyGuide(
+      { strategy: "covered call", accountContext: "taxable" },
+      strategyCatalog,
+      referenceCatalog,
+    );
+    expect(guide).toMatchObject({
+      accountContext: "taxable",
+      notPersonalizedAdvice: true,
+      tradeAuthorized: false,
+      filingResultDetermined: false,
+      strategy: expect.objectContaining({ id: "covered-call" }),
+    });
+    expect(guide.ruleTopics.map((topic) => topic.id)).toEqual(
+      expect.arrayContaining([
+        "option-writer-lifecycle",
+        "qualified-covered-calls",
+        "constructive-sales",
+      ]),
+    );
+    expect(guide.sources.map((source) => source.id)).toEqual(
+      expect.arrayContaining(["irs-pub-550-2025", "ecfr-qcc", "usc-1092"]),
+    );
+    expect(guide.strategy.requiredFacts.map((fact) => fact.id)).toEqual(
+      expect.arrayContaining(["stock-lots", "call-contract", "dividend-dates"]),
+    );
+    expect(guide.strategy.brokerReads.every((read) => read.cli && read.mcp)).toBe(true);
+  });
+
+  it("preserves qualified-dividend and short-sale mechanics as sourced claims", () => {
+    const dividend = getTaxStrategyGuide(
+      { strategy: "dividend-capture", accountContext: "taxable" },
+      strategyCatalog,
+      referenceCatalog,
+    );
+    const dividendText = JSON.stringify(dividend.strategy.supplementalClaims);
+    expect(dividendText).toMatch(/more than 60 days.*121-day period/i);
+    expect(dividendText).toMatch(/diminished risk/i);
+    expect(dividendText).toMatch(/payments in lieu/i);
+    expect(dividend.strategy.supplementalClaims.every((claim) => claim.sourceIds.length > 0)).toBe(
+      true,
+    );
+
+    const shortSale = getTaxStrategyGuide(
+      { strategy: "short-stock", accountContext: "taxable" },
+      strategyCatalog,
+      referenceCatalog,
+    );
+    expect(JSON.stringify(shortSale.strategy.supplementalClaims)).toMatch(/Section 1233/i);
+    expect(shortSale.sources.map((source) => source.id)).toContain("usc-1233");
+  });
+
+  it("reports review age as an internal maintenance signal, not a validity period", () => {
+    const status = getTaxResearchStatus(
+      referenceCatalog,
+      strategyCatalog,
+      new Date("2026-08-25T00:00:00Z"),
+    );
+    expect(status).toMatchObject({
+      reviewedAt: "2026-08-24",
+      reviewAgeDays: 1,
+      reviewYearMatchesCurrentYear: true,
+      reviewRecommended: false,
+      referenceTopicCount: referenceCatalog.topics.length,
+      strategyCount: strategyCatalog.strategies.length,
+      sourceCount: referenceCatalog.sources.length,
+    });
+    expect(status.maintenancePolicy).toMatch(/not a legal validity period/i);
+  });
+
+  it("fails closed when strategy data drifts from the reference catalog", () => {
+    const sourcePath = join(
+      process.cwd(),
+      "knowledge",
+      "tax-strategies.json",
+    );
+    const parsed = JSON.parse(readFileSync(sourcePath, "utf8")) as Record<string, unknown>;
+    const directory = mkdtempSync(join(tmpdir(), "rh-tax-strategy-"));
+    const path = join(directory, "invalid.json");
+    const strategies = parsed.strategies as Array<Record<string, unknown>>;
+    const first = { ...strategies[0], topicIds: ["not-a-real-topic"] };
+    writeFileSync(path, JSON.stringify({ ...parsed, strategies: [first, ...strategies.slice(1)] }));
+    resetTaxStrategyCache();
+    expect(() => loadTaxStrategyCatalog(path, referenceCatalog)).toThrow(/unknown topic/);
+  });
+});
+
+describe("tax strategy CLI", () => {
+  it("lists rule topics and strategy guides from the default tax surface", async () => {
+    const capture = captureIo();
+    await createTaxProgram(capture.io, () => referenceCatalog, () => strategyCatalog).parseAsync(
+      [],
+      { from: "user" },
+    );
+    expect(capture.stdout()).toMatch(/Reference topics:/);
+    expect(capture.stdout()).toMatch(/Strategy guides:/);
+    expect(capture.stdout()).toMatch(/covered-call/);
+  });
+
+  it("returns a structured strategy guide through the main tax parser", async () => {
+    const capture = captureIo();
+    await createTaxProgram(capture.io, () => referenceCatalog, () => strategyCatalog).parseAsync(
+      ["strategy", "covered call", "--account-context", "taxable", "--json"],
+      { from: "user" },
+    );
+    expect(capture.stderr()).toBe("");
+    expect(JSON.parse(capture.stdout())).toMatchObject({
+      accountContext: "taxable",
+      strategy: expect.objectContaining({ id: "covered-call" }),
+      notPersonalizedAdvice: true,
+      tradeAuthorized: false,
+      filingResultDetermined: false,
+    });
+  });
+
+  it("searches strategies and makes an empty result machine-visible", async () => {
+    const found = captureIo();
+    await createTaxProgram(found.io, () => referenceCatalog, () => strategyCatalog).parseAsync(
+      ["strategy", "--query", "dividend", "--json"],
+      { from: "user" },
+    );
+    expect(JSON.parse(found.stdout())).toMatchObject({
+      matchCount: expect.any(Number),
+      strategies: expect.arrayContaining([expect.objectContaining({ id: "dividend-capture" })]),
+      tradeAuthorized: false,
+    });
+
+    const empty = captureIo();
+    await createTaxProgram(empty.io, () => referenceCatalog, () => strategyCatalog).parseAsync(
+      ["strategy", "--query", "definitely-no-match"],
+      { from: "user" },
+    );
+    expect(empty.stdout()).toMatch(/No tax strategy matched/);
+    expect(empty.exitCodes).toEqual([2]);
+  });
+
+  it("exposes source and strategy review status without brokerage state", async () => {
+    const capture = captureIo();
+    await createTaxProgram(capture.io, () => referenceCatalog, () => strategyCatalog).parseAsync(
+      ["status", "--json"],
+      { from: "user" },
+    );
+    expect(JSON.parse(capture.stdout())).toMatchObject({
+      reviewedAt: referenceCatalog.reviewedAt,
+      referenceTopicCount: referenceCatalog.topics.length,
+      strategyCount: strategyCatalog.strategies.length,
+      sourceCount: referenceCatalog.sources.length,
+    });
+  });
+
+  it("rejects an invalid account context before constructing a guide", async () => {
+    const capture = captureIo();
+    await expect(
+      createTaxProgram(capture.io, () => referenceCatalog, () => strategyCatalog).parseAsync(
+        ["strategy", "wheel", "--account-context", "margin"],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(/Unknown account context/);
+  });
+});

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -10,7 +10,7 @@ the user's request. Do not ingest every module by default.
 | --- | --- | --- |
 | 0: operating contract | [`SKILL.md`](../SKILL.md) | Safety invariants, surface selection, and intent routing |
 | 1: focused module | `knowledge/*.md` | Commands, decision rules, and task-specific failure modes |
-| 2: generated reference | [`tax-reference.md`](tax-reference.md) and generated API maps | Versioned claims or machine contracts that prose must not contradict |
+| 2: machine-backed reference | [`tax-reference.md`](tax-reference.md), [`tax-strategy-routing.md`](tax-strategy-routing.md), and generated API maps | Versioned claims, strategy-to-rule contracts, or machine contracts that prose must not contradict |
 | 3: deep research | [`docs/*.md`](../docs/README.md) | Dated evidence, methodology, and longer analysis |
 | 4: maintainer reference | [`AGENTS.md`](../AGENTS.md) | Auth, route details, implementation, and raw examples |
 | runtime truth | CLI `--help`, MCP `tools/list`, package exports | What the current installed build actually exposes |
@@ -19,7 +19,7 @@ Use this precedence when sources conflict:
 
 ```text
 current runtime
-> generated contract
+> generated or validated machine contract
 > primary evidence
 > focused module
 > dated deep research
@@ -53,18 +53,24 @@ Report a discrepancy instead of silently selecting the sentence that makes an ac
 
 ### Tax mechanics and tax-aware account facts
 
-For **every tax question**, load [`tax-reference.md`](tax-reference.md) first. It is generated from a
+For **every material tax claim**, load [`tax-reference.md`](tax-reference.md). It is generated from a
 versioned source catalog and separates primary law, IRS guidance, Robinhood behavior, and planning
 inference.
 
+When the user names a **strategy or structure**, load [`tax-strategy-routing.md`](tax-strategy-routing.md)
+first. It maps the strategy to required facts, maintained Robinhood reads, linked rule topics, red
+flags, and stop conditions without selecting a trade or determining a filing result.
+
 | Module | Load when | Main surfaces |
 | --- | --- | --- |
-| [`tax-reference.md`](tax-reference.md) | Any question about wash sales, Section 1256, QCCs, exercise, boxes, constructive sales, lots, or broker estimates | `robinhood-tax`, importable tax-reference API, MCP knowledge |
+| [`tax-strategy-routing.md`](tax-strategy-routing.md) | Covered call, CSP, wheel, roll, loss harvest, Section 1256 index option, box, collar, dividend capture, short sale, or specific-lot structure | `robinhood-cli tax strategy`, importable tax-strategy API, MCP knowledge plus named account reads |
+| [`tax-reference.md`](tax-reference.md) | Any question about wash sales, Section 1256, QCCs, exercise, boxes, constructive sales, lots, dividend holding periods, short sales, or broker estimates | `robinhood-cli tax`, importable tax-reference API, MCP knowledge |
 | [`tax.md`](tax.md) | The question combines tax mechanics with live Robinhood accounts, lots, history, settings, or documents | `tax-lots`, `documents`, `history`, `recurring`, `settings` |
 | [`tax-loss-harvesting.md`](tax-loss-harvesting.md) | The user is considering a loss sale or replacement exposure | 61-day control workflow and lot evidence |
 
-Tax reference reads are educational and never authorize a sale. Live account facts and state-changing
-actions remain separate surfaces with separate consent.
+Tax research reads are educational and never authorize a sale, roll, assignment response, exercise,
+lot selection, or account change. Live account facts and state-changing actions remain separate
+surfaces with separate consent.
 
 ### Research, income, and operator context
 
@@ -81,7 +87,7 @@ Every focused module should:
 - identify live, local, generated, and inferred evidence separately
 - prefer maintained first-class surfaces over raw routes
 - preserve account scope and timestamps
-- preserve missing, partial, stale, and unverified states
+- preserve missing, partial, stale, unverified, and not-evaluated states
 - use dollar-weighted analysis where position size matters
 - keep mutations dry-run by default
 - require exact user approval for a resolved state-changing action
@@ -95,6 +101,7 @@ A module must not:
 - contradict CLI `--help` or MCP `tools/list`
 - present app estimates as federal tax law
 - turn tax or strategy research into standing trade authorization
+- infer a filing result from a strategy name or product label
 - imply that an HTTP success proves execution
 - erase uncertainty by converting missing values to zero
 
@@ -115,7 +122,16 @@ When a tax claim changes:
 3. use a primary or official source where available
 4. run `pnpm generate:tax-reference`
 5. commit the generated [`tax-reference.md`](tax-reference.md)
-6. update narrative modules only if the operating explanation changed
+6. align [`tax-strategies.json`](tax-strategies.json) when a linked strategy is affected
+7. update narrative modules only if the operating explanation changed
+
+When a tax strategy workflow changes:
+
+1. edit [`tax-strategies.json`](tax-strategies.json)
+2. link only source-backed topic and source IDs from the tax-reference catalog
+3. preserve required facts, broker reads, red flags, and stop conditions
+4. update [`tax-strategy-routing.md`](tax-strategy-routing.md) when the public inventory or contract changes
+5. add focused API and CLI tests
 
 Do not expand [`SKILL.md`](../SKILL.md) into a second `AGENTS.md`. Keep the skill as the binding router
 and place depth here or in `docs/`.

--- a/knowledge/tax-strategies.json
+++ b/knowledge/tax-strategies.json
@@ -1,0 +1,948 @@
+{
+  "schemaVersion": 1,
+  "reviewedAt": "2026-08-24",
+  "jurisdiction": "United States federal income tax",
+  "scope": "Strategy-to-rule research routing for common stock and option structures. The catalog identifies facts, evidence, and rule families to investigate; it does not choose a trade, determine a filing position, or calculate liability.",
+  "disclaimer": "General educational information only. Tax treatment is fact-dependent, state and local rules differ, and the taxpayer's complete return, elections, basis history, other accounts, and year-end forms may change the result.",
+  "agentOutputContract": [
+    "State the strategy, account context, jurisdiction, and review date.",
+    "Separate broker-observed facts, user-supplied facts, official tax rules, planning inferences, and facts not evaluated.",
+    "List every material missing fact before describing a possible tax consequence.",
+    "Do not infer tax treatment from a strategy name, ticker, OCC symbol, app estimate, or order label alone.",
+    "Do not calculate personalized tax liability or claim that a structure is tax-efficient without the taxpayer's complete facts.",
+    "Tax research never authorizes a trade, roll, assignment response, lot selection, or account change."
+  ],
+  "strategies": [
+    {
+      "id": "covered-call",
+      "title": "Covered call and buy-write",
+      "aliases": ["covered call", "buy-write", "call overwrite", "overwrite"],
+      "tags": ["options", "income", "stock", "dividends", "holding-period"],
+      "summary": "Route a stock-plus-short-call structure through option-writer recognition, qualified-covered-call rules, dividend holding-period rules, constructive-sale screening, lot basis, and broker reporting.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": [
+        "option-writer-lifecycle",
+        "qualified-covered-calls",
+        "constructive-sales",
+        "tax-lots-specific-identification",
+        "tax-documents-and-estimates"
+      ],
+      "supplementalClaims": [
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "For common-stock qualified-dividend treatment, Publication 550 generally requires more than 60 holding days during the 121-day window beginning 60 days before the ex-dividend date.",
+          "sourceIds": ["irs-pub-550-2025"]
+        },
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "Days generally do not count toward that dividend holding period while risk of loss is diminished, including certain periods when the taxpayer grants an option to buy substantially identical stock; qualified-covered-call rules can affect the analysis.",
+          "sourceIds": ["irs-pub-550-2025", "ecfr-qcc", "usc-1092"]
+        }
+      ],
+      "requiredFacts": [
+        {
+          "id": "account-context",
+          "prompt": "Is the position in a taxable account, traditional IRA, Roth IRA, or another account type?",
+          "why": "Current taxable recognition, retirement-account consequences, and available broker records differ by account.",
+          "source": "brokerage"
+        },
+        {
+          "id": "stock-lots",
+          "prompt": "Which stock lots are covered, including acquisition dates, quantities, adjusted basis, and any transferred or missing basis?",
+          "why": "Stock holding period, lot selection, assignment proceeds, and dividend qualification depend on the actual lots.",
+          "source": "brokerage"
+        },
+        {
+          "id": "call-contract",
+          "prompt": "What are the exact call instrument, strike, expiration, quantity, premium, and open or close dates?",
+          "why": "Qualified-covered-call and option-writer treatment cannot be inferred from the label covered call.",
+          "source": "brokerage"
+        },
+        {
+          "id": "dividend-dates",
+          "prompt": "Did the stock pay a dividend, and what were the ex-dividend date and stock holding days with diminished risk?",
+          "why": "Dividend qualification has a separate holding-period and risk-of-loss test.",
+          "source": "external"
+        },
+        {
+          "id": "offsetting-positions",
+          "prompt": "Were there other calls, puts, short positions, forwards, collars, or substantially related positions?",
+          "why": "Straddle and constructive-sale rules depend on the whole offsetting position, not one leg.",
+          "source": "user"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Resolve the owned account and account class.",
+          "cli": "robinhood-cli accounts --json",
+          "mcp": "robinhood_accounts"
+        },
+        {
+          "purpose": "Read exact stock lots and basis availability.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Read held option contracts and position side.",
+          "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_holdings"
+        },
+        {
+          "purpose": "Reconcile fills, assignments, exercises, and expirations.",
+          "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_history"
+        },
+        {
+          "purpose": "Reconcile official year-end reporting before a filing conclusion.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Classify the exact stock lots and short-call contract.",
+        "Determine whether the call may be qualified, nonqualified, or not evaluable from available facts.",
+        "Analyze option recognition separately from stock basis, assignment proceeds, dividend holding period, and offsetting-position rules.",
+        "Report broker estimates and federal rule research in separate evidence lanes.",
+        "Leave the filing result unevaluated when contract, lot, dividend, or offsetting-position facts are incomplete."
+      ],
+      "redFlags": [
+        "Deep-in-the-money or long-dated call without a qualified-covered-call analysis.",
+        "Dividend qualification asserted from Form 1099-DIV alone despite short holding period or diminished risk.",
+        "Covered-call label used to dismiss constructive-sale or straddle questions.",
+        "Assignment discussed without identifying the stock lots delivered or the written premium adjustment."
+      ],
+      "stopConditions": [
+        "The strategy includes additional offsetting positions not represented in the broker read.",
+        "Transferred basis, corporate actions, or selected-lot confirmation is missing.",
+        "The user asks whether a particular dividend, loss, or filing position definitively qualifies."
+      ]
+    },
+    {
+      "id": "cash-secured-put",
+      "title": "Cash-secured put",
+      "aliases": ["cash secured put", "csp", "short put", "secured put"],
+      "tags": ["options", "income", "assignment", "basis", "wash-sale"],
+      "summary": "Route a short-put structure through option-writer recognition, assignment basis, substantially-identical replacement review, retirement-account interactions, and year-end reporting.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": [
+        "option-writer-lifecycle",
+        "option-exercise-holding-period",
+        "wash-sales",
+        "retirement-account-wash-sales",
+        "tax-documents-and-estimates"
+      ],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "account-context",
+          "prompt": "Which account holds the short put, and are substantially identical acquisitions occurring in any taxable or retirement account?",
+          "why": "A replacement acquisition in an IRA or Roth IRA can produce a different wash-sale consequence from an ordinary taxable replacement.",
+          "source": "user"
+        },
+        {
+          "id": "put-contract",
+          "prompt": "What are the exact put instrument, strike, expiration, premium, quantity, and lifecycle events?",
+          "why": "Expiration, closing purchase, and assignment have different recognition mechanics.",
+          "source": "brokerage"
+        },
+        {
+          "id": "prior-loss-sales",
+          "prompt": "Were substantially identical shares, options, or contracts sold at a loss in the surrounding 61-day window?",
+          "why": "A put or assigned stock may interact with wash-sale rules; option terms do not create a universal safe harbor.",
+          "source": "user"
+        },
+        {
+          "id": "assignment-stock",
+          "prompt": "If assigned, what shares were acquired and what premium, fees, date, and broker basis were recorded?",
+          "why": "Written-put premium generally reduces the acquired stock basis, and the stock holding period starts after acquisition.",
+          "source": "brokerage"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Resolve account class and ownership.",
+          "cli": "robinhood-cli accounts --json",
+          "mcp": "robinhood_accounts"
+        },
+        {
+          "purpose": "Read the exact short-put holding and contract identifiers.",
+          "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_holdings"
+        },
+        {
+          "purpose": "Read assignments, expirations, exercises, and order history.",
+          "cli": "robinhood-cli options events --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_events"
+        },
+        {
+          "purpose": "Read resulting or replacement stock lots.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        }
+      ],
+      "workflow": [
+        "Identify whether the put expired, was closed, or was assigned.",
+        "Treat the option result and any acquired-stock basis as separate outputs.",
+        "Scan taxable, retirement, recurring, and dividend-reinvestment activity for substantially identical acquisitions.",
+        "Do not label a replacement option safe or washed solely from strike or expiration differences.",
+        "Reconcile the result to year-end forms before presenting a filing conclusion."
+      ],
+      "redFlags": [
+        "Premium described as taxable when received rather than at the relevant lifecycle event.",
+        "Assignment basis computed without the written premium.",
+        "Wash-sale review limited to one account or only identical ticker purchases.",
+        "A Roth or IRA acquisition ignored after a taxable-account loss."
+      ],
+      "stopConditions": [
+        "Other brokers, spouse accounts, or automatic acquisitions are not known.",
+        "The substantially-identical question depends on option terms not resolved by existing authority.",
+        "The user asks for a definitive wash-sale or basis filing result from incomplete records."
+      ]
+    },
+    {
+      "id": "wheel",
+      "title": "Wheel strategy",
+      "aliases": ["wheel", "options wheel", "csp covered call loop"],
+      "tags": ["options", "stock", "assignment", "covered-call", "cash-secured-put"],
+      "summary": "Treat the wheel as a sequence of separate taxable events and stock lots, not one continuous tax object. Route each short put, assignment, stock lot, covered call, roll, and disposition through its own rule set.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": [
+        "option-writer-lifecycle",
+        "option-exercise-holding-period",
+        "qualified-covered-calls",
+        "wash-sales",
+        "retirement-account-wash-sales",
+        "tax-lots-specific-identification",
+        "constructive-sales",
+        "tax-documents-and-estimates"
+      ],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "event-ledger",
+          "prompt": "What are the open, close, expiration, assignment, exercise, and stock-sale events for every wheel leg?",
+          "why": "Each leg can realize or defer a different item; the economic loop is not one tax lot.",
+          "source": "brokerage"
+        },
+        {
+          "id": "stock-lots",
+          "prompt": "Which assigned or purchased stock lots remain, and which lots were delivered or sold?",
+          "why": "Basis, holding period, lot identification, and assignment proceeds require exact lots.",
+          "source": "brokerage"
+        },
+        {
+          "id": "replacement-activity",
+          "prompt": "What same-underlying activity occurred across taxable, retirement, recurring, and DRIP accounts during each loss window?",
+          "why": "Wheel repetition can create replacement acquisitions around loss realizations.",
+          "source": "user"
+        },
+        {
+          "id": "dividend-and-call-facts",
+          "prompt": "Did held stock pay dividends while calls were open, and were the calls technically qualified covered calls?",
+          "why": "Dividend and stock holding-period effects are separate from option premium recognition.",
+          "source": "external"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Classify the current wheel stage from actual stock and option holdings.",
+          "cli": "robinhood-cli wheel <SYMBOL> --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_wheel"
+        },
+        {
+          "purpose": "Build the event ledger across equities and options.",
+          "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_history"
+        },
+        {
+          "purpose": "Read exact remaining and disposed stock lots.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Read option lifecycle and assignment events.",
+          "cli": "robinhood-cli options events --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_events"
+        },
+        {
+          "purpose": "Check recurring and DRIP activity that may create replacement shares.",
+          "cli": "robinhood-cli recurring list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_recurring"
+        }
+      ],
+      "workflow": [
+        "Expand the wheel into a dated event ledger before applying tax rules.",
+        "Analyze each closed or expired option separately from assigned or sold shares.",
+        "Track stock basis and holding period from the actual assignment or purchase date.",
+        "Run wash-sale and retirement-account checks around every realized loss, not just the final cycle.",
+        "Treat projected wheel income as economic analysis, not current taxable income."
+      ],
+      "redFlags": [
+        "Net premium across many legs presented as the taxable result.",
+        "Rolls treated as deferring recognition automatically.",
+        "Assigned shares treated as inheriting the option holding period.",
+        "Covered calls assumed qualified without contract-level analysis.",
+        "Recurring buys or DRIP ignored during a harvesting window."
+      ],
+      "stopConditions": [
+        "The event ledger cannot reconcile order history to stock lots.",
+        "Activity at another broker or retirement account is unknown.",
+        "The user asks whether the whole strategy is categorically tax-efficient."
+      ]
+    },
+    {
+      "id": "option-roll",
+      "title": "Equity-option roll",
+      "aliases": ["roll", "rolling options", "roll out", "roll up", "roll down"],
+      "tags": ["options", "realization", "wash-sale", "covered-call"],
+      "summary": "A roll is a close and a new open. Route the closed contract through recognition and character, then analyze the replacement contract independently for wash-sale, straddle, qualified-covered-call, and account-context issues.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": [
+        "option-writer-lifecycle",
+        "wash-sales",
+        "retirement-account-wash-sales",
+        "qualified-covered-calls",
+        "tax-documents-and-estimates"
+      ],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "close-leg",
+          "prompt": "What exact contract, side, position effect, quantity, fill, and date closed?",
+          "why": "The close leg is a separate realization event and must be matched to the correct original contract.",
+          "source": "brokerage"
+        },
+        {
+          "id": "open-leg",
+          "prompt": "What exact replacement contract, strike, expiration, quantity, fill, and date opened?",
+          "why": "Replacement exposure drives wash-sale and straddle review and cannot be inferred from net roll price.",
+          "source": "brokerage"
+        },
+        {
+          "id": "position-context",
+          "prompt": "Was the rolled option long or written, covered or uncovered, and linked to stock or other offsetting positions?",
+          "why": "Recognition, QCC status, collateral, and offsetting-position rules differ by position role.",
+          "source": "brokerage"
+        },
+        {
+          "id": "cross-account-replacements",
+          "prompt": "Were related contracts or shares acquired in another taxable or retirement account?",
+          "why": "A one-account roll view is not a complete wash-sale analysis.",
+          "source": "user"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Read exact option fills and order linkage.",
+          "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_history"
+        },
+        {
+          "purpose": "Read the remaining option holdings after the roll.",
+          "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_holdings"
+        },
+        {
+          "purpose": "Preserve staged cash-account roll intent without claiming execution.",
+          "cli": "robinhood-cli roll-ledger list --json",
+          "mcp": "robinhood_roll_ledger"
+        }
+      ],
+      "workflow": [
+        "Decompose net roll price into the closed contract and opened contract.",
+        "Recognize that continuation of economic exposure does not by itself defer the closed leg.",
+        "Classify replacement exposure as a wash-sale, straddle, or QCC review flag only when facts support the flag.",
+        "Keep order evidence separate from the roll ledger or UI description.",
+        "Report missing cross-account facts as not evaluated."
+      ],
+      "redFlags": [
+        "A roll described as tax-free or deferred merely because it was one broker ticket.",
+        "Net debit or credit used as the tax result without separate leg basis and proceeds.",
+        "Changed strike or expiration treated as a universal wash-sale escape.",
+        "Cash-account staged roll ledger treated as proof the open leg executed."
+      ],
+      "stopConditions": [
+        "Close and open fills cannot be separated.",
+        "The original contract basis or written premium is missing.",
+        "Substantially-identical or straddle treatment requires a personalized legal conclusion."
+      ]
+    },
+    {
+      "id": "tax-loss-harvesting",
+      "title": "Tax-loss harvesting and replacement exposure",
+      "aliases": ["tax loss harvesting", "tlh", "harvest a loss", "loss harvesting"],
+      "tags": ["loss", "wash-sale", "tax-lots", "retirement-account", "replacement"],
+      "summary": "Route a proposed loss sale through exact-lot identification, complete 61-day acquisition review, retirement-account checks, replacement-exposure uncertainty, and post-trade reconciliation.",
+      "accountContexts": ["taxable", "unknown"],
+      "topicIds": [
+        "wash-sales",
+        "retirement-account-wash-sales",
+        "tax-lots-specific-identification",
+        "tax-documents-and-estimates"
+      ],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "loss-lot",
+          "prompt": "Which exact lot would be sold, with adjusted basis, acquisition date, quantity, and unrealized loss?",
+          "why": "Harvesting is lot-specific; aggregate position loss does not identify the disposed shares.",
+          "source": "brokerage"
+        },
+        {
+          "id": "acquisition-ledger",
+          "prompt": "What substantially identical stock, option, recurring, DRIP, spouse, and other-broker acquisitions occurred or are scheduled in the 61-day window?",
+          "why": "The statutory window reaches before and after the loss sale and can cross account boundaries.",
+          "source": "user"
+        },
+        {
+          "id": "replacement-plan",
+          "prompt": "What replacement exposure is proposed, and what facts support or undermine substantially-identical treatment?",
+          "why": "There is no universal option-strike or expiration safe harbor.",
+          "source": "user"
+        },
+        {
+          "id": "carryovers-and-return-context",
+          "prompt": "What realized gains, capital-loss carryovers, elections, and return-year facts are relevant?",
+          "why": "Economic value from a harvested loss cannot be calculated from the lot alone.",
+          "source": "tax-form"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Read exact available lots and basis provenance.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Read filled sales and acquisitions around the control window.",
+          "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_history"
+        },
+        {
+          "purpose": "Read automatic recurring acquisitions.",
+          "cli": "robinhood-cli recurring list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_recurring"
+        },
+        {
+          "purpose": "Read DRIP and related account settings.",
+          "cli": "robinhood-cli settings --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_settings"
+        },
+        {
+          "purpose": "Reconcile to official tax documents after year end.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Identify the exact loss lot before discussing replacement exposure.",
+        "Build a 61-day acquisition ledger across all known accounts and automations.",
+        "Classify each replacement as clearly identical, clearly different, or fact-specific; do not invent a safe harbor.",
+        "Keep estimated tax value unevaluated unless return-year and carryover facts are supplied.",
+        "After execution, verify the filled lot and reconcile broker adjustments and year-end forms."
+      ],
+      "redFlags": [
+        "Position-level loss used instead of a selected lot.",
+        "Only the 30 days after sale reviewed.",
+        "IRA, Roth IRA, spouse, DRIP, recurring, or other-broker acquisitions omitted.",
+        "Replacement option declared safe solely because strike or expiration changed.",
+        "App estimate treated as the final wash-sale adjustment."
+      ],
+      "stopConditions": [
+        "The complete acquisition ledger is unavailable.",
+        "Transferred basis or corporate-action adjustments are unresolved.",
+        "The user asks for a definitive substantially-identical or personalized tax-savings conclusion."
+      ]
+    },
+    {
+      "id": "section-1256-index-options",
+      "title": "Section 1256 index-option structure",
+      "aliases": ["section 1256", "1256", "index options", "spx options", "xsp options", "ndx options", "rut options", "vix options"],
+      "tags": ["index-options", "mark-to-market", "60-40", "form-6781"],
+      "summary": "Confirm the actual contract before applying Section 1256. Then route year-end mark-to-market, 60/40 capital character, Form 6781, straddles, elections, and broker reporting as separate questions.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": ["section-1256", "tax-documents-and-estimates"],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "actual-contract",
+          "prompt": "What exact contract, underlying index, exchange product, exercise style, settlement, and broker tax classification are involved?",
+          "why": "The phrase index option or a familiar ticker is not enough to establish statutory contract status.",
+          "source": "brokerage"
+        },
+        {
+          "id": "year-end-open-positions",
+          "prompt": "Which contracts remained open on the last business day of the tax year?",
+          "why": "Section 1256 generally marks qualifying open contracts to market annually.",
+          "source": "brokerage"
+        },
+        {
+          "id": "mixed-position-context",
+          "prompt": "Were the contracts part of a mixed straddle, hedge, box, collar, or position with non-Section-1256 legs?",
+          "why": "Mixed positions and elections can change timing and reporting.",
+          "source": "user"
+        },
+        {
+          "id": "form-6781-records",
+          "prompt": "What did the broker report for the return year, and were Form 6781 adjustments or elections made?",
+          "why": "Transaction history alone is not the full filing record.",
+          "source": "tax-form"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Resolve exact option contract and product metadata.",
+          "cli": "robinhood-cli options inspect <OPTION_ID> --json",
+          "mcp": "robinhood_options_inspect"
+        },
+        {
+          "purpose": "Read current and historical option events.",
+          "cli": "robinhood-cli options events --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_events"
+        },
+        {
+          "purpose": "Read official tax forms and Section 1256 reporting.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Confirm contract identity before applying Section 1256 language.",
+        "Separate statutory 60/40 character from current marginal-rate comparisons.",
+        "Identify year-end open contracts and mark-to-market items.",
+        "Screen for mixed straddles, hedges, boxes, and elections.",
+        "Reconcile to the return-year Form 1099-B and Form 6781."
+      ],
+      "redFlags": [
+        "Any index option assumed Section 1256 from ticker alone.",
+        "60/40 described as a tax rate rather than capital character.",
+        "Open year-end contracts omitted from analysis.",
+        "A mixed Section 1256 and equity-option structure treated as pure Section 1256."
+      ],
+      "stopConditions": [
+        "Contract classification or broker reporting is unavailable.",
+        "A mixed-straddle or election question is material.",
+        "The user asks for a personalized rate advantage without return-year facts."
+      ]
+    },
+    {
+      "id": "box-spread",
+      "title": "Box spread and fixed-return option structure",
+      "aliases": ["box spread", "long box", "short box", "box financing"],
+      "tags": ["options", "financing", "section-1256", "straddle", "conversion-transaction"],
+      "summary": "A fixed payoff does not create one automatic tax characterization. Route a box through contract identity, Section 1256 status, straddle rules, conversion transactions, elections, purpose, and broker reporting.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": ["box-spreads", "section-1256", "constructive-sales", "tax-documents-and-estimates"],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "leg-contracts",
+          "prompt": "What are the exact four contracts, expirations, strikes, quantities, fills, settlement style, and product classifications?",
+          "why": "Contract composition controls whether Section 1256 or mixed-position questions arise.",
+          "source": "brokerage"
+        },
+        {
+          "id": "economic-purpose",
+          "prompt": "Was the structure entered for investment, financing, hedging, or another purpose, and what cash flows were expected?",
+          "why": "Conversion-transaction and interest-equivalent analysis can depend on purpose and economics.",
+          "source": "user"
+        },
+        {
+          "id": "other-positions",
+          "prompt": "Were there related appreciated positions, hedges, straddles, or offsetting contracts?",
+          "why": "The box cannot be analyzed in isolation when other positions alter exposure or tax treatment.",
+          "source": "user"
+        },
+        {
+          "id": "elections-and-forms",
+          "prompt": "What elections and return-year broker reporting apply?",
+          "why": "Form 6781 and mixed-straddle elections can change timing and character.",
+          "source": "tax-form"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Inspect every exact option contract and settlement characteristic.",
+          "cli": "robinhood-cli options inspect <OPTION_ID> --json",
+          "mcp": "robinhood_options_inspect"
+        },
+        {
+          "purpose": "Price and verify the full four-leg package without authorizing execution.",
+          "cli": "robinhood-cli options workbench --json",
+          "mcp": "robinhood_options_workbench"
+        },
+        {
+          "purpose": "Reconcile year-end Section 1256 and straddle reporting.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Verify the four exact contracts and whether every leg is Section 1256 eligible.",
+        "Separate fixed economic payoff from federal timing and character.",
+        "Screen for straddle, conversion-transaction, constructive-sale, and election issues.",
+        "Treat financing-cost or favorable-character claims as fact-specific planning inferences.",
+        "Require professional review before presenting a personalized deduction or characterization."
+      ],
+      "redFlags": [
+        "Short-box cost called automatically deductible interest or capital loss.",
+        "Long-box return called automatically favorable 60/40 income.",
+        "Mixed contracts treated as a pure Section 1256 box.",
+        "Execution and settlement risk dismissed because payoff is fixed at expiration."
+      ],
+      "stopConditions": [
+        "Any leg's statutory classification is unclear.",
+        "The structure is linked to another appreciated or offsetting position.",
+        "The user requests a definitive financing deduction or filing characterization."
+      ]
+    },
+    {
+      "id": "collar-or-protective-put",
+      "title": "Collar or protective-put structure",
+      "aliases": ["collar", "protective put", "married put", "zero cost collar"],
+      "tags": ["options", "hedging", "constructive-sale", "holding-period", "dividends"],
+      "summary": "Route stock hedges through actual risk retained, put and call contracts, stock holding period, qualified-covered-call status, straddles, constructive sales, dividends, and year-end reporting.",
+      "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
+      "topicIds": [
+        "constructive-sales",
+        "qualified-covered-calls",
+        "option-exercise-holding-period",
+        "tax-lots-specific-identification",
+        "tax-documents-and-estimates"
+      ],
+      "supplementalClaims": [
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "Publication 550 says qualified-dividend holding days generally exclude periods in which risk of loss is diminished by a put, a granted call on substantially identical stock, a short sale, or similar related positions, subject to applicable exceptions and regulations.",
+          "sourceIds": ["irs-pub-550-2025", "ecfr-qcc"]
+        }
+      ],
+      "requiredFacts": [
+        {
+          "id": "appreciated-stock",
+          "prompt": "What exact stock lots, holding periods, basis, and unrealized appreciation are hedged?",
+          "why": "Constructive-sale and holding-period analysis depend on the appreciated position and lots.",
+          "source": "brokerage"
+        },
+        {
+          "id": "hedge-contracts",
+          "prompt": "What are the exact put and call strikes, expirations, quantities, premiums, and exercise styles?",
+          "why": "Strategy labels do not reveal how much upside and downside exposure remains.",
+          "source": "brokerage"
+        },
+        {
+          "id": "risk-retained",
+          "prompt": "What market risk remains after considering all related positions and contractual obligations?",
+          "why": "Constructive-sale and straddle questions turn on actual offset, not marketing terminology.",
+          "source": "user"
+        },
+        {
+          "id": "dividend-window",
+          "prompt": "Did dividends occur during periods when the hedge diminished risk?",
+          "why": "Qualified-dividend holding days can be affected separately from stock gain recognition.",
+          "source": "external"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Read stock lots and unrealized appreciation.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Read every exact option leg and current position side.",
+          "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_options_holdings"
+        },
+        {
+          "purpose": "Read dividend dates and current holding-linked payouts.",
+          "cli": "robinhood-cli dividends --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_dividends"
+        }
+      ],
+      "workflow": [
+        "Identify the appreciated stock lots and every hedge leg.",
+        "Measure the actual economic risk retained without converting that measurement into a tax conclusion.",
+        "Screen constructive-sale, straddle, QCC, stock holding-period, and dividend holding-period rules separately.",
+        "Classify unsupported conclusions as not evaluated or fact-specific.",
+        "Keep hedge research separate from trade authorization."
+      ],
+      "redFlags": [
+        "Collar label used as proof that Section 1259 does or does not apply.",
+        "Qualified-dividend status assumed despite diminished risk.",
+        "Only one option leg considered while another related position remains open.",
+        "Tax treatment inferred from net zero premium."
+      ],
+      "stopConditions": [
+        "The complete related-position set is unknown.",
+        "Actual risk retained cannot be established.",
+        "The user requests a definitive constructive-sale conclusion."
+      ]
+    },
+    {
+      "id": "dividend-capture",
+      "title": "Dividend capture or short holding-period dividend trade",
+      "aliases": ["dividend capture", "buy before ex dividend", "qualified dividend holding period"],
+      "tags": ["dividends", "holding-period", "hedging", "substitute-payment"],
+      "summary": "Route a short holding-period dividend trade through qualified-dividend eligibility, diminished-risk days, payments in lieu, economic price adjustment, stock-lot loss rules, and year-end Form 1099-DIV reconciliation.",
+      "accountContexts": ["taxable", "unknown"],
+      "topicIds": ["qualified-covered-calls", "tax-lots-specific-identification", "tax-documents-and-estimates"],
+      "supplementalClaims": [
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "For common stock, Publication 550 generally requires holding the shares for more than 60 days during the 121-day period beginning 60 days before the ex-dividend date for qualified-dividend treatment.",
+          "sourceIds": ["irs-pub-550-2025"]
+        },
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "The holding-day count generally excludes days when risk of loss is diminished by a put, an open short sale, a granted call on substantially identical stock, or substantially similar or related positions.",
+          "sourceIds": ["irs-pub-550-2025"]
+        },
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "Payments in lieu of dividends are not automatically qualified dividends, and dividends tied to related-payment obligations can be excluded from qualified-dividend treatment.",
+          "sourceIds": ["irs-pub-550-2025"]
+        }
+      ],
+      "requiredFacts": [
+        {
+          "id": "stock-dates",
+          "prompt": "What were the stock trade dates, ex-dividend date, record date, and disposition date?",
+          "why": "Qualified-dividend eligibility uses a specific statutory holding window and trade-date counting.",
+          "source": "brokerage"
+        },
+        {
+          "id": "risk-diminishing-positions",
+          "prompt": "Were puts, calls, short sales, forwards, collars, or related positions open during the holding window?",
+          "why": "Those days may not count toward the required holding period.",
+          "source": "user"
+        },
+        {
+          "id": "payment-classification",
+          "prompt": "Was the payment an issuer dividend or a payment in lieu, and how was it reported on Form 1099-DIV?",
+          "why": "Payment labels and withholding can differ from qualified-dividend treatment.",
+          "source": "tax-form"
+        },
+        {
+          "id": "stock-loss-and-distributions",
+          "prompt": "Was the stock sold at a loss, and were extraordinary or other distributions received?",
+          "why": "Separate loss-character or basis rules may apply beyond dividend qualification.",
+          "source": "tax-form"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Read stock acquisition and disposition history.",
+          "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_history"
+        },
+        {
+          "purpose": "Read exact stock lots and holding dates.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Read dividends and payable dates.",
+          "cli": "robinhood-cli dividends --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_dividends"
+        },
+        {
+          "purpose": "Reconcile Form 1099-DIV and payment classification.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Build the statutory holding-day timeline using trade dates and ex-dividend date.",
+        "Remove days with diminished risk only when supported by the complete position facts.",
+        "Distinguish issuer dividends from payments in lieu and related-payment obligations.",
+        "Separate dividend character from economic profit, stock gain or loss, and filing reconciliation.",
+        "Do not call a trade tax-advantaged from a displayed qualified-dividend amount alone."
+      ],
+      "redFlags": [
+        "Form 1099-DIV box 1b treated as conclusive despite failure to meet the taxpayer holding period.",
+        "Options or hedges ignored while counting holding days.",
+        "Payment in lieu described as a qualified dividend.",
+        "Dividend amount discussed without the stock price adjustment and disposition result."
+      ],
+      "stopConditions": [
+        "Trade dates, ex-dividend date, or risk-diminishing positions are incomplete.",
+        "Payment classification cannot be reconciled to the broker tax form.",
+        "The user asks for a personalized tax-rate or after-tax-return conclusion."
+      ]
+    },
+    {
+      "id": "short-stock",
+      "title": "Short stock and substantially identical long property",
+      "aliases": ["short stock", "short sale", "stock short", "short against the box"],
+      "tags": ["short-sale", "holding-period", "constructive-sale", "payments-in-lieu"],
+      "summary": "Route a short sale through closing-property character, substantially identical long positions, holding-period effects, wash sales, related dividend payments, constructive sales, and broker reporting.",
+      "accountContexts": ["taxable", "unknown"],
+      "topicIds": ["wash-sales", "constructive-sales", "tax-documents-and-estimates"],
+      "supplementalClaims": [
+        {
+          "lane": "primary-law",
+          "certainty": "high",
+          "text": "Section 1233 can treat gain on a short sale as short-term and can restart the holding period of substantially identical property held or acquired during the short sale, subject to its statutory conditions.",
+          "sourceIds": ["usc-1233"]
+        },
+        {
+          "lane": "primary-law",
+          "certainty": "high",
+          "text": "If substantially identical property had been held for more than one year on the short-sale date, Section 1233 can treat a loss on closing the short sale as long-term, subject to its scope and exceptions.",
+          "sourceIds": ["usc-1233", "irs-pub-550-2025"]
+        },
+        {
+          "lane": "irs-guidance",
+          "certainty": "high",
+          "text": "Related payments and payments in lieu of dividends require separate classification and are not automatically qualified dividends.",
+          "sourceIds": ["irs-pub-550-2025"]
+        }
+      ],
+      "requiredFacts": [
+        {
+          "id": "short-lifecycle",
+          "prompt": "What property was sold short, when was the short opened and closed, and what property was delivered to close it?",
+          "why": "Character and timing depend on the short-sale lifecycle and closing property.",
+          "source": "brokerage"
+        },
+        {
+          "id": "identical-long-property",
+          "prompt": "What substantially identical stock, securities, futures, or puts were held or acquired, including spouse activity where relevant?",
+          "why": "Section 1233 holding-period and character rules depend on substantially identical property.",
+          "source": "user"
+        },
+        {
+          "id": "appreciated-position",
+          "prompt": "Was the short economically offsetting an appreciated financial position?",
+          "why": "Short-against-the-box or similar structures can raise constructive-sale questions.",
+          "source": "user"
+        },
+        {
+          "id": "dividend-payments",
+          "prompt": "What dividends, payments in lieu, and related-payment obligations occurred while the short was open?",
+          "why": "Payment character and deductibility are separate from short-sale gain or loss.",
+          "source": "tax-form"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Read short-position and closing transaction history where the product is supported.",
+          "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_history"
+        },
+        {
+          "purpose": "Read related long stock lots.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Reconcile dividends, payments, and official tax forms.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Build the short-sale open and close timeline.",
+        "Inventory substantially identical property held or acquired during the short.",
+        "Apply short-sale character and holding-period rules separately from wash-sale and constructive-sale review.",
+        "Classify dividend-related payments from official records rather than assumptions.",
+        "Leave unsupported deductibility and filing conclusions unevaluated."
+      ],
+      "redFlags": [
+        "Short-sale gain assumed long-term from the holding period of delivered shares.",
+        "Existing long position ignored in the character and holding-period analysis.",
+        "Short against the box described as deferring gain without a Section 1259 review.",
+        "Payment in lieu described as an ordinary qualified dividend."
+      ],
+      "stopConditions": [
+        "The closing property or substantially identical holdings are unknown.",
+        "Spouse, other-broker, or derivative activity may be material but is unavailable.",
+        "The user asks for a definitive deduction, character, or constructive-sale conclusion."
+      ]
+    },
+    {
+      "id": "specific-lot-sale",
+      "title": "Specific-lot stock sale",
+      "aliases": ["specific lot", "tax lot sale", "choose tax lots", "highest cost", "fifo sale"],
+      "tags": ["tax-lots", "basis", "holding-period", "broker-confirmation", "wash-sale"],
+      "summary": "Route a lot-aware sale through timely broker identification, written confirmation, basis provenance, holding period, unavailable-lot fallback, wash-sale adjustments, and post-fill verification.",
+      "accountContexts": ["taxable", "unknown"],
+      "topicIds": ["tax-lots-specific-identification", "wash-sales", "tax-documents-and-estimates"],
+      "supplementalClaims": [],
+      "requiredFacts": [
+        {
+          "id": "available-lots",
+          "prompt": "Which exact lots are currently available, including quantity, acquisition date, adjusted basis, basis source, and holding period?",
+          "why": "A position-level average cannot substitute for the selected shares.",
+          "source": "brokerage"
+        },
+        {
+          "id": "selection-timing",
+          "prompt": "When and how will the broker receive the lot instruction, and what written confirmation will be retained?",
+          "why": "Adequate identification depends on timely instructions and confirmation.",
+          "source": "brokerage"
+        },
+        {
+          "id": "fallback-method",
+          "prompt": "What default disposal method applies if selected shares are unavailable or the instruction fails?",
+          "why": "The executed lots can differ from the plan when the broker falls back.",
+          "source": "brokerage"
+        },
+        {
+          "id": "basis-adjustments",
+          "prompt": "Are transferred basis, corporate actions, return of capital, wash sales, or missing adjustments unresolved?",
+          "why": "Displayed basis can be incomplete or estimated.",
+          "source": "tax-form"
+        }
+      ],
+      "brokerReads": [
+        {
+          "purpose": "Inventory exact open lots and basis provenance.",
+          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lots"
+        },
+        {
+          "purpose": "Build a non-sending exact-lot plan.",
+          "cli": "robinhood-cli tax-lot plan --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lot_plan"
+        },
+        {
+          "purpose": "Verify the order and selected or closed lots after execution.",
+          "cli": "robinhood-cli tax-lot order <ORDER_ID> --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_tax_lot_order"
+        },
+        {
+          "purpose": "Reconcile year-end basis and proceeds.",
+          "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
+          "mcp": "robinhood_documents"
+        }
+      ],
+      "workflow": [
+        "Read current eligible lots immediately before planning.",
+        "Preserve selected lot IDs, quantities, basis provenance, and expected fallback.",
+        "Keep the plan non-sending until exact action approval and a verified live contract are available.",
+        "After the fill, verify order history and the broker's selected or closed-lot record.",
+        "Reconcile to year-end forms and external basis records."
+      ],
+      "redFlags": [
+        "Average cost used as if it were a specific lot.",
+        "A planning screen treated as written confirmation or execution evidence.",
+        "Unavailable selected shares silently replaced by a different lot.",
+        "Transferred or missing basis ignored.",
+        "Lot selection optimized without checking wash-sale or return-wide facts."
+      ],
+      "stopConditions": [
+        "The selected lot is unavailable or basis provenance is unresolved.",
+        "The broker cannot provide a retained confirmation of the lot instruction.",
+        "The user asks which lot minimizes tax without return-wide gains, losses, carryovers, and rate facts."
+      ]
+    }
+  ]
+}

--- a/knowledge/tax-strategies.json
+++ b/knowledge/tax-strategies.json
@@ -18,7 +18,7 @@
       "title": "Covered call and buy-write",
       "aliases": ["covered call", "buy-write", "call overwrite", "overwrite"],
       "tags": ["options", "income", "stock", "dividends", "holding-period"],
-      "summary": "Route a stock-plus-short-call structure through option-writer recognition, qualified-covered-call rules, dividend holding-period rules, constructive-sale screening, lot basis, and broker reporting.",
+      "summary": "Route stock plus a written call through option-writer recognition, qualified-covered-call rules, dividend holding periods, lot basis, constructive-sale screening, and broker reporting.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": [
         "option-writer-lifecycle",
@@ -45,31 +45,31 @@
         {
           "id": "account-context",
           "prompt": "Is the position in a taxable account, traditional IRA, Roth IRA, or another account type?",
-          "why": "Current taxable recognition, retirement-account consequences, and available broker records differ by account.",
+          "why": "Current recognition and available broker records differ by account.",
           "source": "brokerage"
         },
         {
           "id": "stock-lots",
-          "prompt": "Which stock lots are covered, including acquisition dates, quantities, adjusted basis, and any transferred or missing basis?",
-          "why": "Stock holding period, lot selection, assignment proceeds, and dividend qualification depend on the actual lots.",
+          "prompt": "Which stock lots are covered, including acquisition dates, quantities, adjusted basis, and basis provenance?",
+          "why": "Stock holding period, assignment proceeds, dividend qualification, and lot identification depend on the actual lots.",
           "source": "brokerage"
         },
         {
           "id": "call-contract",
-          "prompt": "What are the exact call instrument, strike, expiration, quantity, premium, and open or close dates?",
-          "why": "Qualified-covered-call and option-writer treatment cannot be inferred from the label covered call.",
+          "prompt": "What are the exact call instrument, strike, expiration, quantity, premium, and lifecycle dates?",
+          "why": "Qualified-covered-call and writer treatment cannot be inferred from the label covered call.",
           "source": "brokerage"
         },
         {
           "id": "dividend-dates",
-          "prompt": "Did the stock pay a dividend, and what were the ex-dividend date and stock holding days with diminished risk?",
-          "why": "Dividend qualification has a separate holding-period and risk-of-loss test.",
+          "prompt": "Did the stock pay a dividend, and which holding days involved diminished risk?",
+          "why": "Dividend qualification has a separate holding-period test.",
           "source": "external"
         },
         {
           "id": "offsetting-positions",
-          "prompt": "Were there other calls, puts, short positions, forwards, collars, or substantially related positions?",
-          "why": "Straddle and constructive-sale rules depend on the whole offsetting position, not one leg.",
+          "prompt": "Were there other calls, puts, shorts, forwards, collars, or substantially related positions?",
+          "why": "Straddle and constructive-sale analysis depends on the complete position.",
           "source": "user"
         }
       ],
@@ -81,11 +81,11 @@
         },
         {
           "purpose": "Read exact stock lots and basis availability.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
-          "purpose": "Read held option contracts and position side.",
+          "purpose": "Read the exact short-call contract and position side.",
           "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_options_holdings"
         },
@@ -95,28 +95,28 @@
           "mcp": "robinhood_history"
         },
         {
-          "purpose": "Reconcile official year-end reporting before a filing conclusion.",
+          "purpose": "Reconcile official year-end reporting.",
           "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_documents"
         }
       ],
       "workflow": [
-        "Classify the exact stock lots and short-call contract.",
-        "Determine whether the call may be qualified, nonqualified, or not evaluable from available facts.",
-        "Analyze option recognition separately from stock basis, assignment proceeds, dividend holding period, and offsetting-position rules.",
+        "Classify the exact stock lots and call contract.",
+        "Determine whether qualified-covered-call status is supported, unsupported, or not evaluable.",
+        "Analyze option recognition, stock basis, assignment proceeds, and dividend holding period separately.",
         "Report broker estimates and federal rule research in separate evidence lanes.",
-        "Leave the filing result unevaluated when contract, lot, dividend, or offsetting-position facts are incomplete."
+        "Leave the filing result unevaluated when contract, lot, dividend, or related-position facts are incomplete."
       ],
       "redFlags": [
         "Deep-in-the-money or long-dated call without a qualified-covered-call analysis.",
-        "Dividend qualification asserted from Form 1099-DIV alone despite short holding period or diminished risk.",
+        "Dividend qualification asserted from Form 1099-DIV alone.",
         "Covered-call label used to dismiss constructive-sale or straddle questions.",
-        "Assignment discussed without identifying the stock lots delivered or the written premium adjustment."
+        "Assignment discussed without identifying delivered stock lots and premium adjustment."
       ],
       "stopConditions": [
-        "The strategy includes additional offsetting positions not represented in the broker read.",
+        "Additional offsetting positions are not represented in the account evidence.",
         "Transferred basis, corporate actions, or selected-lot confirmation is missing.",
-        "The user asks whether a particular dividend, loss, or filing position definitively qualifies."
+        "The user asks for a definitive dividend, loss, or filing conclusion."
       ]
     },
     {
@@ -124,7 +124,7 @@
       "title": "Cash-secured put",
       "aliases": ["cash secured put", "csp", "short put", "secured put"],
       "tags": ["options", "income", "assignment", "basis", "wash-sale"],
-      "summary": "Route a short-put structure through option-writer recognition, assignment basis, substantially-identical replacement review, retirement-account interactions, and year-end reporting.",
+      "summary": "Route a short put through option-writer recognition, assignment basis, replacement-property review, retirement-account interactions, and year-end reporting.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": [
         "option-writer-lifecycle",
@@ -137,26 +137,26 @@
       "requiredFacts": [
         {
           "id": "account-context",
-          "prompt": "Which account holds the short put, and are substantially identical acquisitions occurring in any taxable or retirement account?",
-          "why": "A replacement acquisition in an IRA or Roth IRA can produce a different wash-sale consequence from an ordinary taxable replacement.",
+          "prompt": "Which account holds the put, and are related acquisitions occurring in any taxable or retirement account?",
+          "why": "Replacement acquisitions in retirement accounts can have different consequences.",
           "source": "user"
         },
         {
           "id": "put-contract",
           "prompt": "What are the exact put instrument, strike, expiration, premium, quantity, and lifecycle events?",
-          "why": "Expiration, closing purchase, and assignment have different recognition mechanics.",
+          "why": "Expiration, closing purchase, and assignment have different mechanics.",
           "source": "brokerage"
         },
         {
           "id": "prior-loss-sales",
           "prompt": "Were substantially identical shares, options, or contracts sold at a loss in the surrounding 61-day window?",
-          "why": "A put or assigned stock may interact with wash-sale rules; option terms do not create a universal safe harbor.",
+          "why": "Assignment or a replacement option may interact with wash-sale rules.",
           "source": "user"
         },
         {
           "id": "assignment-stock",
           "prompt": "If assigned, what shares were acquired and what premium, fees, date, and broker basis were recorded?",
-          "why": "Written-put premium generally reduces the acquired stock basis, and the stock holding period starts after acquisition.",
+          "why": "Written-put premium generally adjusts acquired-stock basis.",
           "source": "brokerage"
         }
       ],
@@ -172,33 +172,33 @@
           "mcp": "robinhood_options_holdings"
         },
         {
-          "purpose": "Read assignments, expirations, exercises, and order history.",
+          "purpose": "Read assignment, expiration, exercise, and option-event evidence.",
           "cli": "robinhood-cli options events --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_options_events"
         },
         {
           "purpose": "Read resulting or replacement stock lots.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         }
       ],
       "workflow": [
         "Identify whether the put expired, was closed, or was assigned.",
-        "Treat the option result and any acquired-stock basis as separate outputs.",
-        "Scan taxable, retirement, recurring, and dividend-reinvestment activity for substantially identical acquisitions.",
-        "Do not label a replacement option safe or washed solely from strike or expiration differences.",
-        "Reconcile the result to year-end forms before presenting a filing conclusion."
+        "Treat the option result and acquired-stock basis as separate outputs.",
+        "Scan taxable, retirement, recurring, and DRIP activity for replacement acquisitions.",
+        "Do not label a replacement option safe solely from strike or expiration differences.",
+        "Reconcile to year-end forms before a filing conclusion."
       ],
       "redFlags": [
-        "Premium described as taxable when received rather than at the relevant lifecycle event.",
-        "Assignment basis computed without the written premium.",
+        "Premium described as taxable when received rather than at the lifecycle event.",
+        "Assignment basis computed without written premium.",
         "Wash-sale review limited to one account or only identical ticker purchases.",
-        "A Roth or IRA acquisition ignored after a taxable-account loss."
+        "IRA or Roth IRA acquisition ignored after a taxable-account loss."
       ],
       "stopConditions": [
-        "Other brokers, spouse accounts, or automatic acquisitions are not known.",
-        "The substantially-identical question depends on option terms not resolved by existing authority.",
-        "The user asks for a definitive wash-sale or basis filing result from incomplete records."
+        "Other brokers, spouse accounts, or automatic acquisitions are unknown.",
+        "Substantially-identical treatment depends on unresolved option facts.",
+        "The user asks for a definitive wash-sale or basis filing result."
       ]
     },
     {
@@ -206,7 +206,7 @@
       "title": "Wheel strategy",
       "aliases": ["wheel", "options wheel", "csp covered call loop"],
       "tags": ["options", "stock", "assignment", "covered-call", "cash-secured-put"],
-      "summary": "Treat the wheel as a sequence of separate taxable events and stock lots, not one continuous tax object. Route each short put, assignment, stock lot, covered call, roll, and disposition through its own rule set.",
+      "summary": "Treat the wheel as a sequence of separate option events and stock lots, not one continuous tax object.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": [
         "option-writer-lifecycle",
@@ -222,8 +222,8 @@
       "requiredFacts": [
         {
           "id": "event-ledger",
-          "prompt": "What are the open, close, expiration, assignment, exercise, and stock-sale events for every wheel leg?",
-          "why": "Each leg can realize or defer a different item; the economic loop is not one tax lot.",
+          "prompt": "What are the open, close, expiration, assignment, exercise, and stock-sale events for every leg?",
+          "why": "Each leg can realize or defer a different item.",
           "source": "brokerage"
         },
         {
@@ -235,7 +235,7 @@
         {
           "id": "replacement-activity",
           "prompt": "What same-underlying activity occurred across taxable, retirement, recurring, and DRIP accounts during each loss window?",
-          "why": "Wheel repetition can create replacement acquisitions around loss realizations.",
+          "why": "Repeated cycles can create replacement acquisitions around realized losses.",
           "source": "user"
         },
         {
@@ -257,8 +257,8 @@
           "mcp": "robinhood_history"
         },
         {
-          "purpose": "Read exact remaining and disposed stock lots.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "purpose": "Read remaining and disposed stock lots.",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
@@ -267,23 +267,23 @@
           "mcp": "robinhood_options_events"
         },
         {
-          "purpose": "Check recurring and DRIP activity that may create replacement shares.",
+          "purpose": "Check recurring activity that can create replacement shares.",
           "cli": "robinhood-cli recurring list --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_recurring"
         }
       ],
       "workflow": [
-        "Expand the wheel into a dated event ledger before applying tax rules.",
+        "Expand the wheel into a dated event ledger.",
         "Analyze each closed or expired option separately from assigned or sold shares.",
         "Track stock basis and holding period from the actual assignment or purchase date.",
-        "Run wash-sale and retirement-account checks around every realized loss, not just the final cycle.",
+        "Run wash-sale and retirement-account checks around every realized loss.",
         "Treat projected wheel income as economic analysis, not current taxable income."
       ],
       "redFlags": [
         "Net premium across many legs presented as the taxable result.",
-        "Rolls treated as deferring recognition automatically.",
+        "Rolls treated as automatically deferring recognition.",
         "Assigned shares treated as inheriting the option holding period.",
-        "Covered calls assumed qualified without contract-level analysis.",
+        "Covered calls assumed qualified without contract analysis.",
         "Recurring buys or DRIP ignored during a harvesting window."
       ],
       "stopConditions": [
@@ -297,7 +297,7 @@
       "title": "Equity-option roll",
       "aliases": ["roll", "rolling options", "roll out", "roll up", "roll down"],
       "tags": ["options", "realization", "wash-sale", "covered-call"],
-      "summary": "A roll is a close and a new open. Route the closed contract through recognition and character, then analyze the replacement contract independently for wash-sale, straddle, qualified-covered-call, and account-context issues.",
+      "summary": "A roll is a close and a new open. Analyze the closed contract and replacement contract separately.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": [
         "option-writer-lifecycle",
@@ -311,25 +311,25 @@
         {
           "id": "close-leg",
           "prompt": "What exact contract, side, position effect, quantity, fill, and date closed?",
-          "why": "The close leg is a separate realization event and must be matched to the correct original contract.",
+          "why": "The close leg is a separate realization event.",
           "source": "brokerage"
         },
         {
           "id": "open-leg",
           "prompt": "What exact replacement contract, strike, expiration, quantity, fill, and date opened?",
-          "why": "Replacement exposure drives wash-sale and straddle review and cannot be inferred from net roll price.",
+          "why": "Replacement exposure drives wash-sale and straddle review.",
           "source": "brokerage"
         },
         {
           "id": "position-context",
-          "prompt": "Was the rolled option long or written, covered or uncovered, and linked to stock or other offsetting positions?",
-          "why": "Recognition, QCC status, collateral, and offsetting-position rules differ by position role.",
+          "prompt": "Was the option long or written, covered or uncovered, and linked to stock or other offsets?",
+          "why": "Recognition, QCC, and offsetting-position rules differ by role.",
           "source": "brokerage"
         },
         {
           "id": "cross-account-replacements",
           "prompt": "Were related contracts or shares acquired in another taxable or retirement account?",
-          "why": "A one-account roll view is not a complete wash-sale analysis.",
+          "why": "One-account evidence is not a complete wash-sale review.",
           "source": "user"
         }
       ],
@@ -340,7 +340,7 @@
           "mcp": "robinhood_history"
         },
         {
-          "purpose": "Read the remaining option holdings after the roll.",
+          "purpose": "Read remaining option holdings after the roll.",
           "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_options_holdings"
         },
@@ -351,22 +351,22 @@
         }
       ],
       "workflow": [
-        "Decompose net roll price into the closed contract and opened contract.",
-        "Recognize that continuation of economic exposure does not by itself defer the closed leg.",
-        "Classify replacement exposure as a wash-sale, straddle, or QCC review flag only when facts support the flag.",
-        "Keep order evidence separate from the roll ledger or UI description.",
+        "Decompose net roll price into closed and opened contracts.",
+        "Do not infer deferral from continued economic exposure.",
+        "Flag wash-sale, straddle, or QCC review only when facts support the flag.",
+        "Keep order evidence separate from a roll ledger or UI description.",
         "Report missing cross-account facts as not evaluated."
       ],
       "redFlags": [
-        "A roll described as tax-free or deferred merely because it was one broker ticket.",
-        "Net debit or credit used as the tax result without separate leg basis and proceeds.",
+        "Roll described as tax-free or deferred because it was one broker ticket.",
+        "Net debit or credit used as the tax result without separate legs.",
         "Changed strike or expiration treated as a universal wash-sale escape.",
-        "Cash-account staged roll ledger treated as proof the open leg executed."
+        "Roll ledger treated as proof the open leg executed."
       ],
       "stopConditions": [
         "Close and open fills cannot be separated.",
-        "The original contract basis or written premium is missing.",
-        "Substantially-identical or straddle treatment requires a personalized legal conclusion."
+        "Original contract basis or written premium is missing.",
+        "Substantially-identical or straddle treatment requires a personalized conclusion."
       ]
     },
     {
@@ -374,7 +374,7 @@
       "title": "Tax-loss harvesting and replacement exposure",
       "aliases": ["tax loss harvesting", "tlh", "harvest a loss", "loss harvesting"],
       "tags": ["loss", "wash-sale", "tax-lots", "retirement-account", "replacement"],
-      "summary": "Route a proposed loss sale through exact-lot identification, complete 61-day acquisition review, retirement-account checks, replacement-exposure uncertainty, and post-trade reconciliation.",
+      "summary": "Route a loss sale through exact-lot identification, a complete 61-day acquisition review, retirement-account checks, and post-trade reconciliation.",
       "accountContexts": ["taxable", "unknown"],
       "topicIds": [
         "wash-sales",
@@ -387,36 +387,36 @@
         {
           "id": "loss-lot",
           "prompt": "Which exact lot would be sold, with adjusted basis, acquisition date, quantity, and unrealized loss?",
-          "why": "Harvesting is lot-specific; aggregate position loss does not identify the disposed shares.",
+          "why": "Harvesting is lot-specific.",
           "source": "brokerage"
         },
         {
           "id": "acquisition-ledger",
-          "prompt": "What substantially identical stock, option, recurring, DRIP, spouse, and other-broker acquisitions occurred or are scheduled in the 61-day window?",
-          "why": "The statutory window reaches before and after the loss sale and can cross account boundaries.",
+          "prompt": "What related stock, option, recurring, DRIP, spouse, and other-broker acquisitions occurred or are scheduled in the 61-day window?",
+          "why": "The statutory window reaches before and after the sale and can cross accounts.",
           "source": "user"
         },
         {
           "id": "replacement-plan",
-          "prompt": "What replacement exposure is proposed, and what facts support or undermine substantially-identical treatment?",
+          "prompt": "What replacement exposure is proposed, and what supports or undermines substantially-identical treatment?",
           "why": "There is no universal option-strike or expiration safe harbor.",
           "source": "user"
         },
         {
-          "id": "carryovers-and-return-context",
-          "prompt": "What realized gains, capital-loss carryovers, elections, and return-year facts are relevant?",
-          "why": "Economic value from a harvested loss cannot be calculated from the lot alone.",
+          "id": "return-context",
+          "prompt": "What realized gains, carryovers, elections, and return-year facts are relevant?",
+          "why": "The economic value of a loss cannot be calculated from one lot alone.",
           "source": "tax-form"
         }
       ],
       "brokerReads": [
         {
           "purpose": "Read exact available lots and basis provenance.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
-          "purpose": "Read filled sales and acquisitions around the control window.",
+          "purpose": "Read filled sales and acquisitions around the window.",
           "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_history"
         },
@@ -427,11 +427,11 @@
         },
         {
           "purpose": "Read DRIP and related account settings.",
-          "cli": "robinhood-cli settings --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli settings show --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_settings"
         },
         {
-          "purpose": "Reconcile to official tax documents after year end.",
+          "purpose": "Reconcile official tax documents after year end.",
           "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_documents"
         }
@@ -439,9 +439,9 @@
       "workflow": [
         "Identify the exact loss lot before discussing replacement exposure.",
         "Build a 61-day acquisition ledger across all known accounts and automations.",
-        "Classify each replacement as clearly identical, clearly different, or fact-specific; do not invent a safe harbor.",
-        "Keep estimated tax value unevaluated unless return-year and carryover facts are supplied.",
-        "After execution, verify the filled lot and reconcile broker adjustments and year-end forms."
+        "Classify replacements as clearly identical, clearly different, or fact-specific.",
+        "Leave estimated tax value unevaluated without return-wide facts.",
+        "After execution, verify the filled lot and reconcile broker adjustments."
       ],
       "redFlags": [
         "Position-level loss used instead of a selected lot.",
@@ -453,7 +453,7 @@
       "stopConditions": [
         "The complete acquisition ledger is unavailable.",
         "Transferred basis or corporate-action adjustments are unresolved.",
-        "The user asks for a definitive substantially-identical or personalized tax-savings conclusion."
+        "The user asks for a definitive substantially-identical or tax-savings conclusion."
       ]
     },
     {
@@ -461,40 +461,40 @@
       "title": "Section 1256 index-option structure",
       "aliases": ["section 1256", "1256", "index options", "spx options", "xsp options", "ndx options", "rut options", "vix options"],
       "tags": ["index-options", "mark-to-market", "60-40", "form-6781"],
-      "summary": "Confirm the actual contract before applying Section 1256. Then route year-end mark-to-market, 60/40 capital character, Form 6781, straddles, elections, and broker reporting as separate questions.",
+      "summary": "Confirm the actual contract before applying Section 1256, then analyze mark-to-market, 60/40 character, Form 6781, straddles, elections, and reporting separately.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": ["section-1256", "tax-documents-and-estimates"],
       "supplementalClaims": [],
       "requiredFacts": [
         {
           "id": "actual-contract",
-          "prompt": "What exact contract, underlying index, exchange product, exercise style, settlement, and broker tax classification are involved?",
-          "why": "The phrase index option or a familiar ticker is not enough to establish statutory contract status.",
+          "prompt": "What exact contract, underlying index, exchange product, exercise style, settlement, and broker classification are involved?",
+          "why": "The phrase index option or a ticker does not establish statutory status.",
           "source": "brokerage"
         },
         {
           "id": "year-end-open-positions",
-          "prompt": "Which contracts remained open on the last business day of the tax year?",
+          "prompt": "Which qualifying contracts remained open on the last business day of the tax year?",
           "why": "Section 1256 generally marks qualifying open contracts to market annually.",
           "source": "brokerage"
         },
         {
           "id": "mixed-position-context",
           "prompt": "Were the contracts part of a mixed straddle, hedge, box, collar, or position with non-Section-1256 legs?",
-          "why": "Mixed positions and elections can change timing and reporting.",
+          "why": "Mixed positions and elections can change the simple result.",
           "source": "user"
         },
         {
           "id": "form-6781-records",
-          "prompt": "What did the broker report for the return year, and were Form 6781 adjustments or elections made?",
-          "why": "Transaction history alone is not the full filing record.",
+          "prompt": "What did the broker report for the return year, and were Form 6781 elections or adjustments made?",
+          "why": "Transaction history alone is not the complete filing record.",
           "source": "tax-form"
         }
       ],
       "brokerReads": [
         {
           "purpose": "Resolve exact option contract and product metadata.",
-          "cli": "robinhood-cli options inspect <OPTION_ID> --json",
+          "cli": "robinhood-cli options inspect <OPTION_ID> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_options_inspect"
         },
         {
@@ -510,21 +510,21 @@
       ],
       "workflow": [
         "Confirm contract identity before applying Section 1256 language.",
-        "Separate statutory 60/40 character from current marginal-rate comparisons.",
+        "Separate 60/40 capital character from marginal-rate comparisons.",
         "Identify year-end open contracts and mark-to-market items.",
         "Screen for mixed straddles, hedges, boxes, and elections.",
-        "Reconcile to the return-year Form 1099-B and Form 6781."
+        "Reconcile to Form 1099-B and Form 6781."
       ],
       "redFlags": [
         "Any index option assumed Section 1256 from ticker alone.",
-        "60/40 described as a tax rate rather than capital character.",
-        "Open year-end contracts omitted from analysis.",
-        "A mixed Section 1256 and equity-option structure treated as pure Section 1256."
+        "60/40 described as a tax rate rather than character.",
+        "Open year-end contracts omitted.",
+        "Mixed equity and Section 1256 legs treated as a pure Section 1256 position."
       ],
       "stopConditions": [
         "Contract classification or broker reporting is unavailable.",
         "A mixed-straddle or election question is material.",
-        "The user asks for a personalized rate advantage without return-year facts."
+        "The user asks for a personalized rate advantage."
       ]
     },
     {
@@ -532,7 +532,7 @@
       "title": "Box spread and fixed-return option structure",
       "aliases": ["box spread", "long box", "short box", "box financing"],
       "tags": ["options", "financing", "section-1256", "straddle", "conversion-transaction"],
-      "summary": "A fixed payoff does not create one automatic tax characterization. Route a box through contract identity, Section 1256 status, straddle rules, conversion transactions, elections, purpose, and broker reporting.",
+      "summary": "A fixed payoff does not create one automatic tax characterization. Analyze contract identity, Section 1256, straddles, conversion transactions, elections, purpose, and reporting.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": ["box-spreads", "section-1256", "constructive-sales", "tax-documents-and-estimates"],
       "supplementalClaims": [],
@@ -540,37 +540,37 @@
         {
           "id": "leg-contracts",
           "prompt": "What are the exact four contracts, expirations, strikes, quantities, fills, settlement style, and product classifications?",
-          "why": "Contract composition controls whether Section 1256 or mixed-position questions arise.",
+          "why": "Contract composition controls Section 1256 and mixed-position questions.",
           "source": "brokerage"
         },
         {
           "id": "economic-purpose",
-          "prompt": "Was the structure entered for investment, financing, hedging, or another purpose, and what cash flows were expected?",
+          "prompt": "Was the structure entered for investment, financing, hedging, or another purpose?",
           "why": "Conversion-transaction and interest-equivalent analysis can depend on purpose and economics.",
           "source": "user"
         },
         {
           "id": "other-positions",
           "prompt": "Were there related appreciated positions, hedges, straddles, or offsetting contracts?",
-          "why": "The box cannot be analyzed in isolation when other positions alter exposure or tax treatment.",
+          "why": "The box may not be analyzable in isolation.",
           "source": "user"
         },
         {
           "id": "elections-and-forms",
-          "prompt": "What elections and return-year broker reporting apply?",
+          "prompt": "What elections and return-year reporting apply?",
           "why": "Form 6781 and mixed-straddle elections can change timing and character.",
           "source": "tax-form"
         }
       ],
       "brokerReads": [
         {
-          "purpose": "Inspect every exact option contract and settlement characteristic.",
-          "cli": "robinhood-cli options inspect <OPTION_ID> --json",
+          "purpose": "Inspect each exact option contract and settlement characteristic.",
+          "cli": "robinhood-cli options inspect <OPTION_ID> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_options_inspect"
         },
         {
-          "purpose": "Price and verify the full four-leg package without authorizing execution.",
-          "cli": "robinhood-cli options workbench --json",
+          "purpose": "Inspect required inputs for non-sending package analysis.",
+          "cli": "robinhood-cli options workbench --help",
           "mcp": "robinhood_options_workbench"
         },
         {
@@ -580,11 +580,11 @@
         }
       ],
       "workflow": [
-        "Verify the four exact contracts and whether every leg is Section 1256 eligible.",
+        "Verify the four exact contracts and statutory classification of each leg.",
         "Separate fixed economic payoff from federal timing and character.",
         "Screen for straddle, conversion-transaction, constructive-sale, and election issues.",
-        "Treat financing-cost or favorable-character claims as fact-specific planning inferences.",
-        "Require professional review before presenting a personalized deduction or characterization."
+        "Treat financing-cost or favorable-character claims as fact-specific inferences.",
+        "Require professional review before a personalized deduction or characterization."
       ],
       "redFlags": [
         "Short-box cost called automatically deductible interest or capital loss.",
@@ -603,7 +603,7 @@
       "title": "Collar or protective-put structure",
       "aliases": ["collar", "protective put", "married put", "zero cost collar"],
       "tags": ["options", "hedging", "constructive-sale", "holding-period", "dividends"],
-      "summary": "Route stock hedges through actual risk retained, put and call contracts, stock holding period, qualified-covered-call status, straddles, constructive sales, dividends, and year-end reporting.",
+      "summary": "Route stock hedges through actual risk retained, exact contracts, stock lots, constructive sales, straddles, qualified-covered-call status, dividends, and reporting.",
       "accountContexts": ["taxable", "traditional-ira", "roth-ira", "unknown"],
       "topicIds": [
         "constructive-sales",
@@ -624,24 +624,24 @@
         {
           "id": "appreciated-stock",
           "prompt": "What exact stock lots, holding periods, basis, and unrealized appreciation are hedged?",
-          "why": "Constructive-sale and holding-period analysis depend on the appreciated position and lots.",
+          "why": "Constructive-sale and holding-period analysis depends on the appreciated lots.",
           "source": "brokerage"
         },
         {
           "id": "hedge-contracts",
           "prompt": "What are the exact put and call strikes, expirations, quantities, premiums, and exercise styles?",
-          "why": "Strategy labels do not reveal how much upside and downside exposure remains.",
+          "why": "Strategy labels do not show how much market risk remains.",
           "source": "brokerage"
         },
         {
           "id": "risk-retained",
-          "prompt": "What market risk remains after considering all related positions and contractual obligations?",
-          "why": "Constructive-sale and straddle questions turn on actual offset, not marketing terminology.",
+          "prompt": "What market risk remains after considering every related position and obligation?",
+          "why": "Constructive-sale and straddle questions turn on actual offset.",
           "source": "user"
         },
         {
           "id": "dividend-window",
-          "prompt": "Did dividends occur during periods when the hedge diminished risk?",
+          "prompt": "Did dividends occur while the hedge diminished risk?",
           "why": "Qualified-dividend holding days can be affected separately from stock gain recognition.",
           "source": "external"
         }
@@ -649,31 +649,31 @@
       "brokerReads": [
         {
           "purpose": "Read stock lots and unrealized appreciation.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
-          "purpose": "Read every exact option leg and current position side.",
+          "purpose": "Read every exact option leg and position side.",
           "cli": "robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_options_holdings"
         },
         {
-          "purpose": "Read dividend dates and current holding-linked payouts.",
+          "purpose": "Read dividend dates and holding-linked payouts.",
           "cli": "robinhood-cli dividends --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_dividends"
         }
       ],
       "workflow": [
-        "Identify the appreciated stock lots and every hedge leg.",
-        "Measure the actual economic risk retained without converting that measurement into a tax conclusion.",
-        "Screen constructive-sale, straddle, QCC, stock holding-period, and dividend holding-period rules separately.",
+        "Identify appreciated stock lots and every hedge leg.",
+        "Measure actual risk retained without converting the measurement into a tax conclusion.",
+        "Screen constructive-sale, straddle, QCC, stock, and dividend holding-period rules separately.",
         "Classify unsupported conclusions as not evaluated or fact-specific.",
         "Keep hedge research separate from trade authorization."
       ],
       "redFlags": [
         "Collar label used as proof that Section 1259 does or does not apply.",
         "Qualified-dividend status assumed despite diminished risk.",
-        "Only one option leg considered while another related position remains open.",
+        "Only one leg considered while another related position remains open.",
         "Tax treatment inferred from net zero premium."
       ],
       "stopConditions": [
@@ -687,7 +687,7 @@
       "title": "Dividend capture or short holding-period dividend trade",
       "aliases": ["dividend capture", "buy before ex dividend", "qualified dividend holding period"],
       "tags": ["dividends", "holding-period", "hedging", "substitute-payment"],
-      "summary": "Route a short holding-period dividend trade through qualified-dividend eligibility, diminished-risk days, payments in lieu, economic price adjustment, stock-lot loss rules, and year-end Form 1099-DIV reconciliation.",
+      "summary": "Route a short holding-period dividend trade through qualified-dividend eligibility, diminished-risk days, payments in lieu, stock-lot results, and Form 1099-DIV reconciliation.",
       "accountContexts": ["taxable", "unknown"],
       "topicIds": ["qualified-covered-calls", "tax-lots-specific-identification", "tax-documents-and-estimates"],
       "supplementalClaims": [
@@ -714,25 +714,25 @@
         {
           "id": "stock-dates",
           "prompt": "What were the stock trade dates, ex-dividend date, record date, and disposition date?",
-          "why": "Qualified-dividend eligibility uses a specific statutory holding window and trade-date counting.",
+          "why": "Qualified-dividend eligibility uses a specific holding window and day count.",
           "source": "brokerage"
         },
         {
           "id": "risk-diminishing-positions",
-          "prompt": "Were puts, calls, short sales, forwards, collars, or related positions open during the holding window?",
-          "why": "Those days may not count toward the required holding period.",
+          "prompt": "Were puts, calls, short sales, forwards, collars, or related positions open during the window?",
+          "why": "Those days may not count toward the holding requirement.",
           "source": "user"
         },
         {
           "id": "payment-classification",
-          "prompt": "Was the payment an issuer dividend or a payment in lieu, and how was it reported on Form 1099-DIV?",
-          "why": "Payment labels and withholding can differ from qualified-dividend treatment.",
+          "prompt": "Was the payment an issuer dividend or a payment in lieu, and how was it reported?",
+          "why": "Payment labels can differ from qualified-dividend treatment.",
           "source": "tax-form"
         },
         {
           "id": "stock-loss-and-distributions",
           "prompt": "Was the stock sold at a loss, and were extraordinary or other distributions received?",
-          "why": "Separate loss-character or basis rules may apply beyond dividend qualification.",
+          "why": "Separate loss-character or basis rules may apply.",
           "source": "tax-form"
         }
       ],
@@ -744,7 +744,7 @@
         },
         {
           "purpose": "Read exact stock lots and holding dates.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
@@ -759,21 +759,21 @@
         }
       ],
       "workflow": [
-        "Build the statutory holding-day timeline using trade dates and ex-dividend date.",
-        "Remove days with diminished risk only when supported by the complete position facts.",
+        "Build the holding-day timeline using trade and ex-dividend dates.",
+        "Exclude diminished-risk days only when supported by complete facts.",
         "Distinguish issuer dividends from payments in lieu and related-payment obligations.",
-        "Separate dividend character from economic profit, stock gain or loss, and filing reconciliation.",
-        "Do not call a trade tax-advantaged from a displayed qualified-dividend amount alone."
+        "Separate dividend character from economic profit and stock gain or loss.",
+        "Do not call a trade tax-advantaged from displayed dividend amounts alone."
       ],
       "redFlags": [
-        "Form 1099-DIV box 1b treated as conclusive despite failure to meet the taxpayer holding period.",
+        "Form 1099-DIV box 1b treated as conclusive despite a failed holding-period test.",
         "Options or hedges ignored while counting holding days.",
         "Payment in lieu described as a qualified dividend.",
-        "Dividend amount discussed without the stock price adjustment and disposition result."
+        "Dividend amount discussed without the stock price and disposition result."
       ],
       "stopConditions": [
         "Trade dates, ex-dividend date, or risk-diminishing positions are incomplete.",
-        "Payment classification cannot be reconciled to the broker tax form.",
+        "Payment classification cannot be reconciled to the tax form.",
         "The user asks for a personalized tax-rate or after-tax-return conclusion."
       ]
     },
@@ -782,7 +782,7 @@
       "title": "Short stock and substantially identical long property",
       "aliases": ["short stock", "short sale", "stock short", "short against the box"],
       "tags": ["short-sale", "holding-period", "constructive-sale", "payments-in-lieu"],
-      "summary": "Route a short sale through closing-property character, substantially identical long positions, holding-period effects, wash sales, related dividend payments, constructive sales, and broker reporting.",
+      "summary": "Route a short sale through closing-property character, substantially identical long positions, holding-period effects, wash sales, payments, constructive sales, and reporting.",
       "accountContexts": ["taxable", "unknown"],
       "topicIds": ["wash-sales", "constructive-sales", "tax-documents-and-estimates"],
       "supplementalClaims": [
@@ -808,42 +808,42 @@
       "requiredFacts": [
         {
           "id": "short-lifecycle",
-          "prompt": "What property was sold short, when was the short opened and closed, and what property was delivered to close it?",
+          "prompt": "What property was sold short, when was it opened and closed, and what property closed it?",
           "why": "Character and timing depend on the short-sale lifecycle and closing property.",
           "source": "brokerage"
         },
         {
           "id": "identical-long-property",
-          "prompt": "What substantially identical stock, securities, futures, or puts were held or acquired, including spouse activity where relevant?",
-          "why": "Section 1233 holding-period and character rules depend on substantially identical property.",
+          "prompt": "What substantially identical stock, securities, futures, or puts were held or acquired?",
+          "why": "Section 1233 rules depend on substantially identical property.",
           "source": "user"
         },
         {
           "id": "appreciated-position",
           "prompt": "Was the short economically offsetting an appreciated financial position?",
-          "why": "Short-against-the-box or similar structures can raise constructive-sale questions.",
+          "why": "Short-against-the-box structures can raise constructive-sale questions.",
           "source": "user"
         },
         {
           "id": "dividend-payments",
-          "prompt": "What dividends, payments in lieu, and related-payment obligations occurred while the short was open?",
-          "why": "Payment character and deductibility are separate from short-sale gain or loss.",
+          "prompt": "What dividends, payments in lieu, and related-payment obligations occurred?",
+          "why": "Payment character is separate from short-sale gain or loss.",
           "source": "tax-form"
         }
       ],
       "brokerReads": [
         {
-          "purpose": "Read short-position and closing transaction history where the product is supported.",
+          "purpose": "Read short-position and closing transaction history where supported.",
           "cli": "robinhood-cli history --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_history"
         },
         {
           "purpose": "Read related long stock lots.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
-          "purpose": "Reconcile dividends, payments, and official tax forms.",
+          "purpose": "Reconcile payments and official tax forms.",
           "cli": "robinhood-cli documents list --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_documents"
         }
@@ -851,19 +851,19 @@
       "workflow": [
         "Build the short-sale open and close timeline.",
         "Inventory substantially identical property held or acquired during the short.",
-        "Apply short-sale character and holding-period rules separately from wash-sale and constructive-sale review.",
-        "Classify dividend-related payments from official records rather than assumptions.",
-        "Leave unsupported deductibility and filing conclusions unevaluated."
+        "Apply Section 1233 separately from wash-sale and constructive-sale review.",
+        "Classify dividend-related payments from official records.",
+        "Leave unsupported deduction and filing conclusions unevaluated."
       ],
       "redFlags": [
         "Short-sale gain assumed long-term from the holding period of delivered shares.",
-        "Existing long position ignored in the character and holding-period analysis.",
-        "Short against the box described as deferring gain without a Section 1259 review.",
+        "Existing long property ignored.",
+        "Short against the box described as deferring gain without Section 1259 review.",
         "Payment in lieu described as an ordinary qualified dividend."
       ],
       "stopConditions": [
         "The closing property or substantially identical holdings are unknown.",
-        "Spouse, other-broker, or derivative activity may be material but is unavailable.",
+        "Spouse, other-broker, or derivative activity may be material but unavailable.",
         "The user asks for a definitive deduction, character, or constructive-sale conclusion."
       ]
     },
@@ -872,27 +872,27 @@
       "title": "Specific-lot stock sale",
       "aliases": ["specific lot", "tax lot sale", "choose tax lots", "highest cost", "fifo sale"],
       "tags": ["tax-lots", "basis", "holding-period", "broker-confirmation", "wash-sale"],
-      "summary": "Route a lot-aware sale through timely broker identification, written confirmation, basis provenance, holding period, unavailable-lot fallback, wash-sale adjustments, and post-fill verification.",
+      "summary": "Route a lot-aware sale through timely identification, written confirmation, basis provenance, holding period, fallback, wash-sale adjustments, and post-fill verification.",
       "accountContexts": ["taxable", "unknown"],
       "topicIds": ["tax-lots-specific-identification", "wash-sales", "tax-documents-and-estimates"],
       "supplementalClaims": [],
       "requiredFacts": [
         {
           "id": "available-lots",
-          "prompt": "Which exact lots are currently available, including quantity, acquisition date, adjusted basis, basis source, and holding period?",
-          "why": "A position-level average cannot substitute for the selected shares.",
+          "prompt": "Which exact lots are available, including quantity, acquisition date, adjusted basis, basis source, and holding period?",
+          "why": "A position-level average cannot substitute for selected shares.",
           "source": "brokerage"
         },
         {
           "id": "selection-timing",
-          "prompt": "When and how will the broker receive the lot instruction, and what written confirmation will be retained?",
-          "why": "Adequate identification depends on timely instructions and confirmation.",
+          "prompt": "When and how will the broker receive the instruction, and what confirmation will be retained?",
+          "why": "Adequate identification depends on timely instruction and confirmation.",
           "source": "brokerage"
         },
         {
           "id": "fallback-method",
-          "prompt": "What default disposal method applies if selected shares are unavailable or the instruction fails?",
-          "why": "The executed lots can differ from the plan when the broker falls back.",
+          "prompt": "What default method applies if selected shares are unavailable or the instruction fails?",
+          "why": "Executed lots can differ from the plan.",
           "source": "brokerage"
         },
         {
@@ -905,17 +905,17 @@
       "brokerReads": [
         {
           "purpose": "Inventory exact open lots and basis provenance.",
-          "cli": "robinhood-cli tax-lots --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots list <SYMBOL> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lots"
         },
         {
           "purpose": "Build a non-sending exact-lot plan.",
-          "cli": "robinhood-cli tax-lot plan --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots plan-sell <SYMBOL> --account <ACCOUNT_NUMBER> --shares <QUANTITY> --objective <OBJECTIVE> --json",
           "mcp": "robinhood_tax_lot_plan"
         },
         {
           "purpose": "Verify the order and selected or closed lots after execution.",
-          "cli": "robinhood-cli tax-lot order <ORDER_ID> --account <ACCOUNT_NUMBER> --json",
+          "cli": "robinhood-cli tax-lots order <ORDER_ID> --account <ACCOUNT_NUMBER> --json",
           "mcp": "robinhood_tax_lot_order"
         },
         {
@@ -927,21 +927,21 @@
       "workflow": [
         "Read current eligible lots immediately before planning.",
         "Preserve selected lot IDs, quantities, basis provenance, and expected fallback.",
-        "Keep the plan non-sending until exact action approval and a verified live contract are available.",
-        "After the fill, verify order history and the broker's selected or closed-lot record.",
+        "Keep the plan non-sending until exact approval and a verified live contract are available.",
+        "After the fill, verify order history and the broker lot record.",
         "Reconcile to year-end forms and external basis records."
       ],
       "redFlags": [
         "Average cost used as if it were a specific lot.",
-        "A planning screen treated as written confirmation or execution evidence.",
+        "A planning screen treated as confirmation or execution evidence.",
         "Unavailable selected shares silently replaced by a different lot.",
         "Transferred or missing basis ignored.",
-        "Lot selection optimized without checking wash-sale or return-wide facts."
+        "Lot selection optimized without return-wide facts."
       ],
       "stopConditions": [
         "The selected lot is unavailable or basis provenance is unresolved.",
-        "The broker cannot provide a retained confirmation of the lot instruction.",
-        "The user asks which lot minimizes tax without return-wide gains, losses, carryovers, and rate facts."
+        "The broker cannot provide retained confirmation of the instruction.",
+        "The user asks which lot minimizes tax without return-wide facts."
       ]
     }
   ]

--- a/knowledge/tax-strategy-routing.md
+++ b/knowledge/tax-strategy-routing.md
@@ -10,6 +10,8 @@ whether a trade is good, calculate personalized tax liability, choose a filing p
 a mutation. Federal tax treatment depends on the actual contracts, account type, lots, dates,
 elections, other accounts, and facts outside Robinhood.
 
+**Tax research never authorizes a trade or sale.**
+
 ## Three surfaces, one catalog
 
 ### CLI

--- a/knowledge/tax-strategy-routing.md
+++ b/knowledge/tax-strategy-routing.md
@@ -1,0 +1,191 @@
+# Tax strategy routing: facts, rules, and stop conditions
+
+> **When to load this:** the user names a strategy or structure and asks how its tax mechanics may
+> work, what records matter, or what an agent should inspect. Examples include a covered call, cash-
+> secured put, wheel, roll, loss harvest, Section 1256 index option, box spread, collar, dividend
+> capture, short sale, or specific-lot disposition.
+
+This module routes strategy language into a source-backed research workflow. It does **not** decide
+whether a trade is good, calculate personalized tax liability, choose a filing position, or authorize
+a mutation. Federal tax treatment depends on the actual contracts, account type, lots, dates,
+elections, other accounts, and facts outside Robinhood.
+
+## Three surfaces, one catalog
+
+### CLI
+
+```bash
+# List strategy guides
+robinhood-cli tax strategy
+
+# Resolve an id or alias
+robinhood-cli tax strategy wheel
+robinhood-cli tax strategy "covered call" --account-context taxable
+
+# Search facts, tags, rule topics, and red flags
+robinhood-cli tax strategy --query "dividend"
+
+# Machine contract
+robinhood-cli tax strategy box-spread --json
+
+# Review age and catalog counts
+robinhood-cli tax status --json
+```
+
+The dedicated `robinhood-tax` binary accepts the same arguments without the leading `tax`.
+
+### Importable API
+
+```ts
+import {
+  getTaxResearchStatus,
+  getTaxStrategyGuide,
+  listTaxStrategies,
+  searchTaxStrategies,
+} from "@zaydiscold/robinhood-cli/tax-strategy";
+
+const guide = getTaxStrategyGuide({
+  strategy: "covered call",
+  accountContext: "taxable",
+});
+```
+
+### MCP
+
+1. Call `robinhood_knowledge` with the `tax-strategy-routing` module for the operating contract.
+2. Read `tax-reference` for the linked source-backed rule topics.
+3. Use only the broker-read tools named by the selected strategy guide to collect account facts.
+4. Keep broker facts and tax-rule research in separate fields.
+5. Do not call a mutation tool merely because the research guide contains a possible action.
+
+The MCP knowledge route is intentionally separate from account reads. Reading a tax module must not
+initialize a trade, supply consent, or imply that a tax-sensitive action is appropriate.
+
+## Required response shape
+
+Every agent response built from a strategy guide should contain these sections:
+
+```text
+strategy and account context
+known broker facts
+user-supplied or external facts
+missing material facts
+official rule topics
+broker-platform behavior
+planning inferences
+not evaluated
+sources
+mutation status: not authorized
+```
+
+Never collapse `missing`, `uncertain`, and `not evaluated` into `no issue`. Never convert a broker
+estimate into federal tax law. Never infer a filing result from the strategy name alone.
+
+## Strategy catalog
+
+| ID | Structure | Core rule families |
+| --- | --- | --- |
+| `covered-call` | Stock plus written call or buy-write | option-writer lifecycle, QCC, dividend holding period, lots, constructive sales |
+| `cash-secured-put` | Written put backed by cash | option lifecycle, assignment basis, wash sales, retirement-account replacement |
+| `wheel` | Repeated short puts, assignment, stock, and covered calls | event-by-event recognition, lots, wash sales, QCC, constructive sales |
+| `option-roll` | Close one option and open another | closed-leg realization, replacement exposure, wash sales, QCC, straddles |
+| `tax-loss-harvesting` | Loss sale plus replacement exposure | exact lots, 61-day acquisition ledger, wash sales, retirement accounts |
+| `section-1256-index-options` | Qualifying index-option contracts | contract classification, annual mark-to-market, 60/40 character, Form 6781 |
+| `box-spread` | Four-leg fixed-return structure | Section 1256, straddles, conversion transactions, elections, reporting |
+| `collar-or-protective-put` | Stock hedged with puts and possibly calls | actual risk retained, constructive sale, straddles, QCC, dividend holding period |
+| `dividend-capture` | Short holding-period dividend trade | qualified-dividend window, diminished-risk days, payments in lieu, lot result |
+| `short-stock` | Short sale, including against a long position | Section 1233 character and holding period, payments, wash sales, constructive sales |
+| `specific-lot-sale` | Sale using selected stock lots | timely identification, written confirmation, basis provenance, fallback, wash sales |
+
+The machine source is [`tax-strategies.json`](tax-strategies.json). It links each strategy to reviewed
+entries in [`tax-reference.json`](tax-reference.json) and fails closed when a topic, source, evidence
+lane, account context, or alias is invalid.
+
+## Operating sequence
+
+### 1. Resolve the structure
+
+Use `tax strategy <id-or-alias>` before retrieving account data. A phrase such as “roll,” “collar,”
+“wheel,” or “index option” is not enough to establish the contracts or federal treatment.
+
+### 2. Resolve account context
+
+Classify the relevant account as taxable, traditional IRA, Roth IRA, or unknown. Do not assume that
+a tax rule applicable to a taxable brokerage account has the same current consequence inside a
+retirement account. Do not assume Robinhood sees every other account or spouse transaction.
+
+### 3. Collect only named facts
+
+The guide returns `requiredFacts` with a source classification:
+
+- `brokerage`: obtain through a maintained CLI or MCP read
+- `tax-form`: reconcile to official year-end forms and return records
+- `user`: facts Robinhood cannot establish, including other brokers, spouse activity, purpose, and elections
+- `external`: ex-dividend dates, issuer actions, regulations, or other non-account evidence
+
+Do not invent values to complete a strategy template.
+
+### 4. Follow the linked rule topics
+
+The guide's `ruleTopics` and `supplementalClaims` are the source-backed legal-mechanics lane. The
+reference catalog distinguishes primary law, IRS guidance, Robinhood behavior, and planning
+inference. Preserve those labels in the answer.
+
+Important examples:
+
+- A roll is a close and a new open. Economic continuity does not itself defer the closed leg.
+- A covered-call label does not prove qualified-covered-call status or eliminate constructive-sale
+  and straddle questions.
+- Section 1256 assigns 60% long-term and 40% short-term capital **character**. Those percentages are
+  not tax rates.
+- A fixed box-spread payoff does not create one automatic financing deduction or 60/40 result.
+- For common-stock qualified dividends, the general federal holding test is more than 60 days in the
+  121-day window, and days with diminished risk can be excluded.
+- A payment in lieu of a dividend is not automatically a qualified dividend.
+- Changing an option strike or expiration is not a universal wash-sale safe harbor.
+
+Read the linked official sources before repeating a material claim. Do not quote a narrative module
+as if it were the authority.
+
+### 5. Preserve the stop conditions
+
+Each strategy has explicit `stopConditions`. Stop and recommend qualified professional review when:
+
+- a complete related-position set is unavailable
+- other brokers, spouse activity, elections, or retirement accounts may be material
+- basis or selected-lot confirmation is missing
+- contract classification is uncertain
+- the user asks for a definitive substantially-identical, qualified-covered-call, constructive-sale,
+  conversion-transaction, deduction, or filing conclusion
+- the requested output would require personalized rates, carryovers, or return-wide netting
+
+### 6. Keep research and execution separate
+
+A guide can name the broker reads required to understand a position. It does not recommend closing,
+rolling, assigning, exercising, harvesting, or selecting a lot. Any later action starts a new flow:
+
+```text
+user requests action
+  -> resolve account and exact instruments/lots
+  -> refresh quotes and account capabilities
+  -> build a dry-run
+  -> echo exact action
+  -> obtain exact approval
+  -> gated send
+  -> verify order history and selected lots
+```
+
+Tax research never supplies the approval step.
+
+## Maintenance
+
+When a strategy rule or workflow changes:
+
+1. Update `knowledge/tax-strategies.json`.
+2. Link only existing source-backed tax-reference topics and sources.
+3. Add or update focused tests for aliases, facts, source closure, and stop conditions.
+4. Update this module only when the operating contract or public strategy inventory changes.
+5. Run `pnpm build`, `pnpm quality`, and `pnpm test:built`.
+
+When controlling authority, IRS guidance, or Robinhood reporting behavior changes, update the tax
+reference catalog first and align the strategy catalog's review date in the same change.

--- a/knowledge/tax.md
+++ b/knowledge/tax.md
@@ -1,233 +1,261 @@
-# Tax-aware operation: reference first, account facts second
+# Tax-aware operation: strategy router, rules, then account facts
 
-> **When to load this:** any question about wash sales, Section 1256, option exercise or assignment,
-> qualified covered calls, constructive sales, box spreads, holding periods, tax lots, year-end forms,
-> or how a proposed Robinhood action could affect tax reporting. This module is an operating router.
-> The source-backed rules live in [`tax-reference.md`](tax-reference.md).
+> **When to load this:** a tax-mechanics question needs live Robinhood account facts, tax lots,
+> option events, recurring purchases, settings, or year-end documents. Load
+> [`tax-strategy-routing.md`](tax-strategy-routing.md) when a named structure is involved, and load
+> [`tax-reference.md`](tax-reference.md) before repeating a material federal rule.
 
 ## Binding posture
 
 Tax content in this repository is educational US federal tax research, not a personalized filing
-conclusion. State rules differ. The complete result can depend on filing status, taxable income,
-basis, holding period, carryovers, elections, spouse activity, retirement accounts, other brokers,
-and facts the Robinhood account cannot expose.
+conclusion. State and local rules differ. A complete result can depend on filing status, taxable
+income, basis, holding periods, carryovers, elections, spouse activity, retirement accounts, other
+brokers, and facts Robinhood cannot expose.
 
-Use four evidence lanes and name the lane when it matters:
+Use and name four evidence lanes:
 
 1. **Primary law or regulation**
 2. **IRS guidance or reporting instruction**
 3. **Broker-platform behavior**
 4. **Planning inference**
 
-A Robinhood estimate or product label is not federal tax law. A planning inference is not a legal
-conclusion. A tax read never authorizes a trade.
+A Robinhood estimate or product label is not federal tax law. A planning inference is not a filing
+position. Tax research does not authorize a trade, roll, exercise, assignment response, lot
+selection, recurring change, or sale.
 
-## Start with the maintained reference
+## Start with the maintained research surfaces
 
 ```bash
-# List the reviewed topics
-node cli/dist/tax-cli.js
+# List reviewed rule topics and strategy guides
+robinhood-cli tax
 
-# Read one topic
-node cli/dist/tax-cli.js wash-sales
-node cli/dist/tax-cli.js section-1256
-node cli/dist/tax-cli.js qualified-covered-calls
-node cli/dist/tax-cli.js box-spreads
+# Read or search rule topics
+robinhood-cli tax wash-sales
+robinhood-cli tax section-1256
+robinhood-cli tax qualified-covered-calls
+robinhood-cli tax --query "exercise holding period"
 
-# Search across claims, caveats, evidence lanes, and source IDs
-node cli/dist/tax-cli.js --query "exercise holding period"
+# Map a named structure to facts, reads, rules, red flags, and stop conditions
+robinhood-cli tax strategy wheel
+robinhood-cli tax strategy "covered call" --account-context taxable
+robinhood-cli tax strategy --query "dividend"
 
-# Structured output for scripts or agents
-node cli/dist/tax-cli.js tax-lots-specific-identification --json
+# Machine-readable research status
+robinhood-cli tax status --json
 ```
+
+The dedicated `robinhood-tax` binary accepts the same arguments without the leading `tax`.
 
 API applications use:
 
 ```ts
 import { getTaxReference } from "@zaydiscold/robinhood-cli/tax-reference";
+import { getTaxStrategyGuide } from "@zaydiscold/robinhood-cli/tax-strategy";
 ```
 
-MCP clients read the generated `tax-reference` module through `robinhood_knowledge`. The generated
-Markdown and the CLI/API catalog are built from the same versioned source.
+MCP clients read `tax-strategy-routing` and `tax-reference` through `robinhood_knowledge`, then use
+the named account tools for live facts. Structured account data and tax research remain separate
+fields.
 
-## Then gather live account facts
+## Gather live account facts after routing
 
-Reference mechanics and account evidence are separate. Use the smallest live surface that answers
-the factual question.
-
-### Accounts and eligibility
+### 1. Account identity and class
 
 ```bash
-node cli/dist/index.js accounts --json
-node cli/dist/index.js account-pulse --json
+robinhood-cli accounts --json
+robinhood-cli account-pulse --json
 ```
 
-Identify taxable and retirement accounts explicitly. Do not treat losses inside an IRA or Roth IRA
-as harvestable tax losses. Do not assume a transaction in one account is isolated from activity in
-another account.
+Preserve the selected account number internally and display only the label and masked tail. Explicitly
+classify taxable, traditional IRA, Roth IRA, or unknown. Do not infer that an account is tax-free or
+that a loss is usable merely from a product name.
 
-### Open tax lots and lot-aware planning
+### 2. Exact stock lots
+
+The current command grammar requires a symbol and subcommand:
 
 ```bash
-node cli/dist/index.js tax-lots list <SYMBOL> --account <ACCOUNT> --json
-node cli/dist/index.js tax-lots plan-sell <SYMBOL> \
-  --account <ACCOUNT> \
+# Read stable open-lot IDs and basis provenance
+robinhood-cli tax-lots list <SYMBOL> \
+  --account <ACCOUNT_NUMBER> \
+  --json
+
+# Build a non-sending exact-lot plan
+robinhood-cli tax-lots plan-sell <SYMBOL> \
+  --account <ACCOUNT_NUMBER> \
   --shares <QUANTITY> \
   --objective harvest_loss \
   --json
+
+# After a fill, verify which lots Robinhood selected or closed
+robinhood-cli tax-lots order <ORDER_ID> \
+  --account <ACCOUNT_NUMBER> \
+  --json
 ```
 
-A plan is not execution evidence. Specific identification depends on the actual broker instruction,
-availability of the selected shares, the filled order, the broker's selected or closed-lot record,
-and year-end reporting. Preserve stable lot IDs and exact quantities rather than identifying lots by
-acquisition date alone.
+A plan or app screen is not adequate identification, broker confirmation, or execution evidence.
+Specific-lot work depends on the actual instruction, selected lot IDs, fill, broker lot record, basis
+provenance, and year-end reporting. If selected shares are unavailable, the broker may fall back to a
+default method. Surface that risk before any action.
 
-### History and automatic acquisitions
+### 3. Equity and option lifecycle
 
 ```bash
-node cli/dist/index.js history --account <ACCOUNT> --json
-node cli/dist/index.js recurring list --json
-node cli/dist/index.js settings show --account <ACCOUNT>
+robinhood-cli history --account <ACCOUNT_NUMBER> --json
+robinhood-cli options holdings --account <ACCOUNT_NUMBER> --json
+robinhood-cli options events --account <ACCOUNT_NUMBER> --json
+robinhood-cli orders open --account <ACCOUNT_NUMBER> --json
+robinhood-cli order-status --id <ORDER_ID> --json
 ```
 
-For a wash-sale review, inspect purchases before and after the loss sale, recurring investments,
-dividend reinvestment, other taxable accounts, and IRA or Roth IRA activity. The repository cannot
-see every broker, spouse transaction, or outside acquisition, so absence in this account is not proof
-that no replacement acquisition exists.
+Build a dated event ledger. Keep an option close, replacement open, expiration, exercise, assignment,
+stock acquisition, stock disposition, and dividend as separate facts. A net roll debit or credit is
+not the tax result. Order history is the only proof an order happened.
 
-### Tax documents
+### 4. Automatic acquisitions and settings
 
 ```bash
-node cli/dist/index.js documents list --year <YEAR> --json
-node cli/dist/index.js documents download --type 1099 --year <YEAR> --json
+robinhood-cli recurring list --json
+robinhood-cli settings show --account <ACCOUNT_NUMBER> --json
 ```
 
-Use app and CLI figures for planning. Reconcile filing work to the broker's year-end forms and the
-taxpayer's complete records, including transferred basis, corporate actions, wash adjustments, and
-other brokers.
+For wash-sale and holding-period work, inspect recurring buys, DRIP, related accounts, and any other
+known acquisition automation. Robinhood cannot prove that no spouse, IRA, Roth IRA, or outside-broker
+acquisition occurred.
 
-## Mechanics that deserve an automatic flag
+### 5. Dividends and payment dates
+
+```bash
+robinhood-cli dividends --account <ACCOUNT_NUMBER> --json
+robinhood-cli calendar --account <ACCOUNT_NUMBER> --json
+```
+
+Dividend amounts and dates are account facts, not automatic qualified-dividend conclusions. For
+common stock, the general federal qualified-dividend test uses more than 60 days in the 121-day
+window. Days with diminished risk can be excluded. Payments in lieu are not automatically qualified
+dividends. Read the `dividend-capture` or `covered-call` strategy guide and the official source-backed
+claims before summarizing the result.
+
+### 6. Official tax documents
+
+```bash
+robinhood-cli documents list --account <ACCOUNT_NUMBER> --year <YEAR> --json
+robinhood-cli documents download --type 1099 --year <YEAR> --json
+```
+
+Use app and CLI figures for planning. Reconcile filing work to official year-end forms and complete
+records, including transferred basis, corporate actions, wash-sale adjustments, other brokers, Form
+6781, and relevant elections.
+
+## Automatic rule flags
 
 ### Written equity options
 
 A written non-Section-1256 equity option is generally recognized when it expires, is closed, or is
-exercised, not merely when cash premium arrives. Buying to close realizes the closed leg even when a
-new leg is opened as part of a roll. Assignment can fold premium into stock proceeds or basis.
-
-Load:
+exercised, not merely when premium cash arrives. A roll closes one contract and opens another. Load:
 
 ```bash
-node cli/dist/tax-cli.js option-writer-lifecycle
+robinhood-cli tax option-writer-lifecycle
+robinhood-cli tax strategy option-roll
 ```
 
 ### Exercise and assignment
 
-The disposition method matters. Exercise can move option cost or premium into stock basis or sale
-proceeds, and the acquired property's holding period generally starts after exercise. Do not treat a
-long option's holding period as automatically tacking onto delivered shares.
-
-Load:
+Exercise can move option cost or premium into stock basis or sale proceeds. The acquired property's
+holding period generally starts after exercise. Load:
 
 ```bash
-node cli/dist/tax-cli.js option-exercise-holding-period
+robinhood-cli tax option-exercise-holding-period
 ```
 
-### Wash sales
+### Wash sales and retirement accounts
 
-The statutory window includes 30 days before and 30 days after the loss sale. Options and contracts
-to acquire substantially identical property can matter. The authorities do not supply one universal
-strike-or-expiration safe harbor for options, so do not pronounce a same-underlying replacement safe
-from contract terms alone.
-
-An IRA or Roth IRA acquisition can permanently disallow a taxable-account loss without increasing
-the retirement account's basis. Treat automatic purchases as real acquisitions.
-
-Load:
+The window reaches 30 days before and 30 days after a loss sale. Contracts or options to acquire
+substantially identical stock or securities can matter. There is no universal strike-or-expiration
+safe harbor. An IRA or Roth IRA acquisition can have a particularly adverse result. Load:
 
 ```bash
-node cli/dist/tax-cli.js wash-sales
-node cli/dist/tax-cli.js retirement-account-wash-sales
+robinhood-cli tax wash-sales
+robinhood-cli tax retirement-account-wash-sales
+robinhood-cli tax strategy tax-loss-harvesting
 ```
 
 ### Section 1256
 
-Qualifying Section 1256 contracts are generally marked to market at year-end and characterized 60%
-long-term and 40% short-term regardless of holding period. The 60% component is actual statutory
-long-term capital character. Do not replace the statute with a hard-coded blended tax rate.
-
-Confirm the actual contract and broker reporting. A ticker, the phrase “index option,” or an app
-search result is not enough. Mixed straddles and elections can change the simple result.
-
-Load:
+Qualifying contracts are generally marked to market at year end and characterized 60% long-term and
+40% short-term regardless of holding period. Those percentages are capital character, not tax rates.
+Confirm the actual contract and return-year broker reporting. Load:
 
 ```bash
-node cli/dist/tax-cli.js section-1256
+robinhood-cli tax section-1256
+robinhood-cli tax strategy section-1256-index-options
 ```
 
-### Qualified covered calls and straddles
+### Covered calls, collars, and dividend holding periods
 
-Qualified-covered-call status is a technical safe harbor. It is not shorthand for every covered
-call and cannot be reduced to a fixed dollar amount in the money. Stock price, available strike grid,
-term, applicable regulatory benchmark, and complete position matter.
-
-Load:
+Qualified-covered-call status is a technical safe harbor, not shorthand for every covered call.
+Stock price, strike grid, term, complete related positions, and regulation matter. Hedging can also
+affect stock and dividend holding periods and can raise constructive-sale questions. Load:
 
 ```bash
-node cli/dist/tax-cli.js qualified-covered-calls
+robinhood-cli tax qualified-covered-calls
+robinhood-cli tax constructive-sales
+robinhood-cli tax strategy covered-call
+robinhood-cli tax strategy collar-or-protective-put
 ```
 
-### Box spreads and conversion transactions
+### Box spreads
 
-A fixed economic payoff does not produce one automatic tax characterization. Depending on contract
-composition and facts, Section 1256, straddle, conversion-transaction, and other rules may interact.
-Do not describe short-box financing cost as automatically deductible capital loss or long-box return
-as automatically favorable 60/40 income.
-
-Load:
+A fixed payoff does not produce one automatic federal tax result. Section 1256, straddle,
+conversion-transaction, election, purpose, and reporting questions can interact. Load:
 
 ```bash
-node cli/dist/tax-cli.js box-spreads
+robinhood-cli tax box-spreads
+robinhood-cli tax strategy box-spread
 ```
 
-### Constructive sales
+### Short sales
 
-Do not declare a collar, short sale, put, covered call, forward, or multi-leg structure outside
-constructive-sale treatment based on its strategy name. The appreciated position, offsetting
-transaction, dates, and retained risk must be analyzed.
-
-Load:
+Short-sale character and holding-period rules can depend on substantially identical long property.
+A short against an appreciated position can also raise constructive-sale questions. Dividend-related
+payments require separate classification. Load:
 
 ```bash
-node cli/dist/tax-cli.js constructive-sales
+robinhood-cli tax strategy short-stock
 ```
 
-## Operator decision contract
+## Response contract
 
-For a tax-sensitive proposed action:
+For a tax-sensitive question, report:
 
-1. State the jurisdiction and tax-reference review date.
-2. Identify the relevant evidence lane for each material claim.
-3. Gather account, lot, history, recurring, settings, and document facts separately.
-4. State what Robinhood can observe and what it cannot decide.
-5. Preserve unknown or incomplete basis, holding-period, election, and cross-account facts.
-6. Build a dry-run only after the operator asks for an action.
-7. Echo account, symbol or contract, lot IDs, side, quantity, and price before any live mutation.
-8. Verify the filled order and selected or closed lots after execution.
-9. Reconcile year-end forms independently.
+1. Jurisdiction, review date, strategy, and account context.
+2. Broker-observed facts with timestamps and account scope.
+3. User-supplied and external facts.
+4. Missing material facts.
+5. Primary law and IRS guidance.
+6. Broker-platform behavior.
+7. Planning inference.
+8. What remains not evaluated.
+9. Official source links.
+10. Mutation status: not authorized.
 
 ## What not to do
 
-- Do not calculate a user's final tax liability from a marginal-rate guess.
-- Do not infer “taxable” or “tax-free” from account or product names alone.
-- Do not claim all index options receive Section 1256 treatment.
-- Do not claim changing an option strike or expiration automatically avoids a wash sale.
-- Do not call a covered call qualified without applying the relevant rules.
-- Do not claim a box-spread loss is automatically deductible financing expense.
-- Do not treat a tax-lot plan, HTTP success, or UI state as execution evidence.
-- Do not recommend a trade merely because one tax outcome might be favorable.
+- Do not calculate final liability from a guessed marginal rate.
+- Do not call a strategy categorically tax-efficient.
+- Do not infer taxable or tax-free treatment from an account or product name.
+- Do not claim every index option is a Section 1256 contract.
+- Do not claim changing strike or expiration automatically avoids a wash sale.
+- Do not call a covered call qualified without applying the actual requirements.
+- Do not call a box-spread cost automatically deductible financing expense.
+- Do not treat Form 1099-DIV box 1b as conclusive when the taxpayer holding-period test fails.
+- Do not treat a payment in lieu as automatically qualified dividend income.
+- Do not treat a lot plan, UI state, HTTP success, or roll ledger as execution evidence.
+- Do not recommend a trade merely because one possible tax outcome seems favorable.
 
 ## Focused follow-ups
 
+- [`tax-strategy-routing.md`](tax-strategy-routing.md): strategy-to-facts and rule routing
 - [`tax-reference.md`](tax-reference.md): reviewed claims, caveats, and source IDs
 - [`tax-loss-harvesting.md`](tax-loss-harvesting.md): harvesting control workflow
 - [`execution-safety.md`](execution-safety.md): dry-run, approval, and order-evidence contract

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,10 +1,9 @@
 # @zaydiscold/robinhood-cli-mcp
 
-Stdio MCP server for agent access to the same Robinhood engine used by the CLI.
-The server does not maintain a second trading implementation: it imports
-`@zaydiscold/robinhood-cli/lib`, so auth, route matching, write gates, order
-deduplication, `ref_id` behavior, OTC/fractional guards, and account discovery
-stay aligned with the CLI.
+Stdio MCP server for agent access to the same Robinhood engine used by the CLI. The server does not
+maintain a second trading implementation: it imports `@zaydiscold/robinhood-cli/lib`, so auth, route
+matching, write gates, order deduplication, idempotency, OTC/fractional guards, account discovery, and
+order evidence stay aligned with the CLI.
 
 ## Run
 
@@ -13,59 +12,89 @@ pnpm --filter @zaydiscold/robinhood-cli-mcp build
 node mcp/dist/server.js
 ```
 
-Register with an MCP client using the absolute path to `mcp/dist/server.js`.
-Only include `ROBINHOOD_ALLOW_LIVE_WRITE=1` in the server environment when the
-operator intentionally wants writes to be able to go live.
+Register with an MCP client using the absolute path to `mcp/dist/server.js`. Only include
+`ROBINHOOD_ALLOW_LIVE_WRITE=1` in the server environment when the operator intentionally wants the
+process to be capable of live writes.
 
 ```bash
 claude mcp add robinhood-cli -s user -- \
   node /absolute/path/to/robinhood-cli-mcp-api/mcp/dist/server.js
 ```
 
-After pulling or rebuilding, restart the server or reload the MCP client. The
-running server's `tools/list` response is the live truth; hardcoded counts in
-docs will rot.
+After pulling or rebuilding, restart the server or reload the client. The running server's
+`tools/list` response is the live truth; hardcoded counts in docs will rot.
 
-## Safety Model
+## Safety model
 
-- Read/list/plan tools run live with caller-owned auth.
-- Write-capable tools are dry-run by default unless
-  `ROBINHOOD_ALLOW_LIVE_WRITE=1` is present in the server environment.
-- `dryRun: true` always forces a preview, even when the switch is present.
-- Every write response is wrapped with `executed` and `executionStatus` so a
-  dry-run plan cannot read like a completed order.
-- Order history, not a `201` alone and not a UI screen, is the execution proof.
+- Account and market-data tools send live reads when caller-owned auth and required inputs are
+  present.
+- Knowledge, route catalogs, generated references, dry-run plans, and pure analysis are local or
+  generated surfaces; they do not become live brokerage reads merely because MCP exposes them.
+- Write-capable tools are dry-run by default unless `ROBINHOOD_ALLOW_LIVE_WRITE=1` is present.
+- `dryRun: true` always forces a preview, even when the process is armed.
+- Every write response exposes `executed` and `executionStatus` so a dry-run cannot read like a
+  completed order.
+- Exact user approval is still required for the fully resolved mutation. A process switch is not
+  standing consent.
+- Order history, not a `201`, UI state, or successful tool call, is the execution proof.
+- Tax and strategy research never authorizes a trade or determines a filing result.
 
-## Tool Families
+## Tax and strategy research
 
-Query `tools/list` for the complete roster. The stable families are:
+MCP uses the existing knowledge surface for the operating contract and the account tools for live
+facts:
 
-- Route map and planning: `robinhood_api_map_summary`,
-  `robinhood_api_map_directory`, `robinhood_brokerage_describe`,
-  `robinhood_recipes`, `robinhood_brokerage_plan`, route-list tools.
+1. Call `robinhood_knowledge` with `action:index` and locate `tax-strategy-routing`.
+2. Read `tax-strategy-routing` for strategy IDs, required response shape, and stop conditions.
+3. Read `tax-reference` for source-backed federal rule topics and official source IDs.
+4. Use only the named account tools to collect lots, history, option events, recurring activity,
+   settings, dividends, or documents.
+5. Keep broker-observed facts, user-supplied facts, official rules, planning inferences, and
+   not-evaluated items separate.
+6. Return mutation status as not authorized unless the user later requests an exact action through a
+   separate execution flow.
+
+CLI and API equivalents are:
+
+```bash
+robinhood-cli tax strategy wheel --json
+robinhood-cli tax strategy "covered call" --account-context taxable --json
+```
+
+```ts
+import { getTaxStrategyGuide } from "@zaydiscold/robinhood-cli/tax-strategy";
+```
+
+The structured strategy catalog is intentionally local. MCP account reads are performed separately
+so tax research cannot silently initialize or authorize a brokerage mutation.
+
+## Tool families
+
+Query `tools/list` for the complete roster. Stable families include:
+
+- Route map and planning: `robinhood_api_map_summary`, `robinhood_api_map_directory`,
+  `robinhood_brokerage_describe`, `robinhood_recipes`, `robinhood_brokerage_plan`, and route-list
+  tools.
 - Account and portfolio reads: `robinhood_accounts`, `robinhood_portfolio`,
-  `robinhood_positions`, `robinhood_buying_power`, `robinhood_quote`,
-  `robinhood_history`, `robinhood_performance`.
+  `robinhood_positions`, `robinhood_buying_power`, `robinhood_quote`, `robinhood_history`, and
+  `robinhood_performance`.
 - Options: `robinhood_options_chain`, `robinhood_options_expirations`,
   `robinhood_options_enumerate`, `robinhood_options_strategy_quote`,
-  `robinhood_options_roll_plan`, `robinhood_options_close`,
-  `robinhood_options_holdings`, `robinhood_options_inspect`.
+  `robinhood_options_roll_plan`, `robinhood_options_close`, `robinhood_options_holdings`,
+  `robinhood_options_inspect`, and `robinhood_options_events`.
 - Execution lifecycle: `robinhood_buy`, `robinhood_sell`, `robinhood_cancel`,
-  `robinhood_order_status`, `robinhood_orders_open`, `robinhood_panic`,
-  `robinhood_pretrade`.
+  `robinhood_order_status`, `robinhood_orders_open`, `robinhood_panic`, and `robinhood_pretrade`.
 - Account control and memory: `robinhood_settings`, `robinhood_recurring`,
-  `robinhood_watchlist*`, `robinhood_knowledge`, `robinhood_roll_ledger`,
-  `robinhood_hotlist`.
-- Analysis and discovery: `robinhood_dividends`, `robinhood_documents`,
-  `robinhood_margin`, `robinhood_review`, `robinhood_income`,
-  `robinhood_risk`, `robinhood_whatif`, `robinhood_calendar`,
-  `robinhood_exposure`, `robinhood_autopilot`, `robinhood_sentinel`,
-  `robinhood_search`, `robinhood_news`, `robinhood_ratings`,
-  `robinhood_earnings`, `robinhood_movers`, `robinhood_options_events`.
-- Crypto: `robinhood_crypto_routes`, `robinhood_crypto_sign`,
-  `robinhood_crypto_plan`, `robinhood_crypto_execute`.
+  `robinhood_watchlist*`, `robinhood_knowledge`, `robinhood_roll_ledger`, and `robinhood_hotlist`.
+- Analysis and discovery: `robinhood_dividends`, `robinhood_documents`, `robinhood_margin`,
+  `robinhood_review`, `robinhood_income`, `robinhood_risk`, `robinhood_whatif`,
+  `robinhood_calendar`, `robinhood_exposure`, `robinhood_autopilot`, `robinhood_sentinel`,
+  `robinhood_search`, `robinhood_news`, `robinhood_ratings`, `robinhood_earnings`, and
+  `robinhood_movers`.
+- Crypto: `robinhood_crypto_routes`, `robinhood_crypto_sign`, `robinhood_crypto_plan`, and
+  `robinhood_crypto_execute`.
 
-For the architecture and improvement map, see
+For the complete operating contract, start with `SKILL.md`; for architecture, see
 `docs/cli-mcp-architecture.md`.
 
 <!-- Zayd Khan // cold // www.zayd.wtf -->

--- a/scripts/check-agent-guidance.py
+++ b/scripts/check-agent-guidance.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import re
 import sys
@@ -13,12 +14,14 @@ ACTIVE_FILES = (
     Path("SKILL.md"),
     Path("knowledge/README.md"),
     Path("knowledge/cli-routing.md"),
+    Path("knowledge/tax-strategy-routing.md"),
     Path("knowledge/tax.md"),
     Path("knowledge/tax-loss-harvesting.md"),
     Path("docs/tax-aware-options-strategies.md"),
 )
 
 TAX_FILES = (
+    Path("knowledge/tax-strategy-routing.md"),
     Path("knowledge/tax.md"),
     Path("knowledge/tax-loss-harvesting.md"),
     Path("docs/tax-aware-options-strategies.md"),
@@ -74,6 +77,10 @@ FORBIDDEN_TAX: tuple[tuple[re.Pattern[str], str], ...] = (
         "constructive-sale analysis is fact-specific and strategy names are not the statutory test",
     ),
     (
+        re.compile(r"payment(?:s)? in lieu[^\n]{0,80}(?:is|are) (?:a )?qualified dividend", re.IGNORECASE),
+        "payments in lieu are not automatically qualified dividends",
+    ),
+    (
         re.compile(r"(?:26\s*[–-]\s*28|32|37)%", re.IGNORECASE),
         "active tax guidance must not hard-code rate comparisons without a return year and full facts",
     ),
@@ -117,6 +124,65 @@ def validate_links(path: Path, text: str, errors: list[str]) -> None:
             errors.append(f"{path}: local link escapes repository: {target}")
         elif not resolved.exists():
             errors.append(f"{path}: broken local link: {target}")
+
+
+def validate_strategy_surface(texts: dict[Path, str], errors: list[str]) -> int:
+    catalog_path = ROOT / "knowledge/tax-strategies.json"
+    module_path = Path("knowledge/tax-strategy-routing.md")
+    if not catalog_path.exists():
+        errors.append("missing structured tax strategy catalog: knowledge/tax-strategies.json")
+        return 0
+    try:
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"tax strategy catalog is unreadable: {exc}")
+        return 0
+
+    strategies = catalog.get("strategies")
+    if not isinstance(strategies, list) or not strategies:
+        errors.append("tax strategy catalog must contain a non-empty strategies list")
+        return 0
+    module = texts.get(module_path, "")
+    seen_ids: set[str] = set()
+    aliases: dict[str, str] = {}
+    for entry in strategies:
+        if not isinstance(entry, dict):
+            errors.append("tax strategy catalog contains a non-object entry")
+            continue
+        strategy_id = entry.get("id")
+        if not isinstance(strategy_id, str) or not strategy_id:
+            errors.append("tax strategy catalog contains an entry without an id")
+            continue
+        if strategy_id in seen_ids:
+            errors.append(f"duplicate tax strategy id: {strategy_id}")
+        seen_ids.add(strategy_id)
+        if f"`{strategy_id}`" not in module:
+            errors.append(f"{module_path}: public strategy inventory omits {strategy_id}")
+        for raw_name in [strategy_id, *entry.get("aliases", [])]:
+            if not isinstance(raw_name, str):
+                errors.append(f"tax strategy {strategy_id} has a non-string alias")
+                continue
+            normalized = re.sub(r"[^a-z0-9]+", "-", raw_name.lower()).strip("-")
+            prior = aliases.get(normalized)
+            if prior and prior != strategy_id:
+                errors.append(
+                    f"tax strategy alias collision: {raw_name!r} resolves to {prior} and {strategy_id}"
+                )
+            aliases[normalized] = strategy_id
+        if not entry.get("requiredFacts"):
+            errors.append(f"tax strategy {strategy_id} has no required facts")
+        if not entry.get("brokerReads"):
+            errors.append(f"tax strategy {strategy_id} has no broker reads")
+        if not entry.get("redFlags") or not entry.get("stopConditions"):
+            errors.append(f"tax strategy {strategy_id} must define red flags and stop conditions")
+
+    if "robinhood-cli tax strategy" not in module:
+        errors.append(f"{module_path}: missing canonical CLI strategy route")
+    if "@zaydiscold/robinhood-cli/tax-strategy" not in module:
+        errors.append(f"{module_path}: missing importable API route")
+    if "robinhood_knowledge" not in module:
+        errors.append(f"{module_path}: missing MCP knowledge route")
+    return len(strategies)
 
 
 def main() -> int:
@@ -174,9 +240,11 @@ def main() -> int:
     if not generated.exists() or not catalog.exists():
         errors.append("generated tax-reference Markdown and JSON catalog must both exist")
 
+    strategy_count = validate_strategy_surface(texts, errors)
     print(
         "Agent guidance check: "
         f"{len(texts)} active file(s), {len(TAX_FILES)} tax workflow file(s), "
+        f"{strategy_count} strategy guide(s), "
         f"{sum(len(text.encode('utf-8')) for text in texts.values()):,} bytes reviewed"
     )
     if errors:

--- a/scripts/check-skill-integrity.py
+++ b/scripts/check-skill-integrity.py
@@ -50,7 +50,7 @@ REQUIRED_CONTRACTS = (
     "A tax-reference read never authorizes",
     "A tax-strategy guide never determines a filing result",
     "tradeAuthorized: false",
-    "CLI, MCP, scripts, and package APIs must share business logic",
+    "CLI, MCP, scripts, and package APIs must share",
 )
 
 FORBIDDEN_PATTERNS: tuple[tuple[str, str], ...] = (

--- a/scripts/check-skill-integrity.py
+++ b/scripts/check-skill-integrity.py
@@ -13,7 +13,7 @@ CLAUDE = ROOT / "CLAUDE.md"
 
 MIN_BYTES = 12_000
 MAX_BYTES = 50_000
-MIN_VERSION = (3, 0, 0)
+MIN_VERSION = (3, 1, 0)
 
 REQUIRED_HEADINGS = (
     "## 30-second operating contract",
@@ -24,6 +24,7 @@ REQUIRED_HEADINGS = (
     "## Raw brokerage executor",
     "## Live-write contract",
     "## Tax and legal-mechanics research contract",
+    "## Agent response contracts",
     "## Failure modes that must stop the workflow",
     "## Verification checklist",
     "## Maintainer rules",
@@ -33,17 +34,22 @@ REQUIRED_CONTRACTS = (
     "ROBINHOOD_ALLOW_LIVE_WRITE=1",
     "--query-param key=value",
     "robinhood-tax",
+    "robinhood-cli tax strategy",
     "@zaydiscold/robinhood-cli/tax-reference",
+    "@zaydiscold/robinhood-cli/tax-strategy",
     "tools/list",
     "Order history is the only proof",
     "Dry-run is the resting state",
     "exact user approval",
     "account allow-list",
     "knowledge/tax-reference.md",
+    "knowledge/tax-strategy-routing.md",
     "primary law or regulation",
     "broker-platform behavior",
     "planning inference",
     "A tax-reference read never authorizes",
+    "A tax-strategy guide never determines a filing result",
+    "tradeAuthorized: false",
     "CLI, MCP, scripts, and package APIs must share business logic",
 )
 
@@ -72,6 +78,10 @@ FORBIDDEN_PATTERNS: tuple[tuple[str, str], ...] = (
         r"60%[^\n]{0,40}(?:not real|isn't real) long[- ]term",
         "Section 1256 assigns actual statutory long-term capital character to the 60% component",
     ),
+    (
+        r"payment(?:s)? in lieu[^\n]{0,80}(?:is|are) (?:a )?qualified dividend",
+        "payments in lieu are not automatically qualified dividends",
+    ),
 )
 
 REQUIRED_LINKS = (
@@ -81,6 +91,7 @@ REQUIRED_LINKS = (
     "knowledge/accounts.md",
     "knowledge/mcp-operations.md",
     "knowledge/tax-reference.md",
+    "knowledge/tax-strategy-routing.md",
     "knowledge/tax.md",
     "knowledge/tax-loss-harvesting.md",
     "docs/write-operations.md",


### PR DESCRIPTION
## Summary

This is a product and research enhancement across the CLI, importable API, MCP operating guidance, and agent skill.

It adds one structured strategy-to-rule research layer for common stock and option structures. The layer answers:

- what exact facts must be collected
- which Robinhood CLI/MCP reads supply broker-observed facts
- which source-backed federal rule topics may apply
- which claims are broker behavior versus law versus planning inference
- what remains missing or not evaluated
- when the workflow must stop and escalate

It deliberately does **not** choose a trade, calculate personalized liability, determine a filing position, or authorize a brokerage mutation.

## New CLI surface

```bash
robinhood-cli tax strategy
robinhood-cli tax strategy wheel
robinhood-cli tax strategy "covered call" --account-context taxable
robinhood-cli tax strategy --query "dividend" --json
robinhood-cli tax status --json
```

The dedicated `robinhood-tax` binary accepts the same arguments without the leading `tax`.

## New importable API

```ts
import {
  getTaxResearchStatus,
  getTaxStrategyGuide,
  listTaxStrategies,
  searchTaxStrategies,
} from "@zaydiscold/robinhood-cli/tax-strategy";
```

Every guide returns hard safety state:

```ts
{
  notPersonalizedAdvice: true,
  filingResultDetermined: false,
  tradeAuthorized: false
}
```

## Strategy catalog

The versioned catalog covers:

- covered calls and buy-writes
- cash-secured puts
- the wheel
- option rolls
- tax-loss harvesting
- Section 1256 index options
- box spreads
- collars and protective puts
- dividend capture
- short stock, including short-against-the-box questions
- specific-lot sales

Every strategy links only to existing source-backed tax-reference topics and sources, and includes required facts, valid current CLI/MCP reads, workflow, red flags, and stop conditions.

## Research corrections and hardening

The active guidance now preserves several mechanics that are commonly misstated:

- common-stock qualified dividends generally use the more-than-60-days / 121-day-window test
- days with diminished risk can be excluded from the holding-day count
- payments in lieu are not automatically qualified dividends
- Section 1256's 60/40 split is capital character, not a tax rate
- an option roll is a close plus a new open, not automatic tax deferral
- changed strike or expiration is not a universal wash-sale safe harbor
- a strategy name does not determine qualified-covered-call, constructive-sale, straddle, or box-spread treatment
- Section 1233 short-sale character and holding-period questions depend on the actual substantially identical property and timeline

## Cross-surface behavior

- CLI: first-class local strategy research and status commands
- API: structured guide and search functions without CLI parsing or brokerage initialization
- MCP: `robinhood_knowledge` routes agents through `tax-strategy-routing` and `tax-reference`, then named account tools gather live facts separately
- Skill: a smaller binding router now defines structured-output precedence, current command grammar, missing-fact states, research-versus-execution separation, and post-fill evidence

## Documentation and quality gates

- replaces stale tax-lot examples with current `tax-lots list`, `plan-sell`, and `order` grammar
- corrects the MCP README's prior claim that all read/list/plan tools were live
- updates CLI package documentation and package exports
- expands agent-guidance and skill-integrity checks
- fails closed on unknown topic/source/lane references, alias collisions, incomplete strategy records, stale tax claims, and missing public strategy routing

## Scope and safety

No brokerage authentication, account data, route map, order body, write gate, live endpoint, or mutation implementation changed or was exercised.

## Validation

CI run 331 passed on head `ca32e674a703854b7643b7c3a202280e9f4fdb90`:

- secret scan passed
- high-severity dependency audit passed
- lint and formatting ratchets passed with zero new debt
- dead-code, API-map, skill-integrity, agent-guidance, tax-reference, portability, and write-boundary gates passed
- build, typecheck, package-boundary tests, and full CLI/MCP Vitest suites passed on Node 20 and 22 across Linux, macOS, and Windows
- coverage ratchets passed on Linux/Node 20
- generated API-map verification passed