### PR TITLE
fix(deps): patch fast-uri security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "packageManager": "pnpm@10.12.1",
   "pnpm": {
     "overrides": {
-      "nanoid@<3.3.18": "3.3.18"
+      "nanoid@<3.3.18": "3.3.18",
+      "fast-uri": "3.1.6"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   nanoid@<3.3.18: 3.3.18
+  fast-uri: 3.1.6
 
 importers:
 
@@ -1018,8 +1019,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -2310,7 +2311,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2568,7 +2569,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fd-package-json@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ overrides:
   "@hono/node-server": 2.0.10
   postcss: 8.5.23
   body-parser: 2.3.0
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   ip-address: 10.3.1
   brace-expansion: 5.0.9
   nanoid: 3.3.18


### PR DESCRIPTION
## Summary
- Pin the transitive `fast-uri` dependency to 3.1.6.
- Regenerate the pnpm lockfile so AJV resolves the patched package.

## Validation
- `pnpm audit --audit-level high` passes with 0 high vulnerabilities (2 moderate remain).
- `pnpm test` passed: 531 CLI tests and 16 MCP tests passed; 2 MCP tests skipped.
- Relevant quality checks passed, including lint, formatting ratchet, dead-code, portability, API-map, agent-guidance, tax-reference, and write-boundary checks.
- Full `pnpm quality` is blocked locally by the pre-existing Windows checkout condition `core.symlinks=false`: `CLAUDE.md` is materialized as a regular file instead of its tracked symlink to `SKILL.md`.
- `gitleaks` found no leaks in `origin/main..HEAD`.