### PR TITLE
fix: make Robinhood auth refresh transactional

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,7 @@
   "type": "module",
   "author": "Zayd Khan // cold (www.zayd.wtf)",
   "packageManager": "pnpm@10.12.1",
-  "pnpm": {
-    "overrides": {
-      "nanoid@<3.3.18": "3.3.18",
-      "fast-uri": "3.1.6"
-    }
-  },
+
   "scripts": {
     "build": "node scripts/pnpm-portable.mjs --filter @zaydiscold/robinhood-cli build && node scripts/pnpm-portable.mjs --filter @zaydiscold/robinhood-cli-mcp build",
     "sanitize:cdp": "node scripts/sanitize-cdp-capture.mjs",
@@ -25,7 +20,7 @@
     "test:write-boundaries": "node scripts/check-write-boundaries.mjs",
     "generate:api-map": "node scripts/generate-brokerage-openapi.mjs && node scripts/generate-unified-api-map.mjs && node scripts/generate-brokerage-markdown.mjs && node scripts/generate-brokerage-curl.mjs && node scripts/generate-endpoint-markdown.mjs",
     "generate:tax-reference": "node scripts/generate-tax-reference.mjs",
-    "test": "node scripts/pnpm-portable.mjs build && node scripts/pnpm-portable.mjs test:built && node scripts/test-auth-session.mjs",
+    "test": "node scripts/pnpm-portable.mjs build && node scripts/pnpm-portable.mjs test:built && node scripts/test-auth-session.mjs && python scripts/test_auth_candidate_selection.py",
     "test:built": "node scripts/pnpm-portable.mjs --filter @zaydiscold/robinhood-cli exec vitest run && node scripts/pnpm-portable.mjs --filter @zaydiscold/robinhood-cli-mcp exec vitest run",
     "coverage": "node scripts/pnpm-portable.mjs build && node scripts/pnpm-portable.mjs coverage:built",
     "coverage:built": "node scripts/pnpm-portable.mjs --filter @zaydiscold/robinhood-cli test:coverage && node scripts/pnpm-portable.mjs --filter @zaydiscold/robinhood-cli-mcp test:coverage",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,17 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  nanoid@<3.3.18: 3.3.18
+  esbuild: 0.28.1
+  vite: 8.1.4
+  hono: 4.12.34
+  '@hono/node-server': 2.0.10
+  postcss: 8.5.23
+  body-parser: 2.3.0
   fast-uri: 3.1.6
+  qs: 6.16.0
+  ip-address: 10.3.1
+  brace-expansion: 5.0.9
+  nanoid: 3.3.18
 
 importers:
 
@@ -289,11 +298,11 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.17':
-    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -761,7 +770,7 @@ packages:
     resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.1.4
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1421,8 +1430,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -1488,8 +1497,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -1592,7 +1601,7 @@ packages:
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.3.0
-      esbuild: ^0.27.0 || ^0.28.0
+      esbuild: 0.28.1
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -1644,7 +1653,7 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: 8.1.4
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1859,7 +1868,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.17(hono@4.12.34)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
 
@@ -1890,7 +1899,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.17(hono@4.12.34)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2333,7 +2342,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -2552,7 +2561,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -2951,9 +2960,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   range-parser@1.2.1: {}
 
@@ -3056,7 +3066,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ overrides:
   postcss: 8.5.23
   body-parser: 2.3.0
   fast-uri: 3.1.6
+  qs: 6.16.0
   ip-address: 10.3.1
   brace-expansion: 5.0.9
   nanoid: 3.3.18

--- a/scripts/refresh-auth.sh
+++ b/scripts/refresh-auth.sh
@@ -9,16 +9,17 @@
 #   2. FALLBACK: scan Chrome's on-disk localStorage LevelDB (browser-free, zero
 #      network) — used headless/offline or when no debug Chrome is reachable.
 #
-# Robinhood's web app keeps its auth in localStorage["web:auth_state"], and Chrome
-# continuously flushes that to disk as a LevelDB store. The web app rotates its own
-# access_token automatically (~7.8d lifetime) while you use the site, so the freshest
-# token is always sitting on disk. We read it straight from there.
+# Robinhood's web app keeps its auth in localStorage["web:auth_state"], and Chromium
+# periodically flushes that state to LevelDB. This command does not renew a bearer:
+# it ranks existing browser/session candidates, validates the winner live, and only
+# then promotes it. A new lifetime requires Robinhood to mint a new token at login.
 #
 # Why not CDP / the OAuth refresh-token grant?
 #   - CDP (browser-harness) needs a one-time Chrome "Allow" click on reconnect — noise.
 #   - The OAuth refresh_token grant rotates the refresh token on use, which can silently
 #     invalidate the live browser session. A local disk read touches neither.
-# This script makes ZERO network calls and never opens a browser.
+# Discovery never opens a browser. The final staged bearer is verified with one
+# read-only accounts request before the production .env is replaced.
 #
 # Chrome's localStorage split-encodes: the KEY (web:auth_state) is UTF-16 but the VALUE
 # JSON is stored single-byte (Latin-1) because it's ASCII — so we scan bytes for the
@@ -159,16 +160,79 @@ leveldb_args=()
 shopt -s nullglob
 candidates=("$CANDIDATE_DIR"/*.env)
 shopt -u nullglob
-if [ "${#candidates[@]}" -eq 0 ]; then
-    echo "[refresh-auth] no valid Robinhood auth found via CDP, Safari, or Chromium LevelDB" >&2
+if [ "${#candidates[@]}" -eq 0 ] && [ ! -f "$REPO_DIR/.env" ]; then
+    echo "[refresh-auth] no Robinhood auth found via installed state, CDP, Safari, or Chromium LevelDB" >&2
     exit 2
 fi
 
+# Build a private staged .env, rank the installed bearer alongside every
+# discovered candidate, and reject anything that cannot survive until the next
+# guardian window. No production file is touched before the staged bearer works.
+STAGED_ENV="$CANDIDATE_DIR/selected.env"
+PYTHON_STAGED_ENV="$(native_path "$STAGED_ENV")"
+if [ -f "$REPO_DIR/.env" ]; then
+    cp "$REPO_DIR/.env" "$STAGED_ENV"
+else
+    : > "$STAGED_ENV"
+fi
+
 python_candidates=()
+if [ -f "$REPO_DIR/.env" ]; then
+    python_candidates+=("$TARGET_ENV_PATH")
+fi
 for candidate in "${candidates[@]}"; do
+    [ "$candidate" = "$STAGED_ENV" ] && continue
     python_candidates+=("$(native_path "$candidate")")
 done
-"$PYTHON_BIN" "$PYTHON_REPO_DIR/scripts/select-auth-candidate.py" \
-    --target "$TARGET_ENV_PATH" "${python_candidates[@]}"
+minimum_remaining="${ROBINHOOD_AUTH_MIN_REMAINING_SECONDS:-345600}"
+selection_output="$($PYTHON_BIN "$PYTHON_REPO_DIR/scripts/select-auth-candidate.py" \
+    --target "$PYTHON_STAGED_ENV" \
+    --minimum-remaining-seconds "$minimum_remaining" \
+    "${python_candidates[@]}")" || {
+    echo "[refresh-auth] no acceptable bearer; production .env preserved" >&2
+    exit 2
+}
+
+# Live validation uses the staged bearer through the environment. dotenv does
+# not override it, so the repo's current .env remains untouched during proof.
+set -a
+# shellcheck disable=SC1090
+source "$STAGED_ENV"
+set +a
+VERIFY_JSON="$CANDIDATE_DIR/accounts.json"
+VERIFY_ERR="$CANDIDATE_DIR/accounts.err"
+if ! node "$REPO_DIR/cli/dist/index.js" accounts --json >"$VERIFY_JSON" 2>"$VERIFY_ERR"; then
+    echo "[refresh-auth] staged bearer failed live accounts read; production .env preserved" >&2
+    exit 3
+fi
+"$PYTHON_BIN" - "$PYTHON_CANDIDATE_DIR/accounts.json" <<'PYVERIFY' || {
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    value = json.load(open(path, encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    raise SystemExit(f"invalid accounts verification: {type(exc).__name__}")
+if not isinstance(value, list) or not value:
+    raise SystemExit("accounts verification returned no accounts")
+print(f"accounts_verified={len(value)}")
+PYVERIFY
+    echo "[refresh-auth] staged bearer returned invalid account data; production .env preserved" >&2
+    exit 3
+}
+
+"$PYTHON_BIN" - "$PYTHON_STAGED_ENV" "$TARGET_ENV_PATH" <<'PYPROMOTE'
+import os
+import sys
+
+staged, target = sys.argv[1:]
+os.replace(staged, target)
+try:
+    os.chmod(target, 0o600)
+except OSError:
+    pass
+PYPROMOTE
+printf '%s auth_state=yes token_written=yes live_verified=yes\n' "$selection_output"
 
 # Zayd Khan // cold // www.zayd.wtf

--- a/scripts/select-auth-candidate.py
+++ b/scripts/select-auth-candidate.py
@@ -5,6 +5,7 @@ import base64
 import datetime
 import json
 import os
+import sys
 from pathlib import Path
 
 
@@ -24,7 +25,15 @@ def jwt_exp(token):
         return 0
 
 
-def select_freshest(paths):
+DEFAULT_MIN_REMAINING_SECONDS = 4 * 86400
+
+
+def select_freshest(paths, *, now=None, min_remaining_seconds=DEFAULT_MIN_REMAINING_SECONDS):
+    now = int(
+        datetime.datetime.now(datetime.timezone.utc).timestamp()
+        if now is None
+        else now
+    )
     candidates = []
     for path in paths:
         token = token_from_env(path)
@@ -34,7 +43,15 @@ def select_freshest(paths):
     if not candidates:
         raise RuntimeError("no valid Robinhood auth candidates")
     candidates.sort(key=lambda item: item[:3], reverse=True)
-    return candidates[0]
+    acceptable = [item for item in candidates if item[0] - now >= min_remaining_seconds]
+    if not acceptable:
+        best_remaining = candidates[0][0] - now
+        raise RuntimeError(
+            "no acceptable Robinhood auth candidates: "
+            + f"best_remaining_seconds={best_remaining} "
+            + f"minimum_remaining_seconds={min_remaining_seconds}"
+        )
+    return acceptable[0]
 
 
 def write_target(target, token, source, exp):
@@ -70,10 +87,21 @@ def write_target(target, token, source, exp):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--target", type=Path, required=True)
+    parser.add_argument(
+        "--minimum-remaining-seconds",
+        type=int,
+        default=DEFAULT_MIN_REMAINING_SECONDS,
+    )
     parser.add_argument("candidates", nargs="+", type=Path)
     args = parser.parse_args()
     existing = [path for path in args.candidates if path.exists()]
-    exp, _mtime, _length, path, token = select_freshest(existing)
+    try:
+        exp, _mtime, _length, path, token = select_freshest(
+            existing, min_remaining_seconds=args.minimum_remaining_seconds
+        )
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(2) from None
     source = path.stem
     write_target(args.target, token, source, exp)
     now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
@@ -82,7 +110,7 @@ def main():
     print(
         "source="
         + source
-        + " auth_state=yes token_written=yes session_remaining_days="
+        + " auth_state=yes token_selected=yes session_remaining_days="
         + str(remaining)
         + " token_expires_utc="
         + expires

--- a/scripts/test_auth_candidate_selection.py
+++ b/scripts/test_auth_candidate_selection.py
@@ -34,7 +34,9 @@ class AuthCandidateSelectionTests(unittest.TestCase):
             short.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(100) + "\n")
             long.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(300) + "\n")
             target.write_text("ROBINHOOD_BROKERAGE_TOKEN=old\nROBINHOOD_WEB_APP_VERSION=keep\n")
-            exp, _mtime, _length, path, token = selector.select_freshest([short, long])
+            exp, _mtime, _length, path, token = selector.select_freshest(
+                [short, long], now=0, min_remaining_seconds=0
+            )
             self.assertEqual(exp, 300)
             self.assertEqual(path, long)
             selector.write_target(target, token, path.stem, exp)
@@ -59,6 +61,39 @@ class AuthCandidateSelectionTests(unittest.TestCase):
     def test_no_candidate_fails_closed(self):
         with self.assertRaises(RuntimeError):
             selector.select_freshest([])
+
+    def test_expired_candidates_never_win(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            expired = root / "expired.env"
+            expired.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(999) + "\n")
+            with self.assertRaisesRegex(RuntimeError, "no acceptable Robinhood auth candidates"):
+                selector.select_freshest(
+                    [expired], now=1000, min_remaining_seconds=0
+                )
+
+    def test_candidate_must_outlive_the_guard_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            too_short = root / "seven-hours.env"
+            too_short.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(1000 + 7 * 3600) + "\n")
+            with self.assertRaisesRegex(RuntimeError, "best_remaining_seconds=25200"):
+                selector.select_freshest(
+                    [too_short], now=1000, min_remaining_seconds=4 * 86400
+                )
+
+    def test_installed_token_is_preserved_when_browser_candidate_is_shorter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            installed = root / ".env"
+            browser = root / "cdp-9222.env"
+            installed.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(1000 + 20 * 86400) + "\n")
+            browser.write_text("ROBINHOOD_BROKERAGE_TOKEN=" + jwt(1000 + 10 * 86400) + "\n")
+            exp, _mtime, _length, path, _token = selector.select_freshest(
+                [installed, browser], now=1000, min_remaining_seconds=4 * 86400
+            )
+            self.assertEqual(exp, 1000 + 20 * 86400)
+            self.assertEqual(path, installed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause
The session copier ranked only discovered browser candidates, accepted expired/near-expiry JWTs, and wrote the winner before a live read. On Sep 4 it first accepted a bearer with 0.30 days left, then later overwrote production with a token expired Aug 10.

## Fix
- rank the installed bearer alongside discovered candidates
- reject expired or sub-4-day candidates
- stage the selected env privately
- require a live nonempty accounts read before atomic promotion
- preserve production byte-for-byte on selection or verification failure
- include candidate guard tests in the normal test command
- pin qs 6.16.0 and remove the obsolete package.json pnpm override block

## Verification
- failure integration: exit 2, production SHA-256 unchanged
- 531 CLI tests passed
- 16 MCP tests passed, 2 skipped
- 6 auth candidate tests passed
- typecheck, API map, agent guidance, tax reference, portability, write boundaries passed
- pnpm 11 low-severity audit: no known vulnerabilities

- delilah 🌸